### PR TITLE
improve HeapBalancer req distribution when N=2

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/HeapBalancer.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/HeapBalancer.scala
@@ -21,7 +21,8 @@ object HeapBalancer {
 class HeapBalancer[Req, Rep](
   group: Group[ServiceFactory[Req, Rep]],
   statsReceiver: StatsReceiver = NullStatsReceiver,
-  emptyException: NoBrokersAvailableException = new NoBrokersAvailableException
+  emptyException: NoBrokersAvailableException = new NoBrokersAvailableException,
+  rng: Random = new Random
 ) extends ServiceFactory[Req, Rep] {
 
   import HeapBalancer._
@@ -40,8 +41,6 @@ class HeapBalancer[Req, Rep](
   
   // Linked list of downed nodes.
   private[this] var downq: Node = null
-
-  private[this] val rng = new Random
 
   private[this] val HeapOps = Heap[Node](
     Ordering.by(_.load),
@@ -125,8 +124,8 @@ class HeapBalancer[Req, Rep](
       swap(heap, i, size)
       fixDown(heap, i, size - 1)
 
-      // pick a random index in the shrunk heap, insert n
-      val j = rng.nextInt(size -1) + 1
+      // pick a random node with which we can swap n
+      val j = rng.nextInt(size) + 1
       swap(heap, j, size)
       fixUp(heap, j)
 


### PR DESCRIPTION
- with 2 nodes and a stream of sequential requests,
  the HeapBalancer would always choose the same node

In this particular test, with a seed of 0, the distribution ends up being 6/4 with 10 requests, and 51/49 with 100 requests.

Here is some logging code and output I used to test the behavior of `rng.nextInt(size -1)` when N=2:
https://gist.github.com/slackhappy/8a820ae1e477d2b38177
