### PR TITLE
Fix for NoSuchElementException in finagle-memcached

### DIFF
--- a/finagle-memcached/src/main/scala/com/twitter/finagle/memcached/protocol/text/server/DecodingToCommand.scala
+++ b/finagle-memcached/src/main/scala/com/twitter/finagle/memcached/protocol/text/server/DecodingToCommand.scala
@@ -71,7 +71,12 @@ class DecodingToCommand extends AbstractDecodingToCommand[Command] {
     (tokens.head, tokens(1).toLong)
   }
 
+  private[this] def validateAnyStorageCommand(tokens: Seq[ChannelBuffer]) {
+    if (tokens.isEmpty) throw new ClientError("No arguments specified")
+  }
+
   protected def parseStorageCommand(tokens: Seq[ChannelBuffer], data: ChannelBuffer) = {
+    validateAnyStorageCommand(tokens)
     val commandName = tokens.head
     val args = tokens.tail
     commandName match {
@@ -85,6 +90,7 @@ class DecodingToCommand extends AbstractDecodingToCommand[Command] {
   }
 
   protected def parseNonStorageCommand(tokens: Seq[ChannelBuffer]) = {
+    validateAnyStorageCommand(tokens)
     val commandName = tokens.head
     val args = tokens.tail
     commandName match {


### PR DESCRIPTION
If a client sends no command (just an empty newline), the server decoder throws a `NoSuchElementException`. This is caused by accessing `head` on an empty sequence.
