### PR TITLE
moved redis server classes from private to public

### DIFF
--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/util/TestServer.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/util/TestServer.scala
@@ -9,7 +9,7 @@ import collection.JavaConversions._
 import scala.util.Random
 
 // Helper classes for spinning up a little redis cluster
-private[twitter] object RedisCluster { self =>
+object RedisCluster { self =>
   import collection.mutable.{Stack => MutableStack}
   val instanceStack = MutableStack[ExternalRedis]()
 
@@ -48,7 +48,7 @@ private[twitter] object RedisCluster { self =>
   });
 }
 
-private[twitter] class ExternalRedis() {
+class ExternalRedis() {
   private[this] val rand = new Random
   private[this] var process: Option[Process] = None
   private[this] val forbiddenPorts = 6300.until(7300)


### PR DESCRIPTION
## motivation

These classes are useful for anyone who wants to write an integration test, but right now, in order to use them, you have to have a test where your package is com.twitter... which is a pain.
## implementation

No longer marked private[twitter].
