### PR TITLE
Allow multiple score/member pairs to be inserted with zadd.

### DIFF
--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/SortedSetCommands.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/SortedSetCommands.scala
@@ -31,19 +31,25 @@ trait SortedSets { self: BaseClient =>
   }
 
   /**
-   * Adds member, score pairs to sorted set
-   * @params key, score, member, zero or more (score, member) tuples
+   * Add a member with score to a sorted set
+   * @params key, score, member
    * @return Number of elements added to sorted set
-   * @note The multiple element version of zadd only works with redis 2.4 or later.
    */
-  def zAdd(key: ChannelBuffer, score: JDouble, member: ChannelBuffer,
-           members: (JDouble, ChannelBuffer)*): Future[JLong] = {
-    val allMembers = Seq(ZMember(score, member)) ++ members.map { m => ZMember(m._1, m._2) }
-    doRequest(ZAdd(key, allMembers)) {
+  def zAdd(key: ChannelBuffer, score: JDouble, member: ChannelBuffer): Future[JLong] = {
+    zAddMulti(key, Seq((score, member)))
+  }
+
+  /**
+   * Adds member, score pairs to sorted set
+   * @params key, sequence of (score, member) tuples
+   * @return Number of elements added to sorted set
+   * @note Adding multiple elements only works with redis 2.4 or later.
+   */
+  def zAddMulti(key: ChannelBuffer, members: Seq[(JDouble, ChannelBuffer)]): Future[JLong] = {
+    doRequest(ZAdd(key, members.map { m => ZMember(m._1, m._2) })) {
       case IntegerReply(n) => Future.value(n)
     }
   }
-
   /**
    * Returns sorted set cardinality of the sorted set at key
    * @param key

--- a/finagle-redis/src/test/scala/com/twitter/finagle/redis/integration/ClientSpec.scala
+++ b/finagle-redis/src/test/scala/com/twitter/finagle/redis/integration/ClientSpec.scala
@@ -308,7 +308,7 @@ class ClientSpec extends SpecificationWithJUnit {
       }
 
       "add multiple members and get scores" in {
-        Await.result(client.zAdd(foo, 10.5, bar, (20.1, baz))) mustEqual 2
+        Await.result(client.zAddMulti(foo, Seq((10.5, bar), (20.1, baz))) mustEqual 2
         Await.result(client.zScore(foo, bar)).get mustEqual 10.5
         Await.result(client.zScore(foo, baz)).get mustEqual 20.1
       }


### PR DESCRIPTION
Functionality added in a backwards-compatible way without method overloading. A `zAdd` call would look like

```
client.zAdd(key, score1, member1, (score2, member2), ...)
```

The multiple element version of zadd only works with redis >= 2.4.

Any tips on how to run the integration tests would be appreciated. `NaggatiSpec` is the only file that runs with `sbt`.
