### PR TITLE
Add list of Finagle adopters

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,39 +1,45 @@
-## Finagle outside of Twitter
+## Finagle Adopters
 
 Twitter isn't the only company using Finagle. We're sure the following list
-isn't complete, so please let us know if your company should be included, or if
-you'd like to feature a link to a blog post or article about how you're using
-Finagle. Or even better, add the links yourself and [submit a pull request][0]!
+isn't complete, so please [let us know][0] if your company should be included,
+or if you'd like us to feature a link to a blog post or article about how
+you're using Finagle. Or even better, add the links yourself and
+[submit a pull request][1]!
 
 * [Box](https://www.box.com/)
 * [Foursquare](https://foursquare.com/)
 * [Gigya](http://www.gigya.com/)
 * [Gutefrage.net](http://www.gutefrage.net/)
-  * ["Introducing Gutefrage.net's Service-Oriented Architecture"][1]
+  * ["Introducing Gutefrage.net's Service-Oriented Architecture"][2]
 * [Magine TV](https://magine.com/)
 * [Nest](https://nest.com/)
+* [OpenAura](http://openaura.com/)
 * [PagerDuty](https://www.pagerduty.com/)
 * [Pellucid Analytics](http://www.pellucid.com/)
 * [Pinterest](https://www.pinterest.com/)
-  * ["How we make pins more useful"][2]
+  * ["How we make pins more useful"][3]
 * [Rdio](http://www.rdio.com/)
-  * [Thor, a Finagle-based image processor][3]
+  * [Thor, a Finagle-based image processor][4]
 * [Sharethrough](http://www.sharethrough.com/)
-  * ["Finagle @ Sharethrough: Twitter #Conf Presentation"][4]
+  * ["Finagle @ Sharethrough: Twitter #Conf Presentation"][5]
 * [SoundCloud](https://soundcloud.com/)
 * [Strava](http://www.strava.com/)
-  * ["Introducing Routemaster"][5]
+  * ["Introducing Routemaster"][6]
 * [StumbleUpon](https://www.stumbleupon.com/)
 * [Tapad](http://www.tapad.com/)
-  * [Case study][6] by [Typesafe][7]
+  * [Case study][7] by [Typesafe][8]
 * [Teads.tv](http://teads.tv/)
 * [Tumblr](https://www.tumblr.com/)
+* [Twitter](https://twitter.com/)
+  * ["Finagle: A Protocol-Agnostic RPC System"][9]
 
-[0]: https://github.com/twitter/finagle/blob/master/CONTRIBUTING.md
-[1]: http://engineering.gutefrage.net/post/47693566182/introducing-gutefrage-net-s-service-oriented
-[2]: http://engineering.pinterest.com/post/59132790640/how-we-make-pins-more-useful
-[3]: https://github.com/rdio/thor
-[4]: http://engineering.sharethrough.com/blog/2014/04/17/finagle-at-sharethrough-twitter-conf-talk/
-[5]: http://engineering.strava.com/routemaster/
-[6]: http://typesafe.com/blog/tapad_turns_to_typesafe_platform
-[7]: http://typesafe.com/
+[0]: https://twitter.com/finagle
+[1]: https://github.com/twitter/finagle/blob/master/CONTRIBUTING.md
+[2]: http://engineering.gutefrage.net/post/47693566182/introducing-gutefrage-net-s-service-oriented
+[3]: http://engineering.pinterest.com/post/59132790640/how-we-make-pins-more-useful
+[4]: https://github.com/rdio/thor
+[5]: http://engineering.sharethrough.com/blog/2014/04/17/finagle-at-sharethrough-twitter-conf-talk/
+[6]: http://engineering.strava.com/routemaster/
+[7]: http://typesafe.com/blog/tapad_turns_to_typesafe_platform
+[8]: http://typesafe.com/
+[9]: https://blog.twitter.com/2011/finagle-a-protocol-agnostic-rpc-system

--- a/README.md
+++ b/README.md
@@ -16,11 +16,23 @@ protocols.
 For extensive documentation, please see the
 [user guide](http://twitter.github.io/finagle/guide/) and
 [API documentation](http://twitter.github.io/finagle/docs/#com.twitter.finagle.package)
-websites. Documentation improvements are always welcome, so feel free to send
-patches our way.
+websites. Documentation improvements are always welcome, so please send patches
+our way.
 
-If your organization is using Finagle, consider adding a link to our
-[list of adopters](https://github.com/twitter/finagle/blob/master/ADOPTERS.md).
+## Adopters
+
+The following are a few of the companies that are using Finagle:
+
+* [Foursquare](https://foursquare.com/)
+* [Pinterest](https://www.pinterest.com/)
+* [SoundCloud](https://soundcloud.com/)
+* [Tumblr](https://www.tumblr.com/)
+* [Twitter](https://twitter.com/)
+
+For a more complete list, please see
+[our adopter page](https://github.com/twitter/finagle/blob/master/ADOPTERS.md).
+If your organization is using Finagle, consider adding a link there and sending
+us a pull request!
 
 ## Contributing
 


### PR DESCRIPTION
Problem

The project didn't have a list of adopters.

Solution

Added a new file with a preliminary list and linked it from the README.
