### PR TITLE
redis: Fix decoding nested multi-bulk replies

### DIFF
--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/Reply.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/Reply.scala
@@ -90,14 +90,8 @@ class ReplyCodec extends UnifiedProtocolCodec {
       case BULK_REPLY =>
         decodeBulkReply
       case MBULK_REPLY =>
-        val doneFn = { lines: List[Reply] =>
-          lines.length match {
-            case empty if empty == 0 => EmptyMBulkReply()
-            case n => MBulkReply(lines)
-          }
-        }
         RequireServerProtocol.safe {
-          readLine { line => decodeMBulkReply(NumberFormat.toLong(line), doneFn) }
+          readLine { line => decodeMBulkReply(NumberFormat.toLong(line)) }
         }
       case b: Byte =>
         throw new ServerError("Unknown response format(%c) found".format(b.asInstanceOf[Char]))
@@ -120,19 +114,20 @@ class ReplyCodec extends UnifiedProtocolCodec {
     }
   }
 
-  def decodeMBulkReply[T <: AnyRef](argCount: Long, doneFn: List[Reply] => T) =
-    argCount match {
-      case n if n < 0 => emit(NilMBulkReply())
-      case n => decodeMBulkLines(n, Nil, { lines => doneFn(lines) } )
-    }
+  def decodeMBulkReply(argCount: Long) =
+    decodeMBulkLines(argCount, Nil, Nil)
 
-  def decodeMBulkLines[T <: AnyRef](
-    i: Long,
-    lines: List[Reply],
-    doneFn: List[Reply] => T): NextStep =
-  {
+  def decodeMBulkLines(i: Long, stack: List[(Long, List[Reply])], lines: List[Reply]): NextStep = {
     if (i <= 0) {
-      emit(doneFn(lines.reverse))
+      val reply = (i, lines) match {
+        case (i, _) if i < 0 => NilMBulkReply()
+        case (0, Nil) => EmptyMBulkReply()
+        case (0, lines) => MBulkReply(lines.reverse)
+      }
+      stack match {
+        case Nil => emit(reply)
+        case (i, lines) :: stack => decodeMBulkLines(i, stack, reply :: lines)
+      }
     } else {
       readLine { line =>
         val header = line(0)
@@ -140,29 +135,29 @@ class ReplyCodec extends UnifiedProtocolCodec {
           case ARG_SIZE_MARKER =>
             val size = NumberFormat.toInt(line.drop(1))
             if (size < 1) {
-              decodeMBulkLines(i - 1, EmptyBulkReply() :: lines, doneFn)
+              decodeMBulkLines(i - 1, stack, EmptyBulkReply() :: lines)
             } else {
               readBytes(size) { byteArray =>
                 readBytes(2) { eol =>
                   if (eol(0) != '\r' || eol(1) != '\n') {
                     throw new ProtocolError("Expected EOL after line data and didn't find it")
                   }
-                  decodeMBulkLines(i - 1,
-                    BulkReply(ChannelBuffers.wrappedBuffer(byteArray)) :: lines, doneFn)
+                  decodeMBulkLines(i - 1, stack,
+                    BulkReply(ChannelBuffers.wrappedBuffer(byteArray)) :: lines)
                 }
               }
             }
           case STATUS_REPLY =>
-            decodeMBulkLines(i - 1, StatusReply(BytesToString(
-              line.drop(1).getBytes)) :: lines, doneFn)
+            decodeMBulkLines(i - 1, stack, StatusReply(BytesToString(
+              line.drop(1).getBytes)) :: lines)
           case ARG_COUNT_MARKER =>
-            decodeMBulkLines(line.drop(1).toLong, lines, doneFn)
+            decodeMBulkLines(line.drop(1).toLong, (i - 1, lines) :: stack, Nil)
           case INTEGER_REPLY =>
-            decodeMBulkLines(i - 1, IntegerReply(NumberFormat.toLong(
-              BytesToString(line.drop(1).getBytes))) :: lines, doneFn)
+            decodeMBulkLines(i - 1, stack, IntegerReply(NumberFormat.toLong(
+              BytesToString(line.drop(1).getBytes))) :: lines)
           case ERROR_REPLY =>
-            decodeMBulkLines(i - 1, ErrorReply(BytesToString(
-              line.drop(1).getBytes)) :: lines, doneFn)
+            decodeMBulkLines(i - 1, stack, ErrorReply(BytesToString(
+              line.drop(1).getBytes)) :: lines)
           case b: Char =>
             throw new ProtocolError("Expected size marker $, got " + b)
         }

--- a/finagle-redis/src/test/scala/com/twitter/finagle/redis/NaggatiSpec.scala
+++ b/finagle-redis/src/test/scala/com/twitter/finagle/redis/NaggatiSpec.scala
@@ -794,6 +794,61 @@ class NaggatiSpec extends SpecificationWithJUnit {
         }
 
       }
+      "nested multi-bulk replies" >> {
+        codec(wrap("*3\r\n")) mustEqual Nil
+        codec(wrap(":1\r\n")) mustEqual Nil
+        codec(wrap("*2\r\n")) mustEqual Nil
+        codec(wrap("$3\r\n")) mustEqual Nil
+        codec(wrap("one\r\n")) mustEqual Nil
+        codec(wrap("$5\r\n")) mustEqual Nil
+        codec(wrap("three\r\n")) mustEqual Nil
+        codec(wrap(":3\r\n")) match {
+          case reply :: Nil => reply match {
+            case MBulkReply(List(a, b, c)) =>
+              a mustEqual IntegerReply(1)
+              b match {
+                case MBulkReply(xs) =>
+                  ReplyFormat.toString(xs) mustEqual List("one", "three")
+                case xs => fail("Expected MBulkReply, got: %s" format xs)
+              }
+              c mustEqual IntegerReply(3)
+            case xs => fail("Expected 3-element MBulkReply, got: %s" format xs)
+          }
+          case xs => fail("Expected one reply, got: %s" format xs)
+        }
+
+        codec(wrap("*4\r\n")) mustEqual Nil
+        codec(wrap(":0\r\n")) mustEqual Nil
+        codec(wrap(":1\r\n")) mustEqual Nil
+        codec(wrap("*3\r\n")) mustEqual Nil
+        codec(wrap(":10\r\n")) mustEqual Nil
+        codec(wrap("*0\r\n")) mustEqual Nil
+        codec(wrap("*2\r\n")) mustEqual Nil
+        codec(wrap("*0\r\n")) mustEqual Nil
+        codec(wrap(":100\r\n")) mustEqual Nil
+        codec(wrap(":2\r\n")) match {
+          case reply :: Nil => reply match {
+            case MBulkReply(List(a, b, c, d)) =>
+              a mustEqual IntegerReply(0)
+              b mustEqual IntegerReply(1)
+              c match {
+                case MBulkReply(List(aa, ab, ac)) =>
+                  aa mustEqual IntegerReply(10)
+                  ab mustEqual EmptyMBulkReply()
+                  ac match {
+                    case MBulkReply(List(aaa, aab)) =>
+                      aaa mustEqual EmptyMBulkReply()
+                      aab mustEqual IntegerReply(100)
+                    case xs => fail("Expected 2-element MBulkReply, got: %s" format xs)
+                  }
+                case xs => fail("Expected 3-element, got: %s" format xs)
+              }
+              d mustEqual IntegerReply(2)
+            case xs => fail("Expected 4-element MBulkReply, got: %s" format xs)
+          }
+          case xs => fail("Expected one reply, got: %s" format xs)
+        }
+      }
     }
 
     "Properly encode" >> {


### PR DESCRIPTION
[Description imported from https://github.com/twitter/finagle/issues/216]

``` scala
import java.nio.charset.Charset
import org.jboss.netty.buffer.ChannelBuffer
import org.jboss.netty.buffer.ChannelBuffers.wrappedBuffer
import com.twitter.util.{Future, Await}
import com.twitter.finagle.builder.ClientBuilder
import com.twitter.finagle.redis.protocol._
import com.twitter.finagle.redis.Redis

def s2buf(s: String): ChannelBuffer = wrappedBuffer(s.getBytes)
def buf2s(buf: ChannelBuffer): String = buf.toString(Charset.forName("utf8"))

def pretty(rep: Reply): String = rep match {
  case MBulkReply(msgs) => "MBulkReply(%s)" format (msgs map pretty)
  case BulkReply(msg)   => "BulkReply(%s)" format buf2s(msg)
  case x                => x.toString
}

val svc = (ClientBuilder()
  .hosts("localhost:6379")
  .hostConnectionLimit(1)
  .codec(Redis())
  .build
)
```

An `mget` command, which gives a multi-bulk reply:

``` scala
Await.result(Future.collect(Seq(
  MGet(List(s2buf("a"), s2buf("b")))
) map svc)) map pretty foreach println
```

Output (correct):

```
MBulkReply(List(BulkReply(one), BulkReply(three)))
```

A transaction, which gives a multi-bulk reply:

``` scala
Await.result(Future.collect(Seq(
  Strlen(s2buf("a")),
  MGet(List(s2buf("a"), s2buf("b"))),
  Strlen(s2buf("a"))
) map svc)) map pretty foreach println
```

Output (correct):

```
IntegerReply(3)
MBulkReply(List(BulkReply(one), BulkReply(three)))
IntegerReply(3)
```

An `mget` command within a transaction, which gives nested multi-bulk replies:

``` scala
Await.result(Future.collect(Seq(
  Multi,
  Strlen(s2buf("a")),
  MGet(List(s2buf("a"), s2buf("b"))),
  Strlen(s2buf("a")),
  Exec
) map svc)) map pretty foreach println
```

Output (incorrect):

```
StatusReply(OK)
StatusReply(QUEUED)
StatusReply(QUEUED)
StatusReply(QUEUED)
MBulkReply(List(IntegerReply(3), BulkReply(one), BulkReply(three)))
```

Should be:

```
StatusReply(OK)
StatusReply(QUEUED)
StatusReply(QUEUED)
StatusReply(QUEUED)
MBulkReply(List(IntegerReply(3), MBulkReply(List(BulkReply(one), BulkReply(three))), IntegerReply(3)))
```

Here's what the raw reply from the server should look like:

```
$ (echo -en '*1\r\n$5\r\nmulti\r\n'; echo -en '*2\r\n$6\r\nstrlen\r\n$1\r\na\r\n'; echo -en '*3\r\n$4\r\nmget\r\n$1\r\na\r\n$1\r\nb\r\n'; echo -en '*2\r\n$6\r\nstrlen\r\n$1\r\na\r\n'; echo -en '*1\r\n$4\r\nexec\r\n'; sleep 1) | nc localhost 6379 --close
+OK
+QUEUED
+QUEUED
+QUEUED
*3
:3
*2
$3
one
$5
three
:3
```

I think the following case in `decodeMBulkLines` is the culprit, since it appears to be treating the `*2` as a continuation of the current multi-bulk reply and then ignoring the final `:3` reply entirely:
- https://github.com/twitter/finagle/blob/eaeb845/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/Reply.scala#L158-L159
