### PR TITLE
dual protocol codec

### DIFF
--- a/finagle-dual/src/main/scala/com/twitter/finagle/dual/DualProtocolCodecFactory.scala
+++ b/finagle-dual/src/main/scala/com/twitter/finagle/dual/DualProtocolCodecFactory.scala
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2012-2013  Foursquare Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.finagle.dual
+
+import com.twitter.finagle.{ClientConnection, Codec, CodecFactory, ServerCodecConfig, Service, ServiceFactory}
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.util.{Future, Time}
+import org.jboss.netty.channel.{ChannelPipeline, ChannelPipelineFactory}
+import scalaj.collection.Imports._
+
+/**
+ * A Finagle [[com.twitter.finagle.CodecFactory]] that makes [[com.twitter.finagle.Codec]] instances that understand
+ * how to decode both HTTP and non-HTTP.
+ */
+class DualProtocolCodecFactory[HttpRequestType <: Request, OtherReq, OtherRep](
+      httpFactory: CodecFactory[HttpRequestType, Response],
+      regularFactory: CodecFactory[OtherReq, OtherRep])
+  extends CodecFactory[AnyRef, AnyRef] {
+
+  override def client: DualProtocolCodecFactory[HttpRequestType, OtherReq, OtherRep]#Client =
+    throw new UnsupportedOperationException("Please use the Codec for the specific protocol you want directly.")
+
+  override def server: DualProtocolCodecFactory[HttpRequestType, OtherReq, OtherRep]#Server = {
+    { (config: ServerCodecConfig) =>
+      new Codec[AnyRef, AnyRef] {
+        private val httpCodec = httpFactory.server(config)
+        private val regularCodec = regularFactory.server(config)
+
+        override def pipelineFactory: ChannelPipelineFactory = new ChannelPipelineFactory {
+          override def getPipeline: ChannelPipeline = {
+            // Obtain the HTTP and non-HTTP pipelines. Uses same technique as RichHttp does to obtain the pipeline
+            // from another Codec.
+            val httpPipeline = httpCodec.pipelineFactory.getPipeline
+            val regularPipeline = regularCodec.pipelineFactory.getPipeline
+
+            // Record the names used in the other pipeline. (These will need to be removed from the pipeline when HTTP
+            // is detected.)
+            val regularHandlers = regularPipeline.toMap.asScala.map { case (_, v) => v }.toSeq
+            regularPipeline.addFirst("dualProtocolFrameDecoder",
+              new DualProtocolFrameDecoder("dualProtocolFrameDecoder", httpPipeline, regularHandlers))
+
+            regularPipeline
+          }
+        }
+
+        override def prepareConnFactory(underlying: ServiceFactory[AnyRef, AnyRef]): ServiceFactory[AnyRef, AnyRef] = {
+          val httpServiceFactory =
+            httpCodec.prepareConnFactory(underlying.asInstanceOf[ServiceFactory[HttpRequestType, Response]])
+          val regularServiceFactory =
+            regularCodec.prepareConnFactory(underlying.asInstanceOf[ServiceFactory[OtherReq, OtherRep]])
+
+          new ServiceFactory[AnyRef, AnyRef] {
+            override def apply(conn: ClientConnection): Future[Service[AnyRef, AnyRef]] = {
+              val httpServiceF = httpServiceFactory(conn)
+              val regularServiceF = regularServiceFactory(conn)
+
+              Future.collect(Seq(httpServiceF, regularServiceF)) map { services =>
+                val httpService = services(0).asInstanceOf[Service[HttpRequestType, Response]]
+                val regularService = services(1).asInstanceOf[Service[OtherReq, OtherRep]]
+                new Service[AnyRef, AnyRef] {
+                  def apply(request: AnyRef): Future[AnyRef] = (request match {
+                    case httpRequest: Request => httpService(httpRequest.asInstanceOf[HttpRequestType])
+                    case _ => regularService(request.asInstanceOf[OtherReq])
+                  }) map { r => r.asInstanceOf[AnyRef] }
+                }
+              }
+            }
+
+            override def close(deadline: Time): Future[Unit] = {
+              Future.join(Seq(httpServiceFactory.close(deadline), regularServiceFactory.close(deadline)))
+            }
+          }
+        }
+      }  // new Codec
+    } // ServerCodecConfig => Codec
+  }
+}

--- a/finagle-dual/src/main/scala/com/twitter/finagle/dual/DualProtocolFrameDecoder.scala
+++ b/finagle-dual/src/main/scala/com/twitter/finagle/dual/DualProtocolFrameDecoder.scala
@@ -1,0 +1,177 @@
+/**
+ * Copyright 2012-2013  Foursquare Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.finagle.dual
+
+import org.jboss.netty.buffer.ChannelBuffer
+import org.jboss.netty.channel._
+import org.jboss.netty.handler.codec.frame.FrameDecoder
+import scala.annotation.tailrec
+import scalaj.collection.Imports._
+
+object DualProtocolFrameDecoder {
+   // Helpers for the state machine that detects HTTP.
+
+  case class Transition(ch: Byte, state: Int)
+  object Transition {
+    def apply(ch: Char, state: Int): Transition = apply(ch.toByte, state)
+  }
+
+  case class State(transitions: Seq[Transition] = Seq(), isFinal: Boolean = false)
+
+  object State {
+    def apply(transitions: Transition*): State = State(transitions = transitions)
+  }
+
+  // Simple state machine to recognize GET, HEAD, POST, PUT, and DELETE.
+  val httpMethodStates = Array[State](
+    /*  0 */ State(Transition('G', 1), Transition('P', 7), Transition('H', 4), Transition('D', 12)),
+    /*  1 */ State(Transition('E', 2)),
+    /*  2 */ State(Transition('T', 3)),
+    /*  3 */ State(isFinal = true),
+    /*  4 */ State(Transition('E', 5)),
+    /*  5 */ State(Transition('A', 6)),
+    /*  6 */ State(Transition('D', 3)),
+    /*  7 */ State(Transition('O', 8), Transition('U', 9)),
+    /*  8 */ State(Transition('S', 9)),
+    /*  9 */ State(Transition('T', 3)),
+    /* 10 */ State(Transition('E', 11)),
+    /* 11 */ State(Transition('L', 12)),
+    /* 12 */ State(Transition('E', 13)),
+    /* 13 */ State(Transition('T', 14)),
+    /* 14 */ State(Transition('E', 3))
+  )
+
+  // Decisions made by the HTTP-detection state machine.
+  sealed trait ProtocolDecision
+  case object NoDecision extends ProtocolDecision
+  case object HttpDecision extends ProtocolDecision
+  case object NotHttpDecision extends ProtocolDecision
+}
+
+
+/**
+ * A Netty [[org.jboss.netty.handler.codec.frame.FrameDecoder]] that detects the start of the HTTP protocol and
+ * switches the Netty pipeline it is in to a HTTP protocol stack. If HTTP is not detected, the pipeline is left alone
+ * and the existing handlers remain in place.
+ *
+ * Theory of Operation:
+ *
+ * As data is received by Netty, it eventually reaches this class for processing in the decode() method. That method
+ * uses a simple state machine to recognize whether an HTTP method name (i.e., GET, POST, HEAD, PUT, or DELETE) forms
+ * the start of the network exchange. The state machine can either recognize HTTP, reject HTTP, or require more input.
+ *
+ * If the state machine rejects HTTP, then this class simply "gets out of the way" by removing itself from the Netty
+ * pipeline to allow the other handlers in the pipeline to process the data. This is an optimization for the non-HTTP
+ * case since we expect HTTP to be used for admin purposes. The data is injected again into the pipeline by
+ * returning a new ChannelBuffer with the same data. (FrameDecoder checks to see if we consumed data if we return the
+ * same ChannelBuffer and throws an exception if we didn't. This is not optimal behavior to say the least! It would
+ * be more useful if Netty supported reinjecting the same ChannelBuffer.)
+ *
+ * If the state machine recognizes HTTP, it removes the existing handlers from the pipeline, adds the handlers for
+ * the HTTP protocol stack after itself, then finally removes itself from the pipeline. (Removal of this class from the
+ * pipeline must occur *last* as per the Netty javadocs for FrameDecoer.) The data is then injected back into the
+ * pipeline in the same manner as before.
+ *
+ * If the decoder does not have enough information yet (e.g., it only sees 'G' and 'E'), it returns null so that
+ * FrameDecoder will invoke it later when more data is available.
+ *
+ * NOTES:
+ * - "Unfold" mode is disabled (via the base class' constructor parameter). This causes Object arrays returned by the
+ * decode() method to be "unfolded" before the frames are re-injected into the pipeline. We do not use this feature
+ * so it has been disabled.
+ */
+class DualProtocolFrameDecoder(
+    thisHandlerName: String,
+    httpPipeline: ChannelPipeline,
+    regularHandlers: Seq[ChannelHandler]) extends FrameDecoder(false) {
+
+  /**
+   * Transfer the handlers in otherPipeline into pipeline after the handler named afterHandlerName. The handlers will
+   * no longer be in otherPipeline once this operation completes.
+   *
+   * @param pipeline to which the handlers should be added
+   * @param afterHandlerName name of handler after which the handlers from otherPipeline should be added
+   * @param otherPipeline contains the handlers to be transferred
+   */
+  protected def patchPipeline(pipeline: ChannelPipeline, afterHandlerName: String, otherPipeline: ChannelPipeline) {
+    val names = otherPipeline.toMap.asScala
+
+    var previousName = afterHandlerName
+    names.foreach { case (name, handler) =>
+      otherPipeline.remove(handler)
+      pipeline.addAfter(previousName, name, handler)
+      previousName = name
+    }
+  }
+
+  /**
+   * Decide whether or not a data stream contains HTTP.
+   *
+   * @param context in which this class is operating
+   * @param channel underlying channel
+   * @param buffer contains the data on which to pass judgment
+   * @return an object that the FrameDecoder can inject into the pipeline
+   */
+  protected override def decode(context: ChannelHandlerContext, channel: Channel, buffer: ChannelBuffer): AnyRef = {
+    import DualProtocolFrameDecoder.{HttpDecision, NoDecision, NotHttpDecision, ProtocolDecision, State, httpMethodStates}
+
+    @tailrec
+    def nextState(buf: ChannelBuffer, currentState: State): Either[ProtocolDecision, State] = {
+      if (currentState.isFinal) {
+        Right(currentState)
+      } else {
+        if (buf.readableBytes() >= 1) {
+          val b = buf.readByte()
+          currentState.transitions.find(_.ch == b) match {
+            case Some(transition) => nextState(buf, httpMethodStates(transition.state))
+            case None => Left(NotHttpDecision)
+          }
+        } else {
+          Right(currentState)
+        }
+      }
+    }
+
+    buffer.markReaderIndex()
+    val decision = nextState(buffer, httpMethodStates(0)) match {
+      case Right(state) => if (state.isFinal) HttpDecision else NoDecision
+      case Left(theDecision) => theDecision
+    }
+    buffer.resetReaderIndex()
+
+    decision match {
+      // If no decision can be made, tell FrameDecoder to invoke us later when there is more data available.
+      case NoDecision => null
+
+      case HttpDecision =>
+        // Remove the non-HTTP protocol's handlers. Then install the HTTP handlers. Then remove this handler last.
+        // (See class docs for the reason.) Finally, have the pipeline process the data anew (by returning a new
+        // ChannelBuffer).
+        val pipeline = context.getPipeline
+        regularHandlers.foreach(handler => pipeline.remove(handler))
+        patchPipeline(pipeline, thisHandlerName, httpPipeline)
+        pipeline.remove(this)
+        buffer.readBytes(buffer.readableBytes())
+
+      case NotHttpDecision =>
+        // The pipeline already contains the non-HTTP protocol's handlers. We only need to remove this class from the
+        // pipeline and then have the pipeline process the data anew (by returning a new ChannelBuffer).
+        context.getPipeline.remove(this)
+        buffer.readBytes(buffer.readableBytes())
+    }
+  }
+}

--- a/finagle-dual/src/test/scala/com/twitter/finagle/dual/DualProtocolCodecTest.scala
+++ b/finagle-dual/src/test/scala/com/twitter/finagle/dual/DualProtocolCodecTest.scala
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2012-2013  Foursquare Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.finagle.dual
+
+import com.twitter.conversions.time._
+import com.twitter.finagle.{CodecFactory, Http => FinagleHttp,  Service}
+import com.twitter.finagle.builder.{ClientBuilder, Server, ServerBuilder}
+import com.twitter.finagle.dual.thrift.Adder
+import com.twitter.finagle.http.{Http, Request, Response, RichHttp, Status}
+import com.twitter.finagle.thrift.{ThriftClientFramedCodec, ThriftClientRequest, ThriftServerFramedCodec}
+import com.twitter.util.{Await, Future, Time}
+import java.net.InetSocketAddress
+import org.apache.thrift.protocol.TBinaryProtocol
+import org.jboss.netty.handler.codec.http.HttpResponseStatus
+import org.specs.SpecificationWithJUnit
+
+class FakeThriftCodecFactory extends CodecFactory[Array[Byte], Array[Byte]] {
+  override def client: FakeThriftCodecFactory#Client = throw new UnsupportedOperationException
+
+  override def server: FakeThriftCodecFactory#Server = { config =>
+    ThriftServerFramedCodec.get().apply(config)
+  }
+}
+
+class DualProtocolCodecTest extends SpecificationWithJUnit {
+  "DualProtocolCodecFactory" should {
+    "respond to both Thrift and HTTP requests on the same port" in {
+      // Make the dual services for testing.
+
+      val processor = new Adder.FutureIface {
+        def add(x: Int, y: Int): Future[Int] = Future.value(x + y)
+      }
+
+      val thriftService = new Adder.FinagledService(processor, new TBinaryProtocol.Factory())
+
+      val httpService = new Service[Request, Response] {
+        override def apply(request: Request): Future[Response] = {
+          request.uri match {
+            case "/test" => Future.value(Response(Status.Ok))
+            case _ => Future.value(Response(Status.NotFound))
+          }
+        }
+      }
+
+      val dualService = new Service[AnyRef, AnyRef] {
+        override def apply(request: AnyRef): Future[AnyRef] = {
+          request match {
+            case httpRequest: Request => httpService(httpRequest)
+            case _ => thriftService(request.asInstanceOf[Array[Byte]])  // guaranteed to be Array[Byte] if not a Request
+          }
+        }
+
+        override def close(deadline: Time): Future[Unit] =
+          Future.join(Seq(httpService.close(deadline), thriftService.close(deadline)))
+      }
+
+      val httpCodecFactory = RichHttp[Request](Http())
+
+      val thriftCodecFactory = new FakeThriftCodecFactory
+
+      val dualCodecFactory =
+        new DualProtocolCodecFactory[Request, Array[Byte], Array[Byte]](httpCodecFactory, thriftCodecFactory)
+      val dualCodec = dualCodecFactory.server
+
+      val dualServer: Server = ServerBuilder()
+        .bindTo(new InetSocketAddress(0))
+        .codec(dualCodec)
+        .name("dualserver")
+        .build(dualService)
+
+      val localSocketAddress = dualServer.localAddress.asInstanceOf[InetSocketAddress]
+      val localHostPort = "127.0.0.1:%d" format localSocketAddress.getPort
+
+      // Now make the clients used to access the dual services.
+
+      val thriftServiceClient: Service[ThriftClientRequest, Array[Byte]] = ClientBuilder()
+        .hosts(localHostPort)
+        .codec(ThriftClientFramedCodec())
+        .hostConnectionLimit(1)
+        .build()
+
+      val thriftClient = new Adder.FinagledClient(thriftServiceClient, new TBinaryProtocol.Factory())
+
+      val httpClient: Service[Request, Response] = ClientBuilder()
+        .hosts(localHostPort)
+        .codec(RichHttp[Request](Http()))
+        .hostConnectionLimit(1)
+        .build()
+
+      try {
+        def checkThrift(x: Int, y: Int) {
+          val expectedAnswer = x + y
+          val remoteAnswer = Await.result(thriftClient.add(x, y), 5.seconds)
+          remoteAnswer must_== expectedAnswer
+        }
+
+        def checkHttp(path: String, expectedStatus: HttpResponseStatus) {
+          val request = Request(path)
+          val response = Await.result(httpClient(request), 5.seconds)
+          response.status must_== expectedStatus
+        }
+
+        checkThrift(5, 2025)
+        checkHttp("/test", Status.Ok)
+        checkHttp("/xyzzy", Status.NotFound)
+        checkThrift(-204040, 8848484)
+        checkHttp("/test", Status.Ok)
+      } finally {
+        Await.result(dualService.close(), 5.seconds)
+      }
+    }
+  }
+
+}

--- a/finagle-dual/src/test/thrift/adder.thrift
+++ b/finagle-dual/src/test/thrift/adder.thrift
@@ -1,0 +1,5 @@
+namespace java com.twitter.finagle.dual.thrift
+
+service Adder {
+  i32 add(1: i32 x, 2: i32 y)
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -480,6 +480,20 @@ object Finagle extends Build {
     )
   ).dependsOn(finagleCore, finagleThrift)
    */
+  
+  lazy val finagleDual = Project(
+    id = "finagle-dual",
+    base = file("finagle-dual"),
+    settings = Project.defaultSettings ++
+      ScroogeSBT.newSettings ++  // TODO: needed in test mode only
+      sharedSettings
+  ).settings(
+    name := "finagle-dual",
+    libraryDependencies ++= Seq(
+      nettyLib,
+      "org.scalaj" %% "scalaj-collection" % "1.5"
+    ) ++ thriftLibs ++ scroogeLibs  // TODO: needed in test mode only
+  ).dependsOn(finagleCore, finagleHttp)
 
   lazy val finagleDoc = Project(
     id = "finagle-doc",


### PR DESCRIPTION
Support services that can decode a binary protocol and HTTP on
the same port. Useful for administrative services (like health checks)
where normal web tools can be used to query the admin services without
sacrificing the benefits of the binary protocol and without needing
a second port.
