### PR TITLE
Issue #158: org.apache.thrift#libthrift;0.5.0 doesn't exist

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -80,7 +80,14 @@ object Finagle extends Build {
           <name>Twitter Inc.</name>
           <url>https://www.twitter.com/</url>
         </developer>
-      </developers>),
+      </developers>
+      <repositories>
+        <repository>
+          <id>twitter</id>
+          <name>Twitter Public Repo</name>
+          <url>http://maven.twttr.com</url>
+        </repository>
+      </repositories>),
     publishTo <<= version { (v: String) =>
       val nexus = "https://oss.sonatype.org/"
       if (v.trim.endsWith("SNAPSHOT"))


### PR DESCRIPTION
1. All submodules of the finagle parent POM should reference that parent POM (rather than the `scala-parent-292` artifact).
2. The finagle parent POM should have `scala-parent-292` as its parent.
3. The finagle parent POM should include a reference to Twitter's public maven repo, so that finagle users can resolve transitive dependencies (such as `org.apache.thrift#libthrift;0.5.0`).
