### PR TITLE
Fix basic authentication with special characters

### DIFF
--- a/finagle-http/src/main/scala/com/twitter/finagle/http/RequestBuilder.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/http/RequestBuilder.scala
@@ -182,7 +182,7 @@ class RequestBuilder[HasUrl, HasForm] private[http](
       else
         "%s:%d".format(host, u.getPort)
     val withHost = config.headers.updated(HttpHeaders.Names.HOST, Seq(hostValue))
-    val userInfo =  u.getUserInfo
+    val userInfo =  uri.getUserInfo
     val updated =
       if (userInfo == null || userInfo.isEmpty)
         withHost

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/RequestBuilderSpec.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/RequestBuilderSpec.scala
@@ -9,6 +9,7 @@ import scala.collection.JavaConverters._
 class RequestBuilderSpec extends SpecificationWithJUnit {
   val URL0 = new URL("http://joe:blow@www.google.com:77/xxx?foo=bar#xxx")
   val URL1 = new URL("https://www.google.com/")
+  val URL2 = new URL("http://joe%40host.com:blow@www.google.com:77/xxx?foo=bar#xxx")
 
   val BODY0 = copiedBuffer("blah".getBytes)
   val FORM0 = Seq (
@@ -69,8 +70,10 @@ v3
       val req7 = RequestBuilder().url(URL1).buildPut(BODY0)
       val req8 = RequestBuilder().url(URL0).buildPost(BODY0)
       val req9 = RequestBuilder().url(URL1).buildPost(BODY0)
+      val req10 = RequestBuilder().url(URL2).buildPost(BODY0)
 
       val expected = "Basic am9lOmJsb3c="
+      val expectedSpecial = "Basic am9lQGhvc3QuY29tOmJsb3c="
       req0.headers.get(HttpHeaders.Names.AUTHORIZATION) must_== expected
       req1.headers.get(HttpHeaders.Names.AUTHORIZATION) must beNull
       req2.headers.get(HttpHeaders.Names.AUTHORIZATION) must_== expected
@@ -81,6 +84,7 @@ v3
       req7.headers.get(HttpHeaders.Names.AUTHORIZATION) must beNull
       req8.headers.get(HttpHeaders.Names.AUTHORIZATION) must_== expected
       req9.headers.get(HttpHeaders.Names.AUTHORIZATION) must beNull
+      req10.headers.get(HttpHeaders.Names.AUTHORIZATION) must_== expectedSpecial
     }
 
     "replace the empty path with /" in {


### PR DESCRIPTION
Problem

HTTP basic authentication for users that have special characters
in their name or password didn't work (for example, joe@host.com)

Solution

Describe the modifications you've done.
Changed RequestBuilder.url() to use java.net.URI.getUserInfo
which correctly performs unescaping instead of java.net.URL.getUserInfo which simply returns raw data

Result

Users that have special characters in their name or password can successfully
authenticate themselves via basic authentication
