### PR TITLE
Added possibility to change to delimiter

### DIFF
--- a/finagle-ostrich4/src/main/scala/com/twitter/finagle/stats/OstrichStatsReceiver.scala
+++ b/finagle-ostrich4/src/main/scala/com/twitter/finagle/stats/OstrichStatsReceiver.scala
@@ -3,7 +3,8 @@ package com.twitter.finagle.stats
 import com.twitter.ostrich.stats.{Stats, StatsCollection}
 
 class OstrichStatsReceiver(
-  val repr: StatsCollection = Stats
+  val repr: StatsCollection = Stats,
+  val delimiter: String = "/"
 ) extends StatsReceiverWithCumulativeGauges {
 
   protected[this] def registerGauge(name: Seq[String], f: => Float) {
@@ -28,5 +29,5 @@ class OstrichStatsReceiver(
     }
   }
 
-  private[this] def variableName(name: Seq[String]) = name mkString "/"
+  private[this] def variableName(name: Seq[String]) = name mkString delimiter
 }


### PR DESCRIPTION
We need the possibility to change the delimiter used when creating names for Ostrich stats
