### PR TITLE
Fix generated OpenSSLEngine class to handle direct byte buffers

### DIFF
--- a/finagle-native/tomcat-native-1.1.22.finagle.patch
+++ b/finagle-native/tomcat-native-1.1.22.finagle.patch
@@ -356,7 +356,7 @@ index 0000000..413ac51
 +}
 diff --git a/jni/java/org/apache/tomcat/jni/ssl/OpenSSLEngine.java b/jni/java/org/apache/tomcat/jni/ssl/OpenSSLEngine.java
 new file mode 100644
-index 0000000..e3d0171
+index 0000000..186bd2f
 --- /dev/null
 +++ b/jni/java/org/apache/tomcat/jni/ssl/OpenSSLEngine.java
 @@ -0,0 +1,742 @@
@@ -462,7 +462,7 @@ index 0000000..e3d0171
 +                    int lim = src.limit();
 +                    src.limit(len);
 +                    buffer.put(src);
-+                    src.position(pos).limit(lim);
++                    src.limit(lim).position(pos);
 +                }
 +                int sslWrote = SSL.writeToSSL(ssl, address, len);
 +                if (sslWrote > 0) {
@@ -495,7 +495,7 @@ index 0000000..e3d0171
 +                    int lim = src.limit();
 +                    src.limit(len);
 +                    buffer.put(src);
-+                    src.position(pos).limit(lim);
++                    src.limit(lim).position(pos);
 +                }
 +                int netWrote = SSL.writeToBIO(networkBIO, address, len);
 +                if (netWrote > -1) {


### PR DESCRIPTION
Netty 4 makes use of direct byte buffers. In particular, the constant empty buffer is hard-coded to be a direct buffer. Since the .array() method is unsupported on direct buffers, other parts of the ByteBuffer api are needed when manipulating the buffers.
