### PR TITLE
use new Netty http headers API

### DIFF
--- a/finagle-example/src/main/scala/com/twitter/finagle/example/http/HttpClient.scala
+++ b/finagle-example/src/main/scala/com/twitter/finagle/example/http/HttpClient.scala
@@ -60,7 +60,7 @@ object HttpClient {
   private[this] def makeAuthorizedRequest(client: Service[HttpRequest, HttpResponse]) = {
     val authorizedRequest = new DefaultHttpRequest(
       HttpVersion.HTTP_1_1, HttpMethod.GET, "/")
-    authorizedRequest.addHeader("Authorization", "open sesame")
+    authorizedRequest.headers().add(HttpHeaders.Names.AUTHORIZATION, "open sesame")
 
     client(authorizedRequest) onSuccess { response =>
       val responseString = response.getContent.toString(CharsetUtil.UTF_8)

--- a/finagle-example/src/main/scala/com/twitter/finagle/example/http/HttpServer.scala
+++ b/finagle-example/src/main/scala/com/twitter/finagle/example/http/HttpServer.scala
@@ -47,7 +47,7 @@ object HttpServer {
    */
   class Authorize extends SimpleFilter[HttpRequest, HttpResponse] {
     def apply(request: HttpRequest, continue: Service[HttpRequest, HttpResponse]) = {
-      if ("open sesame" == request.getHeader("Authorization")) {
+      if ("open sesame" == request.headers().get(HttpHeaders.Names.AUTHORIZATION)) {
         continue(request)
       } else {
         Future.exception(new IllegalArgumentException("You don't know the secret"))


### PR DESCRIPTION
We are using Finagle in our project and we recently upgraded to 6.10. After that we found the method building HttpRequest is deprecated as Netty upgraded to 3.8.0. So we changed to use the new API to build Http Request. I found in Finagle example, it is still using the old API. So I am sending this pull request to change to new API.
