### PR TITLE
Fix cas values in memcached text protocol

### DIFF
--- a/finagle-memcached/src/main/scala/com/twitter/finagle/memcached/protocol/text/Show.scala
+++ b/finagle-memcached/src/main/scala/com/twitter/finagle/memcached/protocol/text/Show.scala
@@ -28,7 +28,7 @@ class ResponseToEncoding extends OneToOneEncoder {
       val buffer = ChannelBuffers.dynamicBuffer(100 * values.size)
       val tokensWithData = values map {
         case Value(key, value, Some(casUnique)) =>
-          TokensWithData(Seq(VALUE, key, ZERO, casUnique.toString), value)
+          TokensWithData(Seq(VALUE, key, ZERO), value, Some(casUnique))
         case Value(key, value, None) =>
           TokensWithData(Seq(VALUE, key, ZERO), value)
       }

--- a/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/integration/ProxySpec.scala
+++ b/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/integration/ProxySpec.scala
@@ -1,0 +1,70 @@
+package com.twitter.finagle.memcached.integration
+
+import org.specs.Specification
+
+import org.jboss.netty.buffer.ChannelBuffers
+import org.jboss.netty.util.CharsetUtil
+
+import com.twitter.conversions.time._
+import com.twitter.finagle.memcached.Client
+import com.twitter.finagle.memcached.protocol.text.Memcached
+import com.twitter.finagle.memcached.protocol.{Command, Response}
+import com.twitter.finagle.Service
+import com.twitter.finagle.builder.{ClientBuilder, Server, ServerBuilder}
+import com.twitter.util.RandomSocket
+
+import java.net.{InetSocketAddress, Socket}
+
+object ProxySpec extends Specification {
+
+  type MemcacheService = Service[Command, Response]
+
+  "Proxied Memcached Servers" should {
+    /**
+     * Note: This integration test requires a real Memcached server to run.
+     */
+    var externalClient: Client = null
+    var server: Server = null
+    var serverPort: InetSocketAddress = null
+    var proxyService: MemcacheService = null
+    var proxyClient: MemcacheService = null
+
+    doBefore {
+      ExternalMemcached.start();
+      Thread.sleep(150) // On my box the 100ms sleep wasn't long enough
+      proxyClient = ClientBuilder()
+        .hosts(Seq(ExternalMemcached.address.get))
+        .codec(Memcached())
+        .hostConnectionLimit(1)
+        .build()
+      proxyService = new MemcacheService {
+        def apply(request: Command) = proxyClient(request)
+      }
+      serverPort = RandomSocket()
+      server = ServerBuilder()
+        .codec(Memcached())
+        .bindTo(serverPort)
+        .name("memcached")
+        .build(proxyService)
+      externalClient = Client("%s:%d".format(serverPort.getHostName, serverPort.getPort))
+    }
+
+    doAfter {
+      externalClient.release
+      server.close(0.seconds)
+      proxyService.release
+      proxyClient.release
+      ExternalMemcached.stop()
+    }
+
+    "handle a basic get/set operation" in {
+      externalClient.delete("foo")()
+      externalClient.get("foo")() must beNone
+      externalClient.set("foo", ChannelBuffers.wrappedBuffer("bar".getBytes(CharsetUtil.UTF_8)))()
+      val foo = externalClient.get("foo")()
+      foo must beSome
+      foo.get.toString(CharsetUtil.UTF_8) mustEqual "bar"
+    }
+  }
+
+}


### PR DESCRIPTION
This patch fixes an issue with the memcached response encoding of cas values. Without this patch the output from memcached commands that include a cas value look like:

```
get foo
VALUE foo 0 BigEndianHeapChannelBuffer(ridx=0, widx=1, cap=1) 3
bar
END
```

This patch moves the cas unique value to the end of the value line and stops calling `toString` on the ChannelBuffer.
