### PR TITLE
Add Host Header for Apache Proxy Server

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/httpproxy/HttpConnectHandler.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/httpproxy/HttpConnectHandler.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.atomic.AtomicReference
 
 import org.jboss.netty.buffer.{ChannelBuffer, ChannelBuffers}
 import org.jboss.netty.channel._
-import org.jboss.netty.handler.codec.http.{DefaultHttpRequest, DefaultHttpResponse, HttpClientCodec, HttpMethod, HttpResponseStatus, HttpVersion}
+import org.jboss.netty.handler.codec.http._
 import org.jboss.netty.util.CharsetUtil
 
 import com.twitter.finagle.{ChannelClosedException, ConnectionFailedException, InconsistentStateException}
@@ -37,7 +37,9 @@ class HttpConnectHandler(proxyAddr: SocketAddress, addr: InetSocketAddress, clie
   }
 
   private[this] def writeRequest(ctx: ChannelHandlerContext, e: ChannelStateEvent) {
-    val req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.CONNECT, addr.getAddress.getHostName + ":" + addr.getPort)
+    val hostNameWithPort = addr.getAddress.getHostName + ":" + addr.getPort
+    val req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.CONNECT, hostNameWithPort)
+    req.headers().set("Host", hostNameWithPort)
     Channels.write(ctx, Channels.future(ctx.getChannel), req, null)
   }
 

--- a/finagle-core/src/test/scala/com/twitter/finagle/httpproxy/HttpConnectHandlerSpec.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/httpproxy/HttpConnectHandlerSpec.scala
@@ -82,6 +82,7 @@ class HttpConnectHandlerSpec extends SpecificationWithJUnit with Mockito {
           val req = e.getMessage.asInstanceOf[DefaultHttpRequest]
           req.getMethod must_== HttpMethod.CONNECT
           req.getUri must_== "localhost:443"
+          req.headers().get("Host") must_== "localhost:443"
         }
 
         { // when connect response is received, propagate the connect and remove the handler


### PR DESCRIPTION
I get the following apache error and cannot connect by ClientBuilder#httpProxy when using Apache Proxy Server. 
`[error] [client 127.0.0.1] client sent HTTP/1.1 request without hostname (see RFC2616 section 14.23)`
