### PR TITLE
Don't use ChannelBuffer.array

### DIFF
--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/util/Conversions.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/util/Conversions.scala
@@ -56,7 +56,7 @@ object StringToChannelBuffer {
 }
 object CBToString {
   def apply(arg: ChannelBuffer, charset: Charset = CharsetUtil.UTF_8) = {
-    new String(arg.array, charset)
+    arg.toString(charset)
   }
   def fromList(args: Seq[ChannelBuffer], charset: Charset = CharsetUtil.UTF_8) =
     args.map { arg => CBToString(arg, charset) }


### PR DESCRIPTION
`ChannelBuffer.array` [isn't supported on `CompositeChannelBuffer`](http://netty.io/3.5/xref/org/jboss/netty/buffer/CompositeChannelBuffer.html#165). Use `ChannelBuffer.toString(Charset)` instead (cf. [`http.Message.contentString`](https://github.com/twitter/finagle/blob/master/finagle-http/src/main/scala/com/twitter/finagle/http/Message.scala#L280)).
