### PR TITLE
Fix broken link in document

### DIFF
--- a/doc/src/sphinx/Extending.rst
+++ b/doc/src/sphinx/Extending.rst
@@ -141,7 +141,7 @@ Transporter
 
 A :src:`Transporter <com/twitter/finagle/clients/Transporter.scala>` is responsible for connecting
 a :ref:`Transport <transport_interface>` to a peer — it establishes a session. Our client uses a
-:src:`Netty3Transporter <com/twitter/finagle/netty3/client.scala>`, however
+:src:`Netty3Transporter <com/twitter/finagle/netty3/Netty3Transporter.scala>`, however
 the use of other Transporters is fully supported.
 
 .. includecode:: code/client-server-anatomy/EchoClient.scala#transporter


### PR DESCRIPTION
### Problem

In document "Extending Finagle" the link to Netty3Transporter.scala file
is broken.
### Solution

fork => branch => awesome fix => skip test...
### Result

```
f: Future[Document] map { doc =>
  assert(doc.isAwesome)
}
```
