### PR TITLE
finagle-redis: switch from Int to Long for representing Redis integers

### DIFF
--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/Client.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/Client.scala
@@ -39,7 +39,7 @@ class Client(service: Service[Command, Reply]) {
    * @params key, value
    * @return Length of string after append operation
    */
-  def append(key: String, value: Array[Byte]): Future[Int] =
+  def append(key: String, value: Array[Byte]): Future[Long] =
     doRequest(Append(key, value)) {
       case IntegerReply(n) => Future.value(n)
     }
@@ -51,7 +51,7 @@ class Client(service: Service[Command, Reply]) {
    * @return Value after decrement. Error if key contains value
    * of the wrong type
    */
-  def decrBy(key: String, amount: Int): Future[Int] =
+  def decrBy(key: String, amount: Int): Future[Long] =
     doRequest(DecrBy(key, amount)) {
       case IntegerReply(n) => Future.value(n)
     }
@@ -94,7 +94,7 @@ class Client(service: Service[Command, Reply]) {
    * @param list of keys to remove
    * @return Number of keys removed
    */
-  def del(keys: Seq[String]): Future[Int] =
+  def del(keys: Seq[String]): Future[Long] =
     doRequest(Del(keys.toList)) {
       case IntegerReply(n) => Future.value(n)
     }
@@ -150,7 +150,7 @@ class Client(service: Service[Command, Reply]) {
    * @param hash key, fields
    * @return Number of fields deleted
    */
-  def hDel(key: String, fields: Seq[String]): Future[Int] =
+  def hDel(key: String, fields: Seq[String]): Future[Long] =
     doRequest(HDel(key, fields)) {
       case IntegerReply(n) => Future.value(n)
     }
@@ -193,7 +193,7 @@ class Client(service: Service[Command, Reply]) {
    * @param hash key, field, value
    * @return 1 if field is new, 0 if field was updated
    */
-  def hSet(key: Array[Byte], field: Array[Byte], value: Array[Byte]): Future[Int] =
+  def hSet(key: Array[Byte], field: Array[Byte], value: Array[Byte]): Future[Long] =
     doRequest(HSet(key, field, value)) {
       case IntegerReply(n) => Future.value(n)
     }
@@ -205,7 +205,7 @@ class Client(service: Service[Command, Reply]) {
    * @params key, score, member
    * @return Number of elements added to sorted set
    */
-  def zAdd(key: Array[Byte], score: Double, member: Array[Byte]): Future[Int] =
+  def zAdd(key: Array[Byte], score: Double, member: Array[Byte]): Future[Long] =
     doRequest(ZAdd(key, ZMember(score, member))) {
       case IntegerReply(n) => Future.value(n)
     }
@@ -226,7 +226,7 @@ class Client(service: Service[Command, Reply]) {
    * @params key, min, max
    * @return Number of elements between min and max in sorted set
    */
-  def zCount(key: Array[Byte], min: Double, max: Double): Future[Int] =
+  def zCount(key: Array[Byte], min: Double, max: Double): Future[Long] =
     doRequest(ZCount(key, ZInterval(min), ZInterval(max))) {
       case IntegerReply(n) => Future.value(n)
     }
@@ -259,7 +259,7 @@ class Client(service: Service[Command, Reply]) {
    * @return Integer representing cardinality of sorted set,
    * or 0 if key does not exist
    */
-  def zCard(key: Array[Byte]): Future[Int] =
+  def zCard(key: Array[Byte]): Future[Long] =
     doRequest(ZCard(key)) {
       case IntegerReply(n) => Future.value(n)
     }
@@ -269,7 +269,7 @@ class Client(service: Service[Command, Reply]) {
    * @params key, member(s)
    * @return Number of members removed from sorted set
    */
-  def zRem(key: Array[Byte], members: Seq[Array[Byte]]): Future[Int] =
+  def zRem(key: Array[Byte], members: Seq[Array[Byte]]): Future[Long] =
     doRequest(ZRem(key, members)) {
       case IntegerReply(n) => Future.value(n)
     }

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/Reply.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/Reply.scala
@@ -30,7 +30,7 @@ case class ErrorReply(message: String) extends SingleLineReply {
   RequireServerProtocol(message != null && message.length > 0, "ErrorReply had empty message")
   override def getMessageTuple() = (RedisCodec.ERROR_REPLY, message)
 }
-case class IntegerReply(id: Int) extends SingleLineReply {
+case class IntegerReply(id: Long) extends SingleLineReply {
   override def getMessageTuple() = (RedisCodec.INTEGER_REPLY, id.toString)
 }
 
@@ -82,7 +82,7 @@ class ReplyCodec extends UnifiedProtocolCodec {
       case INTEGER_REPLY =>
         readLine { line =>
           RequireServerProtocol.safe {
-            emit(IntegerReply(NumberFormat.toInt(line)))
+            emit(IntegerReply(NumberFormat.toLong(line)))
           }
         }
       case BULK_REPLY =>

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/Strings.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/Strings.scala
@@ -28,7 +28,7 @@ object Decr {
     new Decr(BytesToString(trimList(args, 1, "DECR")(0)))
   }
 }
-class DecrBy(val key: String, val amount: Int) extends StrictKeyCommand {
+class DecrBy(val key: String, val amount: Long) extends StrictKeyCommand {
   override def toChannelBuffer =
     RedisCodec.toInlineFormat(List(Commands.DECRBY, key, amount.toString))
   override def toString = "DecrBy(%s, %d)".format(key, amount)
@@ -39,11 +39,11 @@ class DecrBy(val key: String, val amount: Int) extends StrictKeyCommand {
   def canEqual(other: Any) = other.isInstanceOf[DecrBy]
 }
 object DecrBy {
-  def apply(key: String, amount: Int) = new DecrBy(key, amount)
+  def apply(key: String, amount: Long) = new DecrBy(key, amount)
   def apply(args: List[Array[Byte]]) = {
     val list = BytesToString.fromList(trimList(args, 2, "DECRBY"))
     val amount = RequireClientProtocol.safe {
-      NumberFormat.toInt(list(1))
+      NumberFormat.toLong(list(1))
     }
     new DecrBy(list(0), amount)
   }
@@ -108,7 +108,7 @@ object Incr {
   }
 }
 
-class IncrBy(val key: String, val amount: Int) extends StrictKeyCommand {
+class IncrBy(val key: String, val amount: Long) extends StrictKeyCommand {
   override def toChannelBuffer =
     RedisCodec.toInlineFormat(List(Commands.INCRBY, key, amount.toString))
   override def toString = "IncrBy(%s, %d)".format(key, amount)
@@ -119,11 +119,11 @@ class IncrBy(val key: String, val amount: Int) extends StrictKeyCommand {
   def canEqual(other: Any) = other.isInstanceOf[IncrBy]
 }
 object IncrBy {
-  def apply(key: String, amount: Int) = new IncrBy(key, amount)
+  def apply(key: String, amount: Long) = new IncrBy(key, amount)
   def apply(args: List[Array[Byte]]) = {
     val list = BytesToString.fromList(trimList(args, 2, "INCRBY"))
     val amount = RequireClientProtocol.safe {
-      NumberFormat.toInt(list(1))
+      NumberFormat.toLong(list(1))
     }
     new IncrBy(list(0), amount)
   }


### PR DESCRIPTION
Redis supports 64 bit signed integers (as stated in the docs, e.g. for the [INCRBY command](http://redis.io/commands/incrby)), and so Redis integers should be represented by `Long` rather than `Int`.

Here is an example of a Redis exchange that is currently not possible using the finagle-redis client:

```
redis 127.0.0.1:6379> SET foo 1
OK
redis 127.0.0.1:6379> INCRBY foo 1000000000000000000
(integer) 1000000000000000001
```

In order to support this I've switched from `Int` to `Long` in the following places: 
- INCRBY, DECRBY command arguments
- Integer replies

Unfortunately this switch from `Int` to `Long` means a breaking change in the API, but it should be very easy for users to fix their client code. 
