### PR TITLE
lets finagle compile

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -4,7 +4,7 @@ import com.twitter.sbt._
 
 object Finagle extends Build {
   val zkVersion = "3.3.4"
-  val utilVersion = "5.3.6"
+  val utilVersion = "6.0.1"
   val nettyLib = "io.netty" % "netty" % "3.5.5.Final" withSources()
   val ostrichLib = "com.twitter" % "ostrich" % "8.2.3" withSources()
   val thriftLibs = Seq(


### PR DESCRIPTION
## motivation

finagle does not compile--it depends upon Stopwatch, which only appears to be in very new versions of util.
## implementation

changes the utilVersion is depends upon from 5.3.6 to 6.0.1
## remaining issues

It compiles now, but fails some tests.
