### PR TITLE
Allow user to pass in an SSL Enginee so client certificates can be used

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/builder/ClientBuilder.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/builder/ClientBuilder.scala
@@ -58,6 +58,7 @@ import org.jboss.netty.handler.timeout.IdleStateHandler
 import com.twitter.concurrent.NamedPoolThreadFactory
 import com.twitter.util.{Future, Duration, Try, Monitor, NullMonitor, Promise, Return }
 import com.twitter.util.TimeConversions._
+import javax.net.ssl.SSLContext
 
 import com.twitter.finagle.channel._
 import com.twitter.finagle.util._
@@ -500,6 +501,22 @@ class ClientBuilder[Req, Rep, HasCluster, HasCodec, HasHostConnectionLimit] priv
   def tls(hostname: String): This =
     withConfig(_.copy(_tls = Some({ () => Ssl.client()}, Some(hostname))))
 
+  /**
+   * Encrypt the connection with SSL.  The Engine to use can be passed into the client.
+   * This allows the user to use client certificates  
+   * No SSL Hostname Validation is performed
+   */
+  def tls(sslContext : SSLContext): This =
+    withConfig(_.copy(_tls = Some({ () => Ssl.client(sslContext)  }, None)))    
+  
+  /**
+   * Encrypt the connection with SSL.  The Engine to use can be passed into the client.
+   * This allows the user to use client certificates  
+   * SSL Hostname Validation is performed, on the passed in hostname
+   */
+  def tls(sslContext : SSLContext, hostname : Option[String]): This =
+    withConfig(_.copy(_tls = Some({ () => Ssl.client(sslContext)  }, hostname)))  
+    
   /**
    * Do not perform TLS validation. Probably dangerous.
    */

--- a/finagle-core/src/main/scala/com/twitter/finagle/ssl/JSSE.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/ssl/JSSE.scala
@@ -43,7 +43,16 @@ object JSSE {
   /**
    * Get a client
    */
-  def client(): Engine = client(null)
+  def client(): Engine = client(null : Array[TrustManager])
+  
+  /**
+   * Get a client from the given Context
+   */
+  def client(ctx : SSLContext) : Engine = {
+    val sslEngine = ctx.createSSLEngine();
+    sslEngine.setUseClientMode(true);
+    new Engine(sslEngine)
+  }
 
   /**
    * Get a client that skips verification of certificates.

--- a/finagle-core/src/main/scala/com/twitter/finagle/ssl/Ssl.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/ssl/Ssl.scala
@@ -64,6 +64,11 @@ object Ssl {
    * Get a client engine
    */
   def client(): Engine = JSSE.client()
+  
+  /**
+   * Get a client engine, from the given context
+   */
+  def client(sslContext : SSLContext): Engine = JSSE.client(sslContext)
 
   /**
    * Get a client engine that doesn't check the validity of certificates


### PR DESCRIPTION
Added to the ClientBuilder the ability to specify the Engine to use,
so a client can create an SSLContext with client certs if they wish:
i.e.

<code>
val ctx = SSLContext.getInstance("TLS")
...
ctx.init(keyManagerFactory.getKeyManagers(), trustManagers, sr)
...
...
cb.tls(new Engine(ctx.createSSLEngine()))
//
// or
//
cb.tls(new Engine(ctx.createSSLEngine()), Option("www.xxx.com"))
</code>
