### PR TITLE
Add a sensible toString method to http.{Request, Response}.

### DIFF
--- a/finagle-http/src/main/scala/com/twitter/finagle/http/Request.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/http/Request.scala
@@ -129,6 +129,9 @@ abstract class Request extends Message with HttpRequestProxy {
 
   /** Get response associated with request. */
   def getResponse(): Response = response
+
+  override def toString =
+    "Request(\"" + method + " " + uri + "\", from " + remoteSocketAddress + ")"
 }
 
 

--- a/finagle-http/src/main/scala/com/twitter/finagle/http/Response.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/http/Response.scala
@@ -19,6 +19,9 @@ abstract class Response extends Message with HttpResponseProxy {
 
   def getStatusCode(): Int      = statusCode
   def setStatusCode(value: Int) { statusCode = value }
+
+  override def toString =
+    "Response(\"" + version + " " + status + ")"
 }
 
 


### PR DESCRIPTION
Because this:

```
Query timeout on com.twitter.finagle.http.Request$$anon$3@305f387c
```

is a lot less useful than this:

```
Query timeout on Request("GET /foo", from 10.42.42.42:56942)
```
