### PR TITLE
FATAL error in logs: "more-than-once release for channel!" when using connection pooling

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/service/ExpiringService.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/service/ExpiringService.scala
@@ -85,7 +85,7 @@ class ExpiringService[Req, Rep](
   }
 
   override def release() {
-    deactivate()
-    super.release()
+    if(deactivate())
+      super.release()
   }
 }

--- a/finagle-core/src/test/scala/com/twitter/finagle/service/ExpiringServiceSpec.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/service/ExpiringServiceSpec.scala
@@ -44,9 +44,9 @@ object ExpiringServiceSpec extends Specification with Mockito {
 
           there was one(underlying).release()
 
-          // Now attempt to release it once more:
+          // Now attempt to release it once more; should not call release again
           service.release()
-          there were two(underlying).release()
+          there was one(underlying).release()
         }
       }
 


### PR DESCRIPTION
When using the following ClientBuilder:

```
    val clientBuilder = ClientBuilder()
      .codec(Http())
      .cluster(new AWSElbCluster(config.url))
      .connectionTimeout(20.seconds)
      .hostConnectionLimit(config.maxConnections)
      .hostConnectionMaxIdleTime(30.seconds)
      .hostConnectionMaxLifeTime(2.minute)
      .retries(1)
      .reportTo(new OstrichStatsReceiver)
      .name(config.url.toString)
```

we get benign FATAL errors in the logs (see https://gist.github.com/1557984). I found that this was the result of an interaction between the ExpiringService wrapper and the WatermarkPool. The time-based timeout in ExpiringService would cause 'release' to be called on the underlying service, then later on the WatermarkPool would attempt to use the connection, find out that it is unusable, and then also attempt to call 'release' on it.

This commit fixes this problem in ExpiringService by ensuring "release" is only called once on the underlying service.
