### PR TITLE
OpenSSL v0.9 and v1.0 have different output for the md5 subcommand

### DIFF
--- a/sbt
+++ b/sbt
@@ -14,26 +14,9 @@ fi
 
 test -f $sbtjar || exit 1
 
-get_md5() {
-  local input_file=$1
-  local openssl_vers=$(openssl version|awk '{print $2}')
+sbtjar_md5=$(openssl md5 < $sbtjar|cut -f2 -d'='|awk '{print $1}')
 
-  case "${openssl_vers}" in
-    0.9.*)
-      openssl md5 < $input_file
-    ;;
-    1.0.*)
-      openssl md5 < $input_file|awk '{print $2}'
-    ;;
-    *)
-      echo "unrecognized version of openssl" >&2
-      exit 42
-    ;;
-  esac
-}
-
-
-if [ $(get_md5 $sbtjar) != 2886cc391e38fa233b3e6c0ec9adfa1e ]; then
+if [ "${sbtjar_md5}" != 2886cc391e38fa233b3e6c0ec9adfa1e ]; then
   echo 'bad sbtjar!' 1>&2
   exit 1
 fi


### PR DESCRIPTION
Check to see what version of OpenSSL the 'openssl version' subcommand
returns, then trim the output if necessary.

I had MacPorts' OpenSSL in the path (which is version 1.0.1c), and the output from its md5 is different than the one in `/usr/bin/openssl`:

```
$ /usr/bin/openssl md5 < sbt-launch.jar 
2886cc391e38fa233b3e6c0ec9adfa1e

$ /opt/local/bin/openssl md5 < sbt-launch.jar 
(stdin)= 2886cc391e38fa233b3e6c0ec9adfa1e
```

This patch just checks the output of the version subcommand and adjusts as appropriate.
