### PR TITLE
Making JSSE.client only create default SSLContext once

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/ssl/JSSE.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/ssl/JSSE.scala
@@ -13,9 +13,11 @@ object JSSE {
   private[this] val log = Logger.getLogger(getClass.getName)
   private[this] val contextCache: MutableMap[String, SSLContext] = MutableMap.empty
   private[this] val protocol = "TLS"
-  private[this] lazy val defaultSSLContext : SSLContext = { val ctx = SSLContext.getInstance(protocol)
-    														ctx.init(null, null, null)
-    														ctx }
+  private[this] lazy val defaultSSLContext: SSLContext = {
+    val ctx = SSLContext.getInstance(protocol)
+    ctx.init(null, null, null)
+    ctx
+  }
 
   /**
    * Get a server


### PR DESCRIPTION
Currently when tls(hostname) is called the SSLContext for the default jsse 
truststore (cacerts) is created on a per request basis.  This seems like overhead,
as a new SSLContext means that cacerts is reread; and a SecureRandom created
for each ssl (https) call.

Therefore, I've made a change; so that only the first call to JSSE.client()
creates the SSLContext, all subsequent calls just create the SSLEngine from
that precreated default SSLContext.
