### PR TITLE
made zRange... commands work more like the actual redis commands

### DIFF
--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/CommandArguments.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/CommandArguments.scala
@@ -17,7 +17,8 @@ case object WithScores extends CommandArgument {
   }
   override def toString = command
   def toChannelBuffer = commandBytes
-  val asArg = Some(WithScores)
+  @deprecated("Prefer option") val asArg = Some(WithScores)
+  def option(opt: Boolean): Option[this.type] = if (opt) asArg else None
 }
 
 case class Limit(offset: Long, count: Long) extends CommandArgument {


### PR DESCRIPTION
In the redis protocol, there are four commands which take a WITHSCORES argument.  In the finagle-redis protocol, in the SortedSets file, every command which takes a WITHSCORES argument has an option in the argument for the constructor that lets you specify it.

However, in the finagle-redis client methods, only the methods zRangeByScore and zRevRangeByScore require that you pass in a withScores boolean, whereas zRange and zRevRange do not let you pass in a boolean.  This means that you can only get scores from zRangeByScore-style calls, although you might want to get them from zRange-style calls, which is suboptimal.  Also, zRangeByScore-style calls return ZRangeResults, whereas zRange-style calls return ChannelBuffers, which actually means that each call can only return one configuration of withScores: if you try to call zRangeByScore with false as the argument to zRangeByScore, it fails.  Similarly, zRange does not support withScores, and so only passes by ChannelBuffers.

I think that the correct way to handle this is to have both styles return an Either[ZRangeResults, Seq[ChannelBuffer]], and to add a withScores argument to zRange.
