### PR TITLE
finagle-memcached: KetamaClientBuilder - expose the client type

### DIFF
--- a/finagle-memcached/src/main/scala/com/twitter/finagle/memcached/Client.scala
+++ b/finagle-memcached/src/main/scala/com/twitter/finagle/memcached/Client.scala
@@ -926,7 +926,7 @@ case class KetamaClientBuilder private[memcached] (
   def ejectFailedHost(eject: Boolean): KetamaClientBuilder =
     copy(_ejectFailedHost = eject)
 
-  def build(): Client = {
+  def build(): KetamaClient = {
     val builder =
       (_clientBuilder getOrElse ClientBuilder().hostConnectionLimit(1).daemon(true))
         .codec(Memcached())


### PR DESCRIPTION
In order to access the client nodes for operations like individual node stats.