### PR TITLE
collection.Set => collection.immutable.Set per #116

### DIFF
--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/SetCommands.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/SetCommands.scala
@@ -1,7 +1,7 @@
 package com.twitter.finagle.redis
 
 import _root_.java.lang.{Long => JLong,Boolean => JBoolean}
-import scala.collection.{Set => CollectionSet}
+import scala.collection.immutable.{Set => ImmutableSet}
 import com.twitter.finagle.redis.protocol._
 import com.twitter.finagle.redis.util.ReplyFormat
 import com.twitter.util.Future
@@ -25,10 +25,10 @@ trait Sets { self: BaseClient =>
    * @param key
    * @return a list of the members
    */
-  def sMembers(key: ChannelBuffer): Future[CollectionSet[ChannelBuffer]] =
+  def sMembers(key: ChannelBuffer): Future[ImmutableSet[ChannelBuffer]] =
     doRequest(SMembers(key)) {
       case MBulkReply(list) => Future.value(ReplyFormat.toChannelBuffers(list) toSet)
-      case EmptyMBulkReply() => Future.value(CollectionSet())
+      case EmptyMBulkReply() => Future.value(ImmutableSet())
     }
 
   /**


### PR DESCRIPTION
## motivation

immutable.Set is the default Set, so if it's described as collection.Set, you can't just say the return value of something that returns a client.sMembers is a Future[Set[ChannelBuffer]], it's a Future[scala.collection.Set[ChannelBuffer]].  There is also no reason to create ambiguity as to whether it's immutable or not, because it makes much more sense for the api to return an immutable version.
## implementation

changed all references of collection.Set to collection.immutable.Set.  Also changed the imported name from CollectionSet to ImmutableSet.  I cannot use the native "Set" name for the class because it is obscured by the Set Command class in finagle-redis.
