### PR TITLE
Provide a timezone for serializing timestamps

### DIFF
--- a/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Request.scala
+++ b/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Request.scala
@@ -5,6 +5,7 @@ import com.twitter.finagle.exp.mysql.protocol.{Command, Packet, Buffer, BufferWr
 import org.jboss.netty.buffer.ChannelBuffer
 import org.jboss.netty.buffer.ChannelBuffers._
 import scala.annotation.tailrec
+import java.util.TimeZone
 
 abstract class Request(seq: Short) {
   /**
@@ -52,7 +53,7 @@ case class PrepareRequest(sqlStatement: String)
  * Uses the binary protocol to build an execute request for
  * a prepared statement.
  */
-case class ExecuteRequest(ps: PreparedStatement, flags: Byte = 0, iterationCount: Int = 1)
+case class ExecuteRequest(ps: PreparedStatement, timeZone: TimeZone = TimeZone.getDefault, flags: Byte = 0, iterationCount: Int = 1)
   extends CommandRequest(Command.COM_STMT_EXECUTE) {
     private[this] val log = Logger("finagle-mysql")
 
@@ -121,9 +122,9 @@ case class ExecuteRequest(ps: PreparedStatement, flags: Byte = 0, iterationCount
       case d: Double      => writer.writeDouble(d)
       case b: Array[Byte] => writer.writeLengthCodedBytes(b)
       // Dates
-      case t: java.sql.Timestamp    => TimestampValue.write(t, writer)
-      case d: java.sql.Date         => DateValue.write(d, writer)
-      case d: java.util.Date        => TimestampValue.write(new java.sql.Timestamp(d.getTime), writer)
+      case t: java.sql.Timestamp    => TimestampValue.write(t, timeZone, writer)
+      case d: java.sql.Date         => DateValue.write(d, timeZone, writer)
+      case d: java.util.Date        => TimestampValue.write(new java.sql.Timestamp(d.getTime), timeZone, writer)
       case _  => writer // skip null and uknown values
     }
 

--- a/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Value.scala
+++ b/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Value.scala
@@ -2,7 +2,7 @@ package com.twitter.finagle.exp.mysql
 
 import com.twitter.finagle.exp.mysql.protocol.{BufferReader, BufferWriter, SQLZeroDate, SQLZeroTimestamp, Type}
 import java.sql.{Timestamp, Date => SQLDate}
-import java.util.Calendar
+import java.util.{TimeZone, Calendar}
 import java.nio.charset.{Charset => JCharset}
 
 /**
@@ -162,10 +162,11 @@ object TimestampValue {
    * Write a java.sql.Timestamp into its
    * MySQL binary representation.
    * @param Timestamp to write
+   * @param TimeZone to write timestamp in
    * @param BufferWriter to write to.
    */
-  def write(ts: Timestamp, buffer: BufferWriter) = {
-    val cal = Calendar.getInstance
+  def write(ts: Timestamp, timeZone: TimeZone, buffer: BufferWriter) = {
+    val cal = Calendar.getInstance(timeZone)
     cal.setTimeInMillis(ts.getTime)
     buffer.writeByte(11)
     buffer.writeShort(cal.get(Calendar.YEAR))
@@ -230,10 +231,11 @@ object DateValue {
    * Writes a java.sql.Date into its
    * MySQL binary representation.
    * @param Date to write
+   * @param TimeZone to write date in
    * @param BufferWriter to write to.
    */
-  def write(date: SQLDate, buffer: BufferWriter) = {
-    val cal = Calendar.getInstance
+  def write(date: SQLDate, timeZone: TimeZone, buffer: BufferWriter) = {
+    val cal = Calendar.getInstance(timeZone)
     cal.setTimeInMillis(date.getTime)
     buffer.writeByte(4)
     buffer.writeShort(cal.get(Calendar.YEAR))

--- a/finagle-mysql/src/test/scala/com/twitter/finagle/mysql/unit/RequestTest.scala
+++ b/finagle-mysql/src/test/scala/com/twitter/finagle/mysql/unit/RequestTest.scala
@@ -2,8 +2,7 @@ package com.twitter.finagle.exp.mysql
 
 import com.twitter.finagle.exp.mysql.protocol.{BufferReader, Buffer, Command, Type}
 import java.sql.{Timestamp, Date => SQLDate}
-import java.util.Calendar
-import java.util.Date
+import java.util.{TimeZone, Calendar, Date}
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.matchers.ShouldMatchers
@@ -90,7 +89,7 @@ class RequestTest extends FunSuite with ShouldMatchers {
   val ps = PreparedStatement(stmtId, params.size)
   ps.parameters = params
   val flags, iteration = 0
-  val req = ExecuteRequest(ps, flags.toByte, iteration)
+  val req = ExecuteRequest(ps, TimeZone.getDefault, flags.toByte, iteration)
 
   val br = BufferReader(req.toChannelBuffer)
   br.skip(4) // header


### PR DESCRIPTION
Adds a way to specify the timezone that dates and times are serialized in.

This is a proposed fix for #190.