### PR TITLE
Implement new SET syntax introduced in redis 2.6.12

### DIFF
--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/StringCommands.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/StringCommands.scala
@@ -237,6 +237,34 @@ trait Strings { self: BaseClient =>
     }
 
   /**
+   * Set key to hold the string value with the specified expire time in seconds
+   * only if the key does not already exist.
+   *
+   * @param key, millis, value
+   * @return true if the key was set, false if condition was not met.
+   * @see http://redis.io.commands/set
+   */
+  def setExNx(key: ChannelBuffer, seconds: Long, value: ChannelBuffer): Future[JBoolean] =
+    doRequest(Set(key, value, Some(InSeconds(seconds)), true, false)) {
+      case StatusReply(_) => Future.value(true)
+      case EmptyBulkReply() => Future.value(false)
+    }
+
+  /**
+   * Set key to hold the string value with the specified expire time in seconds
+   * only if the key already exist.
+   *
+   * @param key, millis, value
+   * @return true if the key was set, false if condition was not met.
+   * @see http://redis.io.commands/set
+   */
+  def setExXx(key: ChannelBuffer, seconds: Long, value: ChannelBuffer): Future[JBoolean] =
+    doRequest(Set(key, value, Some(InSeconds(seconds)), false, true)) {
+      case StatusReply(_) => Future.value(true)
+      case EmptyBulkReply() => Future.value(false)
+    }
+
+  /**
    * Set key to hold string value if key does not exist. In that case, it is
    * equal to SET. When key already holds a value, no operation is performed.
    *
@@ -247,6 +275,58 @@ trait Strings { self: BaseClient =>
   def setNx(key: ChannelBuffer, value: ChannelBuffer): Future[JBoolean] =
     doRequest(SetNx(key, value)) {
       case IntegerReply(n) => Future.value(n == 1)
+    }
+
+  /**
+   * Set key to hold the string value with the specified expire time in milliseconds.
+   *
+   * @param key, millis, value
+   * @see http://redis.io.commands/set
+   */
+  def setPx(key: ChannelBuffer, millis: Long, value: ChannelBuffer): Future[Unit] =
+    doRequest(Set(key, value, Some(InMilliseconds(millis)))) {
+      case StatusReply(_) => Future.Unit
+    }
+
+  /**
+   * Set key to hold the string value with the specified expire time in milliseconds
+   * only if the key does not already exist.
+   *
+   * @param key, millis, value
+   * @return true if the key was set, false if condition was not met.
+   * @see http://redis.io.commands/set
+   */
+  def setPxNx(key: ChannelBuffer, millis: Long, value: ChannelBuffer): Future[JBoolean] =
+    doRequest(Set(key, value, Some(InMilliseconds(millis)), true, false)) {
+      case StatusReply(_) => Future.value(true)
+      case EmptyBulkReply() => Future.value(false)
+    }
+
+  /**
+   * Set key to hold the string value with the specified expire time in milliseconds
+   * only if the key already exist.
+   *
+   * @param key, millis, value
+   * @return true if the key was set, false if condition was not met.
+   * @see http://redis.io.commands/set
+   */
+  def setPxXx(key: ChannelBuffer, millis: Long, value: ChannelBuffer): Future[JBoolean] =
+    doRequest(Set(key, value, Some(InMilliseconds(millis)), false, true)) {
+      case StatusReply(_) => Future.value(true)
+      case EmptyBulkReply() => Future.value(false)
+    }
+
+  /**
+   * Set key to hold the string value only if the key already exist.
+   *
+   * @param key, value
+   * @return true if the key was set, false if condition was not met.
+   * @see http://redis.io.commands/set
+   */
+  def setXx(key: ChannelBuffer, value: ChannelBuffer): Future[JBoolean] =
+    doRequest(Set(key, value, None, false, true)) {
+      case StatusReply(_) => Future.value(true)
+      case EmptyBulkReply() => Future.value(false)
     }
 
   /**

--- a/finagle-redis/src/test/scala/com/twitter/finagle/redis/NaggatiSpec.scala
+++ b/finagle-redis/src/test/scala/com/twitter/finagle/redis/NaggatiSpec.scala
@@ -504,7 +504,7 @@ class NaggatiSpec extends SpecificationWithJUnit {
           }
           "SET" >> {
             unwrap(codec(wrap("SET foo bar\r\n"))) {
-              case Set(foo, bar) => BytesToString(bar.array) mustEqual "bar"
+              case Set(foo, bar, _, _, _) => BytesToString(bar.array) mustEqual "bar"
             }
           }
           "SETBIT" >> {
@@ -526,6 +526,31 @@ class NaggatiSpec extends SpecificationWithJUnit {
             codec(wrap("SETNX key\r\n")) must throwA[ClientError]
             unwrap(codec(wrap("SETNX key value\r\n"))) {
               case SetNx(key, value) => BytesToString(value.array) mustEqual "value"
+            }
+          }
+          "New SET Syntax" >> {
+            codec(wrap("SET foo bar 100\r\n")) must throwA[ClientError]
+            codec(wrap("SET foo bar EX NX\r\n")) must throwA[ClientError]
+            codec(wrap("SET foo bar PX NX\r\n")) must throwA[ClientError]
+
+            unwrap(codec(wrap("SET foo bar EX 10\r\n"))) {
+              case Set(key, value, ttl, false, false) =>
+                ttl mustEqual Some(InSeconds(10L))
+            }
+
+            unwrap(codec(wrap("SET foo bar PX 10000\r\n"))) {
+              case Set(key, value, ttl, false, false) =>
+                ttl mustEqual Some(InMilliseconds(10000L))
+            }
+
+            unwrap(codec(wrap("SET foo bar NX EX 10\r\n"))) {
+              case Set(key, value, ttl, true, false) =>
+                ttl mustEqual Some(InSeconds(10))
+            }
+
+            unwrap(codec(wrap("SET foo bar XX\r\n"))) {
+              case Set(key, value, None, false, true) =>
+                BytesToString(value.array) mustEqual "bar"
             }
           }
           "SETRANGE" >> {

--- a/finagle-redis/src/test/scala/com/twitter/finagle/redis/integration/ClientSpec.scala
+++ b/finagle-redis/src/test/scala/com/twitter/finagle/redis/integration/ClientSpec.scala
@@ -210,6 +210,39 @@ class ClientSpec extends SpecificationWithJUnit {
         Await.result(client.get(baz)) mustEqual Some(StringToChannelBuffer("fbaz"))
       }
 
+      "new set syntax variations" in {
+        Await.result(client.setExNx(foo, 10L, bar)) mustEqual true
+        Await.result(client.get(foo)) mustEqual Some(bar)
+        Await.result(client.ttl(foo)) map (_ must beLessThanOrEqualTo(10L))
+        Await.result(client.setExNx(foo, 10L, baz)) mustEqual false
+
+        Await.result(client.setPxNx(bar, 10000L, baz)) mustEqual true
+        Await.result(client.get(bar)) mustEqual Some(baz)
+        Await.result(client.ttl(bar)) map (_ must beLessThanOrEqualTo(10L))
+        Await.result(client.setPxNx(bar, 100L, bar)) mustEqual false
+
+        Await.result(client.setXx(baz, foo)) mustEqual false
+        Await.result(client.set(baz, foo))
+        Await.result(client.setXx(baz, bar)) mustEqual true
+        Await.result(client.get(baz)) mustEqual Some(bar)
+
+        Await.result(client.setExXx(boo, 10L, foo)) mustEqual false
+        Await.result(client.set(boo, foo))
+        Await.result(client.setExXx(boo, 10L, bar)) mustEqual true
+        Await.result(client.get(boo)) mustEqual Some(bar)
+        Await.result(client.ttl(boo)) map (_ must beLessThanOrEqualTo(10L))
+
+        Await.result(client.setPxXx(moo, 10000L, foo)) mustEqual false
+        Await.result(client.set(moo, foo))
+        Await.result(client.setPxXx(moo, 10000L, bar)) mustEqual true
+        Await.result(client.get(moo)) mustEqual Some(bar)
+        Await.result(client.ttl(moo)) map (_ must beLessThanOrEqualTo(10L))
+
+        Await.result(client.setPx(num, 10000L, foo))
+        Await.result(client.get(num)) mustEqual Some(foo)
+        Await.result(client.ttl(num)) map (_ must beLessThanOrEqualTo(10L))
+      }
+
       "strlen" in {
         Await.result(client.strlen(foo)) mustEqual 0L
         Await.result(client.set(foo, bar))


### PR DESCRIPTION
Adding these methods to StringCommands
    - setExNx
    - setExXx
    - setPx
    - setPxNx
    - setPxXx
    - setXx

These methods are untouched
    - pSetEx
    - setEx
    - setNx
