### PR TITLE
Add Google Analytics tracking code

### DIFF
--- a/doc/src/sphinx/_themes/flask/layout.html
+++ b/doc/src/sphinx/_themes/flask/layout.html
@@ -6,6 +6,16 @@
   {% endif %}
   <link media="only screen and (max-device-width: 480px)" href="{{
     pathto('_static/small_flask.css', 1) }}" type= "text/css" rel="stylesheet" />
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+    ga('create', 'UA-39101739-4', 'twitter.github.io');
+    ga('send', 'pageview');
+
+  </script>
 {% endblock %}
 {%- block relbar2 %}{% endblock %}
 {% block header %}

--- a/site/index.html
+++ b/site/index.html
@@ -39,6 +39,16 @@
     </style>
 
   <title>Finagle</title>
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+    ga('create', 'UA-39101739-4', 'twitter.github.io');
+    ga('send', 'pageview');
+
+  </script>
   </head>
 
   <body>


### PR DESCRIPTION
We want to start tracking traffic to the Finagle documentation, so I've added the Google Analytics tracking script with the Twitter OSS ID to the Sphinx template (only the Flask theme, so it won't get used internally) and the homepage.

Someday it'd probably be nice to have this info for the API docs, but [I'm not sure it's worth the trouble](http://stackoverflow.com/q/24085782/334519).
