### PR TITLE
Redis codec parses case-insensitive commands

### DIFF
--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/Command.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/Command.scala
@@ -214,7 +214,7 @@ object Commands {
 
   )
 
-  def doMatch(cmd: String, args: List[Array[Byte]]) = commandMap.get(cmd).map {
+  def doMatch(cmd: String, args: List[Array[Byte]]) = commandMap.get(cmd.toUpperCase).map {
     _(args)
   }.getOrElse(throw ClientError("Unsupported command: " + cmd))
 


### PR DESCRIPTION
Currently when using the redis codec in a server, it throws a ClientError for any incoming commands that aren't all uppercase -- for example "GET" is ok but "get" is not.  Some redis clients, including the ruby [redis-rb](https://github.com/redis/redis-rb) client, send commands in lowercase.
