### PR TITLE
Fix http server chunking: Fail rep.writer.write on transport failure

### DIFF
--- a/finagle-http/src/main/scala/com/twitter/finagle/http/codec/HttpServerDispatcher.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/http/codec/HttpServerDispatcher.scala
@@ -59,7 +59,7 @@ class HttpServerDispatcher[REQUEST <: Request](
   protected def handle(response: HttpResponse): Future[Unit] = response match {
     case rep: Response =>
       if (rep.isChunked) {
-        trans.write(rep) before streamChunks(rep.reader)
+        trans.write(rep) before streamChunks(rep.reader) onFailure { _ => rep.reader.discard }
       } else {
         // Ensure Content-Length is set if not chunked
         if (!rep.headers.contains(HttpHeaders.Names.CONTENT_LENGTH))


### PR DESCRIPTION
Further, would it be appropriate to use `rep.writer.fail(e)` instead of `rep.reader.discard` here? That would provide a more informative error than `ReaderDiscarded`, but I'm not sure if it assumes too much about the implementation of `Message.reader` and `Message.writer`.
