### PR TITLE
Fixing make

### DIFF
--- a/finagle-native/tomcat-native-1.1.27.finagle.patch
+++ b/finagle-native/tomcat-native-1.1.27.finagle.patch
@@ -1638,7 +1638,7 @@ index 83ad938..583d7cd 100644
 +    SSL *ssl_ = J2P(ssl, SSL *);
 +    if (ssl_ == NULL) {
 +        tcn_ThrowException(e, "ssl is null");
-+        return;
++        return 0;
 +    }
 +
 +    UNREFERENCED(o);
@@ -1652,7 +1652,7 @@ index 83ad938..583d7cd 100644
 +    SSL *ssl_ = J2P(ssl, SSL *);
 +    if (ssl_ == NULL) {
 +        tcn_ThrowException(e, "ssl is null");
-+        return;
++        return 0;
 +    }
 +    const unsigned char *proto;
 +    unsigned int proto_len;


### PR DESCRIPTION
Fixing the following errors during 'make'

`
src/ssl.c:1302:9: error: non-void function 'Java_org_apache_tomcat_jni_SSL_doHandshake' should return a value [-Wreturn-type]
        return;
        ^
src/ssl.c:1316:9: error: non-void function 'Java_org_apache_tomcat_jni_SSL_getNextProtoNegotiated' should return a value [-Wreturn-type]
        return;
        ^
`
