### PR TITLE
Fix arg type in RetryingFilter.apply

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/service/RetryingFilter.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/service/RetryingFilter.scala
@@ -120,7 +120,7 @@ object RetryingFilter {
   def apply[Req, Rep](
     backoffs: Stream[Duration],
     statsReceiver: StatsReceiver = NullStatsReceiver
-  )(shouldRetry: PartialFunction[Try[Rep], Boolean])(implicit timer: Timer) =
+  )(shouldRetry: PartialFunction[Try[Nothing], Boolean])(implicit timer: Timer) =
     new RetryingFilter[Req, Rep](RetryPolicy.backoff(backoffs)(shouldRetry), timer, statsReceiver)
 }
 


### PR DESCRIPTION
`RetryingFilter.apply` should let its `shouldRetry` argument take a `Try[Nothing]` instead of a `Try[Rep]`, since it's immediately turned into a `RetryPolicy[Try[Nothing]]`.
