### PR TITLE
Update URL to Finagle blog post.

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -77,7 +77,7 @@
     <h2>Other resources</h2>
 
     <ul>
-      <li><a href="http://engineering.twitter.com/2011/08/finagle-protocol-agnostic-rpc-system.html">
+      <li><a href="https://blog.twitter.com/2011/finagle-a-protocol-agnostic-rpc-system">
         Twitter engineering blog post</a> motivating and introducting Finagle</li>
       <li>Twitter’s <a href="http://twitter.github.com/scala_school/">Scala School</a> ends with an
       <a href="http://twitter.github.com/scala_school/finagle.html">introduction to Finagle</a>, and finally


### PR DESCRIPTION
https://engineering.twitter.com/2011/08/finagle-protocol-agnostic-rpc-system.html is now a 404
