### PR TITLE
Flags should be retained when encoding response.

### DIFF
--- a/finagle-memcached/src/main/scala/com/twitter/finagle/memcached/protocol/Response.scala
+++ b/finagle-memcached/src/main/scala/com/twitter/finagle/memcached/protocol/Response.scala
@@ -14,4 +14,8 @@ case class NoOp()                         extends Response
 case class Values(values: Seq[Value]) extends Response
 case class Number(value: Long)         extends Response
 
-case class Value(key: ChannelBuffer, value: ChannelBuffer, casUnique: Option[ChannelBuffer] = None)
+case class Value(
+    key: ChannelBuffer,
+    value: ChannelBuffer,
+    casUnique: Option[ChannelBuffer] = None,
+    flags: Option[ChannelBuffer] = None)

--- a/finagle-memcached/src/main/scala/com/twitter/finagle/memcached/protocol/text/Show.scala
+++ b/finagle-memcached/src/main/scala/com/twitter/finagle/memcached/protocol/text/Show.scala
@@ -28,10 +28,10 @@ class ResponseToEncoding extends OneToOneEncoder {
     case Values(values) =>
       val buffer = ChannelBuffers.dynamicBuffer(100 * values.size)
       val tokensWithData = values map {
-        case Value(key, value, Some(casUnique)) =>
-          TokensWithData(Seq(VALUE, key, ZERO), value, Some(casUnique))
-        case Value(key, value, None) =>
-          TokensWithData(Seq(VALUE, key, ZERO), value)
+        case Value(key, value, casUnique, Some(flags)) =>
+          TokensWithData(Seq(VALUE, key, flags), value, casUnique)
+        case Value(key, value, casUnique, None) =>
+          TokensWithData(Seq(VALUE, key, ZERO), value, casUnique)
       }
       ValueLines(tokensWithData)
   }

--- a/finagle-memcached/src/main/scala/com/twitter/finagle/memcached/protocol/text/client/DecodingToResponse.scala
+++ b/finagle-memcached/src/main/scala/com/twitter/finagle/memcached/protocol/text/client/DecodingToResponse.scala
@@ -52,8 +52,9 @@ class DecodingToResponse extends AbstractDecodingToResponse[Response] {
   protected def parseValues(valueLines: Seq[TokensWithData]) = {
     val values = valueLines.map { valueLine =>
       val tokens = valueLine.tokens
+      val flag = if (tokens.length >= 3) Some(tokens(2)) else None
       val casUnique = if (tokens.length == 5) Some(tokens(4)) else None
-      Value(tokens(1), valueLine.data, casUnique)
+      Value(tokens(1), valueLine.data, casUnique, flag)
     }
     Values(values)
   }

--- a/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/integration/InterpreterServiceSpec.scala
+++ b/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/integration/InterpreterServiceSpec.scala
@@ -33,12 +33,13 @@ object InterpreterServiceSpec extends Specification {
     "set & get" in {
       val key   = "key"
       val value = "value"
+      val zero = "0"
       val result = for {
         _ <- client(Delete(key))
         _ <- client(Set(key, 0, Time.epoch, value))
         r <- client(Get(Seq(key)))
       } yield r
-      result(1.second) mustEqual Values(Seq(Value(key, value)))
+      result(1.second) mustEqual Values(Seq(Value(key, value, None, Some(zero))))
       client.isAvailable must beTrue
     }
 

--- a/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/stress/InterpreterServiceSpec.scala
+++ b/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/stress/InterpreterServiceSpec.scala
@@ -32,12 +32,13 @@ object InterpreterServiceSpec extends Specification {
     "set & get" in {
       val _key   = "key"
       val value = "value"
+      val zero = "0"
       val start = System.currentTimeMillis
       (0 until 100) map { i =>
         val key = _key + i
         client(Delete(key))()
         client(Set(key, 0, Time.epoch, value))()
-        client(Get(Seq(key)))() mustEqual Values(Seq(Value(key, value)))
+        client(Get(Seq(key)))() mustEqual Values(Seq(Value(key, value, None, Some(zero))))
       }
       val end = System.currentTimeMillis
       // println("%d ms".format(end - start))

--- a/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/protocol/text/client/DecoderSpec.scala
+++ b/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/protocol/text/client/DecoderSpec.scala
@@ -42,6 +42,19 @@ object DecoderSpec extends Specification with Mockito {
           TokensWithData(Seq("VALUE", "bar", "0", "2"), "12")))
       }
 
+      "data with flag" in {
+        val buffer = stringToChannelBuffer("VALUE foo 20 1\r\n1\r\nVALUE bar 10 2\r\n12\r\nEND\r\n")
+        // These are called once for each state transition (i.e., once per \r\n)
+        // by the FramedCodec
+        decoder.decode(null, null, buffer)
+        decoder.decode(null, null, buffer)
+        decoder.decode(null, null, buffer)
+        decoder.decode(null, null, buffer)
+        decoder.decode(null, null, buffer) mustEqual ValueLines(Seq(
+          TokensWithData(Seq("VALUE", "foo", "20", "1"), "1"),
+          TokensWithData(Seq("VALUE", "bar", "10", "2"), "12")))
+      }
+
       "end" in {
         val buffer = "END\r\n"
         decoder.decode(null, null, buffer) mustEqual ValueLines(Seq[TokensWithData]())


### PR DESCRIPTION
Currently the value for memcache flags are discarded when handling response encoding. This commit fixes that and includes a unit test for verifying that the behavior is correct. This change did require a couple of changes to the interpreter specs but not to the actual interpreter. We're running this patch in production.
