### PR TITLE
Add Trace.recordRpcName to MysqlTracing class

### DIFF
--- a/finagle-mysql/src/main/scala/com/twitter/finagle/Mysql.scala
+++ b/finagle-mysql/src/main/scala/com/twitter/finagle/Mysql.scala
@@ -32,7 +32,7 @@ trait MysqlRichClient { self: com.twitter.finagle.Client[Request, Result] =>
 /**
  * Tracing filter for mysql client requests.
  */
-class MysqlTracing(clientName: String) extends SimpleFilter[Request, Result] {
+private class MysqlTracing(clientName: String) extends SimpleFilter[Request, Result] {
   def apply(request: Request, service: Service[Request, Result]) = {
 
     Trace.recordServiceName(clientName)


### PR DESCRIPTION
Without the Trace.recordRpcName call, all the Mysql spans shown up as unknown on zipkin traces. 
