### PR TITLE
avoid repetition in RetryPolicy

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/service/RetryingFilter.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/service/RetryingFilter.scala
@@ -70,8 +70,7 @@ object RetryPolicy extends JavaSingleton {
     case Throw(RetryableWriteException(_)) => true
   }
 
-  val TimeoutAndWriteExceptionsOnly: PartialFunction[Try[Nothing], Boolean] = {
-    case Throw(RetryableWriteException(_)) => true
+  val TimeoutAndWriteExceptionsOnly: PartialFunction[Try[Nothing], Boolean] = WriteExceptionsOnly orElse {
     case Throw(_: TimeoutException) => true
   }
 


### PR DESCRIPTION
## motivation

This is a super tiny change, but I think it makes sense for two reasons.  First, DRY.  Second, for users who don't have a lot of experience with partial functions, mixing them together might not be intuitively obvious to them.  When they come here to look at how RetryFilters work, and look at TimeoutAndWriteExceptionsOnly as an example, it will encourage the mixing together way of using partial functions.
## change in behavior

no change in behavior
