### PR TITLE
SSL fast failure, SSL Cipher Tracing

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/builder/Http.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/builder/Http.scala
@@ -38,6 +38,7 @@ class Http(compressionLevel: Int = 0) extends Codec[HttpRequest, HttpResponse] {
         // Response to Expect: Continue
         pipeline.addLast("respondToExpectContinue", new RespondToExpectContinue)
         pipeline.addLast("httpDechunker", new HttpChunkAggregator(10<<20))
+        pipeline.addLast("annotateCipher", new AnnotateCipher)
 
         pipeline.addLast(
           "connectionLifecycleManager",

--- a/finagle-core/src/main/scala/com/twitter/finagle/http/AnnotateCipher.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/http/AnnotateCipher.scala
@@ -1,0 +1,23 @@
+package com.twitter.finagle.http
+
+import com.twitter.finagle.builder.SslCipherAttribution
+
+import org.jboss.netty.channel.{Channel, ChannelHandler, ChannelHandlerContext, MessageEvent,
+                                SimpleChannelHandler}
+import org.jboss.netty.handler.codec.http.{HttpRequest, HttpResponse}
+
+/**
+ * Extract the cipher from the SslCipherAttribution ChannelLocal variable and
+ * set it as a header on the HTTP request befor sending it upstream.
+ */
+class AnnotateCipher extends SimpleChannelHandler {
+  override def messageReceived(ctx: ChannelHandlerContext, e: MessageEvent) {
+    if (e.getMessage.isInstanceOf[HttpRequest]) {
+      val req = e.getMessage.asInstanceOf[HttpRequest]
+      val cipher = SslCipherAttribution(ctx.getChannel)
+      req.setHeader("X-Transport-Cipher", cipher)
+    }
+
+    super.messageReceived(ctx, e)
+  }
+}

--- a/finagle-core/src/main/scala/com/twitter/finagle/http/Codec.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/http/Codec.scala
@@ -58,6 +58,8 @@ case class Http(
           "httpDechunker",
           new HttpChunkAggregator(_maxRequestSize.inBytes.toInt))
 
+        pipeline.addLast("annotateCipher", new AnnotateCipher)
+
         pipeline.addLast(
           "connectionLifecycleManager",
           new ServerConnectionManager)


### PR DESCRIPTION
• If TLS/SSL certificate and key files do not exist, a failure is exhibited at startup rather than when a connection is created
• Performance improvement from recycling of SSLContext
• X-Transport-Cipher header added to HTTP requests, annotating the cipher used (or, in the case none was employed, 'plaintext')
