### PR TITLE
Makes the type parameter T of Cluster covariant

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/builder/Cluster.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/builder/Cluster.scala
@@ -14,7 +14,7 @@ import java.util.logging.Logger
  * Note that a Cluster can be elastic: members can join or leave at
  * any time.
  */
-trait Cluster[T] { self =>
+trait Cluster[+T] { self =>
   /**
    * A Future object that is defined when the cluster is initialized.
    * Cluster users can subscribe to this Future object to check or get notified of the availability of the cluster.
@@ -90,14 +90,14 @@ trait Cluster[T] { self =>
 }
 
 object Cluster {
-  sealed abstract trait Change[T] { def value: T }
-  case class Add[T](value: T) extends Change[T]
-  case class Rem[T](value: T) extends Change[T]
+  sealed abstract trait Change[+T] { def value: T }
+  case class Add[+T](value: T) extends Change[T]
+  case class Rem[+T](value: T) extends Change[T]
 }
 
 /**
  * A simple static cluster implementation.
  */
-case class StaticCluster[T](underlying: Seq[T]) extends Cluster[T] {
+case class StaticCluster[+T](underlying: Seq[T]) extends Cluster[T] {
   def snap: (Seq[T], Future[Spool[Cluster.Change[T]]]) = (underlying, Future.value(Spool.empty))
 }

--- a/finagle-core/src/main/scala/com/twitter/finagle/builder/MinimumSetCluster.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/builder/MinimumSetCluster.scala
@@ -9,7 +9,7 @@ import com.twitter.util.Future
  * to specify a Cluster to supplement the initial static set. All operations
  * that would remove entries in the minimum set are censored and counted.
  */
-class MinimumSetCluster[T](
+class MinimumSetCluster[+T](
   minimum: Set[T],
   supplementary: Cluster[T],
   statsReceiver: StatsReceiver = NullStatsReceiver

--- a/finagle-core/src/main/scala/com/twitter/finagle/builder/NonShrinkingCluster.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/builder/NonShrinkingCluster.scala
@@ -13,7 +13,7 @@ import java.util.ArrayDeque
  * impact by delaying node removals. We do so by disallowing the cluster to shrink. Add
  * events are always propagated but Rem events require a corresponding Add.
  */
-class NonShrinkingCluster[T](underlying: Cluster[T]) extends Cluster[T] {
+class NonShrinkingCluster[+T](underlying: Cluster[T]) extends Cluster[T] {
   import Cluster._
 
   def snap: (Seq[T], Future[Spool[Change[T]]]) = {

--- a/finagle-core/src/test/scala/com/twitter/finagle/integration/DynamicCluster.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/integration/DynamicCluster.scala
@@ -4,7 +4,7 @@ import com.twitter.finagle.builder.Cluster
 import com.twitter.concurrent.Spool
 import com.twitter.util.{Return, Promise}
 
-class DynamicCluster[U](initial: Seq[U])
+class DynamicCluster[+U](initial: Seq[U])
   extends Cluster[U] {
 
   def this() = this(Seq[U]())

--- a/finagle-kestrel/src/test/scala/com/twitter/finagle/kestrel/unit/MultiReader.scala
+++ b/finagle-kestrel/src/test/scala/com/twitter/finagle/kestrel/unit/MultiReader.scala
@@ -89,7 +89,7 @@ class MultiReaderSpec extends SpecificationWithJUnit with Mockito {
       }
     }
 
-    class DynamicCluster[U](initial: Seq[U]) extends Cluster[U] {
+    class DynamicCluster[+U](initial: Seq[U]) extends Cluster[U] {
       def this() = this(Seq[U]())
 
       var set = initial.toSet


### PR DESCRIPTION
The following `update(changes)`, for example, will be compile error because the type parameter `[T]` of both `Cluster` and `Change` is invariant.

```
import java.net._
import com.twitter.concurrent.Spool
import com.twitter.finagle.builder._
import com.twitter.util.Future

def update(changes: Future[Spool[Cluster.Change[SocketAddress]]]) = ...
val (hosts, changes) = StaticCluster(List(new InetSocketAddress("192.168.0.1", 8080))).snap

update(changes)
// <console>:18: error: type mismatch;
// found   : com.twitter.util.Future[com.twitter.concurrent.Spool[com.twitter.finagle.builder.Cluster.Change[java.net.InetSocketAddress]]]
// required: com.twitter.util.Future[com.twitter.concurrent.Spool[com.twitter.finagle.builder.Cluster.Change[java.net.SocketAddress]]]
//              update(changes)
//                     ^
```

Of course, this can be solved by specifying a type parameter of `StaticCluster`:

```
StaticCluster[SocketAddress](...)
```

but I think it is inconvenient.
