### PR TITLE
fix up grab_and_patch_tomcat_native.sh in finagle-native

### DIFF
--- a/finagle-native/grab_and_patch_tomcat_native.sh
+++ b/finagle-native/grab_and_patch_tomcat_native.sh
@@ -2,7 +2,7 @@
 
 VER="1.1.22"
 REL="tomcat-native-$VER"
-URL="http://www.apache.org/dist/tomcat/tomcat-connectors/native/$VER/source/$REL-src.tar.gz"
+URL="http://archive.apache.org/dist/tomcat/tomcat-connectors/native/$VER/source/$REL-src.tar.gz"
 TARBALL="$REL-src.tar.gz"
 SRC="$REL-src"
 
@@ -22,7 +22,7 @@ test -f $TARBALL || \
 
 tar zxf $TARBALL
 cd $SRC > /dev/null
-git apply < ../tomcat-native-$VER.finagle.patch || die "patch did not apply"
+patch -p1 < ../tomcat-native-$VER.finagle.patch || die "patch did not apply"
 cd - > /dev/null
 rm $TARBALL
 


### PR DESCRIPTION
Fixes two issues
# tomcat-native-1.22 is now on archive.apache.org
# git apply doesn't like applying patches to a working tree that aren't for that working tree, so use patch instead of git apply to fix up tomcat-native
