### PR TITLE
Fix byte encoding problem with Z(Rev)Rank

### DIFF
--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/SortedSets.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/SortedSets.scala
@@ -160,8 +160,8 @@ case class ZRank(key: ChannelBuffer, member: ChannelBuffer) extends ZRankCmd {
   def commandBytes = CommandBytes.ZRANK
 }
 object ZRank extends ZRankCmdCompanion {
-  def get(key: String, member: String) =
-    new ZRank(StringToChannelBuffer(key), StringToChannelBuffer(member))
+  def get(key: ChannelBuffer, member: ChannelBuffer) =
+    new ZRank(key, member)
 }
 
 case class ZRem(key: ChannelBuffer, members: Seq[ChannelBuffer]) extends StrictKeyCommand {
@@ -274,8 +274,8 @@ case class ZRevRank(key: ChannelBuffer, member: ChannelBuffer) extends ZRankCmd 
   def commandBytes = CommandBytes.ZREVRANK
 }
 object ZRevRank extends ZRankCmdCompanion {
-  def get(key: String, member: String) =
-    new ZRevRank(StringToChannelBuffer(key), StringToChannelBuffer(member))
+  def get(key: ChannelBuffer, member: ChannelBuffer) =
+    new ZRevRank(key, member)
 }
 
 case class ZScore(key: ChannelBuffer, member: ChannelBuffer)
@@ -739,10 +739,10 @@ abstract class ZRankCmd extends StrictKeyCommand with StrictMemberCommand {
       member))
 }
 trait ZRankCmdCompanion {
-  def get(key: String, member: String): ZRankCmd
+  def get(key: ChannelBuffer, member: ChannelBuffer): ZRankCmd
 
   def apply(args: Seq[Array[Byte]]) = {
     val list = trimList(args, 2, "ZRANKcmd")
-    get(BytesToString(args(0)), BytesToString(args(1)))
+    get(ChannelBuffers.copiedBuffer(args(0)), ChannelBuffers.copiedBuffer(args(1)))
   }
 }


### PR DESCRIPTION
There is a bug in parsing Z(Rev)Rank commands; the current code assumes conversion from byte array to String to ChannelBuffer is safe, which it is not.  This patch corrects the defect.
