### PR TITLE
Fix Kestrel Client

### DIFF
--- a/finagle-kestrel/src/main/scala/com/twitter/finagle/kestrel/protocol/DecodingToResponse.scala
+++ b/finagle-kestrel/src/main/scala/com/twitter/finagle/kestrel/protocol/DecodingToResponse.scala
@@ -1,7 +1,7 @@
 package com.twitter.finagle.kestrel.protocol
 
 import org.jboss.netty.buffer.ChannelBuffer
-import com.twitter.finagle.memcached.protocol.text.TokensWithData
+import com.twitter.finagle.memcached.protocol.text.{Tokens, TokensWithData}
 import com.twitter.finagle.memcached.protocol.text.client.AbstractDecodingToResponse
 
 private[kestrel] class DecodingToResponse extends AbstractDecodingToResponse[Response] {
@@ -23,4 +23,6 @@ private[kestrel] class DecodingToResponse extends AbstractDecodingToResponse[Res
     }
     Values(values)
   }
+
+  def parseStatLines(lines: Seq[Tokens]) = Error()
 }


### PR DESCRIPTION
Kestrel depends on the memcache decoder, which I broke. Responding with 'Error' seems appropriate since this feature isn't (afaik) supported by Kestrel.
