### PR TITLE
Update commit message formatting guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,13 +41,16 @@ messages along these guidelines:
     One line description of your change (less than 72 characters)
 
     Problem
+
     Explain here the context, and why you're making that change.
     What is the problem you're trying to solve?
 
     Solution
+
     Describe the modifications you've done.
 
     Result
+
     After your change, what will change?
 
 [0]: http://twitter.github.io/effectivescala/


### PR DESCRIPTION
Problem

The commit message example doesn't match currently agreed-upon practice.

Solution

Added some newlines.
