### PR TITLE
ExceptionFilter does not set the response content-length to 0

### DIFF
--- a/finagle-http/src/test/scala/com/twitter/finagle/http/filter/ExceptionFilterSpec.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/filter/ExceptionFilterSpec.scala
@@ -11,6 +11,7 @@ class ExceptionFilterSpec extends SpecificationWithJUnit {
   val service = new Service[Request, Response] {
     def apply(request: Request): Future[Response] = {
       request.response.write("hello")
+      request.response.contentLength = 5
       if (request.params.get("exception").isDefined)
         throw new Exception
       else if (request.params.get("throw").isDefined)
@@ -30,6 +31,7 @@ class ExceptionFilterSpec extends SpecificationWithJUnit {
       val response = Await.result(filter(request))
       response.status        must_== Status.Ok
       response.contentString must_== "hello"
+      response.contentLength must beSome(5)
     }
 
     "handle exception" in {
@@ -39,6 +41,7 @@ class ExceptionFilterSpec extends SpecificationWithJUnit {
       val response = Await.result(filter(request))
       response.status        must_== Status.InternalServerError
       response.contentString must_== ""
+      response.contentLength must beSome(0)
     }
 
     "handle throw" in {
@@ -48,6 +51,7 @@ class ExceptionFilterSpec extends SpecificationWithJUnit {
       val response = Await.result(filter(request))
       response.status        must_== Status.InternalServerError
       response.contentString must_== ""
+      response.contentLength must beSome(0)
     }
 
     "handle cancel" in {
@@ -57,6 +61,7 @@ class ExceptionFilterSpec extends SpecificationWithJUnit {
       val response = Await.result(filter(request))
       response.statusCode    must_== 499
       response.contentString must_== ""
+      response.contentLength must beSome(0)
     }
   }
 }


### PR DESCRIPTION
[finagle-http] ExceptionFilter does not set the response content-length to 0

Problem

The com.twitter.finagle.http.filter.ExceptionFilter class in finagle-http module calls response.clearContent() to return an empty response but does not set the content-length header to 0.

AWS load balancers are sensitive to missing content-length headers and translate such responses to 502s (Bad gateway).

Solution

Content-Length header is set to 0 in ExceptionFilter class for both 499 and 500 responses.

Results

Content-length is correctly set on empty responses returned by ExceptionFilter.
