### PR TITLE
ChannelSnooper: Print exceptions via Logger

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/builder/ClientBuilder.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/builder/ClientBuilder.scala
@@ -700,7 +700,7 @@ class ClientBuilder[Req, Rep, HasCluster, HasCodec, HasHostConnectionLimit] priv
       socksProxy = config.socksProxy,
       channelReaderTimeout = config.readerIdleTimeout getOrElse Duration.Top,
       channelWriterTimeout = config.writerIdleTimeout getOrElse Duration.Top,
-      channelSnooper = config.logger map { log => ChannelSnooper(config.name)(log.info) },
+      channelSnooper = config.logger map { log => ChannelSnooper(config.name)(log.log(Level.INFO, _, _)) },
       channelOptions = {
         val o = new mutable.MapBuilder[String, Object, Map[String, Object]](Map())
         o += "connectTimeoutMillis" -> (config.tcpConnectTimeout.inMilliseconds: java.lang.Long)

--- a/finagle-core/src/main/scala/com/twitter/finagle/builder/ServerBuilder.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/builder/ServerBuilder.scala
@@ -421,7 +421,7 @@ class ServerBuilder[Req, Rep, HasCodec, HasBindTo, HasName] private[builder](
       name = config.name,
       pipelineFactory = codec.pipelineFactory,
       channelSnooper =
-        if (config.logChannelActivity) Some(ChannelSnooper(config.name)(logger.info))
+        if (config.logChannelActivity) Some(ChannelSnooper(config.name)(logger.log(Level.INFO, _, _)))
         else None,
       channelFactory = config.channelFactory,
       bootstrapOptions = {


### PR DESCRIPTION
We like using `ChannelSnooper` with a logging printer (e.g. via `{ServerBuilder,ClientBuilder}.logger`) and suppressing it by default in our logging config (logback via JUL) by setting the logger's level to `warn`. Then when we encounter problems to diagnose we can toggle `warn` to `info` and back. One annoyance with this approach is that when we suppress the `ChannelSnooper` logging [it still prints exception stacktraces to stdout](https://github.com/jdanbrown/finagle/blob/1744ce2e1aaab363b5c6df9a2a22b2e64c3f19e7/finagle-core/src/main/scala/com/twitter/finagle/netty3/ChannelSnooper.scala#L79) and, further, they don't include any indication of who's printing them.

This change delegates the exception printing to the printer, e.g., a logger that might choose to suppress it, and it also includes the message `"Snooped exception"` to give the end user something to grep for in the code to find out what's going on.
