### PR TITLE
Avoid URISyntaxException on request params

### DIFF
--- a/finagle-http/src/main/scala/com/twitter/finagle/http/HttpMuxer.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/http/HttpMuxer.scala
@@ -43,6 +43,10 @@ class HttpMuxer(protected[this] val handlers: Seq[(String, Service[HttpRequest, 
    * HttpRequest to the registered service; otherwise create a NOT_FOUND response
    */
   def apply(request: HttpRequest): Future[HttpResponse] = {
+  	var uri = request.getUri()
+		var paramPos = uri.indexOf('?')
+		if (paramPos < 0) paramPos = uri.length()
+		uri = uri.take(paramPos)
     val path = normalize(new URI(request.getUri()).getPath())
 
     // find the longest prefix of path; patterns are already sorted by length in descending order.


### PR DESCRIPTION
If the request params contains characters that the URI class considers invalid it will throw an URISyntaxException and the request will fail - although the actual url is fine.
For instance - http://myservice.com?j={}
Since the muxer does not consider the params but only the path we can drop the params before parsing with the URI to avoid this exception.
