### PR TITLE
Add "project/build.properties"

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,2 @@
+sbt.version=0.12.1
+


### PR DESCRIPTION
This file lets you specify which version of sbt to use. sbt will read it, and if necessary, self-bootstrap the correct version of itself before proceeding to build.

Yes, the correct version of sbt (0.12.1) is already specified in the "sbt" build script, but if users choose not to use this script, and rather use sbt directly (for example - the sbt script doesn't work on Windows), they can get the wrong version of sbt.

See https://groups.google.com/forum/#!topic/finaglers/TVOmozhPgWk

> Kirill
> 21. nov.
> 
> Thank you all! The issue occured because I used the latest version of SBT. When I downgraded to sbt 0.12 then it looks it works.
