### PR TITLE
Fixed documentation import

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/package.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/package.scala
@@ -56,7 +56,7 @@ import org.jboss.netty.handler.codec.http.{
   HttpRequest, HttpResponse, DefaultHttpRequest}
 import org.jboss.netty.handler.codec.http.HttpVersion._
 import org.jboss.netty.handler.codec.http.HttpMethod._
-import com.twitter.util.{Future, Await, Future, Return, Throw}
+import com.twitter.util.{Future, Return, Throw}
 
 val client: Service[HttpRequest, HttpResponse] = 
   Http.newService("localhost:8080")


### PR DESCRIPTION
This doesn't compile as-is because of the extra Future in the import.  Also, I removed the Await, which appears to be unused in this example.
