### PR TITLE
WIP - moving finagle-kestrel to ScalaTest

### DIFF
--- a/finagle-kestrel/src/test/scala/com/twitter/finagle/kestrel/integration/ClientSpec.scala
+++ b/finagle-kestrel/src/test/scala/com/twitter/finagle/kestrel/integration/ClientSpec.scala
@@ -6,49 +6,48 @@ import com.twitter.finagle.kestrel.protocol.Kestrel
 import com.twitter.finagle.memcached.util.ChannelBufferUtils._
 import com.twitter.io.Charsets
 import com.twitter.util.Await
-import org.specs.SpecificationWithJUnit
 import com.twitter.finagle.thrift.{ClientId, ThriftClientFramedCodec}
 
-class ClientSpec extends SpecificationWithJUnit {
-  "ConnectedClient" should {
-    skip("This test requires a Kestrel server to run. Please run manually")
+import org.scalatest.junit.JUnitRunner
+import org.junit.runner.RunWith
+import org.scalatest.{BeforeAndAfter, FunSuite, Suites}
 
-    "simple client" in {
-      val serviceFactory = ClientBuilder()
-        .hosts("localhost:22133")
-        .codec(Kestrel())
-        .hostConnectionLimit(1)
-        .buildFactory()
-      val client = Client(serviceFactory)
+@RunWith(classOf[JUnitRunner])
+class ClientTest extends Suites (
+  new ConnectedClientTest, 
+  new ThriftConnectedClientTest
+)
 
-      Await.result(client.delete("foo"))
+class ConnectedClientTest extends FunSuite {
+  val serviceFactory = ClientBuilder()
+    .hosts("localhost:22133")
+    .codec(Kestrel())
+    .hostConnectionLimit(1)
+    .buildFactory()
+  val client = Client(serviceFactory)
 
-      "set & get" in {
-        Await.result(client.get("foo")) mustEqual None
-        Await.result(client.set("foo", "bar"))
-        Await.result(client.get("foo")) map { _.toString(Charsets.Utf8) } mustEqual Some("bar")
-      }
-    }
+  Await.result(client.delete("foo"))
+
+  ignore("simple clientset & get") {
+    assert(Await.result(client.get("foo")) === None)
+    Await.result(client.set("foo", "bar"))
+    assert(Await.result(client.get("foo")).map(f => f.toString(Charsets.Utf8)) === Some("bar"))
   }
+}
 
-  "ThriftConnectedClient" should {
-    skip("This test requires a Kestrel server to run. Please run manually")
+class ThriftConnectedClientTest extends FunSuite {
+  val serviceFactory = ClientBuilder()
+    .hosts("localhost:2229")
+    .codec(ThriftClientFramedCodec(Some(ClientId("testcase"))))
+    .hostConnectionLimit(1)
+    .buildFactory()
+  val client = Client.makeThrift(serviceFactory)
 
-    "simple client" in {
-      val serviceFactory = ClientBuilder()
-        .hosts("localhost:2229")
-        .codec(ThriftClientFramedCodec(Some(ClientId("testcase"))))
-        .hostConnectionLimit(1)
-        .buildFactory()
-      val client = Client.makeThrift(serviceFactory)
+  Await.result(client.delete("foo"))
 
-      Await.result(client.delete("foo"))
-
-      "set & get" in {
-        Await.result(client.get("foo")) mustEqual None
-        Await.result(client.set("foo", "bar"))
-        Await.result(client.get("foo")) map { _.toString(Charsets.Utf8) } mustEqual Some("bar")
-      }
-    }
+  ignore("set & get") {
+    assert(Await.result(client.get("foo")) === None)
+    Await.result(client.set("foo", "bar"))
+    assert(Await.result(client.get("foo")).map(f => f.toString(Charsets.Utf8)) == Some("bar"))
   }
 }

--- a/finagle-kestrel/src/test/scala/com/twitter/finagle/kestrel/unit/ClientSpec.scala
+++ b/finagle-kestrel/src/test/scala/com/twitter/finagle/kestrel/unit/ClientSpec.scala
@@ -5,7 +5,6 @@ import org.junit.runner.RunWith
 import org.scalatest.{FunSuite, Suites}
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.mock.MockitoSugar
-
 import org.mockito.Mockito.{verify, times, when}
 
 import org.jboss.netty.buffer.{ChannelBuffer, ChannelBuffers}
@@ -20,6 +19,7 @@ import com.twitter.finagle.memcached.util.ChannelBufferUtils._
 import com.twitter.finagle.thrift.ThriftClientRequest
 import com.twitter.finagle.kestrel.net.lag.kestrel.thriftscala.Item
 
+@RunWith(classOf[JUnitRunner])
 class ClientTest extends Suites(
   new ClientReadReliablyTest, 
   new ConnectedClientReadTest, 

--- a/finagle-kestrel/src/test/scala/com/twitter/finagle/kestrel/unit/MultiReaderSpec.scala
+++ b/finagle-kestrel/src/test/scala/com/twitter/finagle/kestrel/unit/MultiReaderSpec.scala
@@ -13,46 +13,85 @@ import com.twitter.finagle.kestrel.protocol._
 import com.twitter.finagle.memcached.util.ChannelBufferUtils._
 import com.twitter.util.{Await, Future, Promise, Return, Time, Updatable, Var}
 import org.jboss.netty.buffer.ChannelBuffer
-import org.specs.SpecificationWithJUnit
-import org.specs.mock.Mockito
 import scala.collection.mutable.{ArrayBuffer, Set => MSet}
 import scala.collection.immutable.{Set => ISet}
 
-class MultiReaderSpec extends SpecificationWithJUnit with Mockito {
-  noDetailedDiffs()
+import org.junit.runner.RunWith
+import org.scalatest.{FunSuite, Suites}
+import org.scalatest.matchers._
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.mock.MockitoSugar
+import org.mockito.Mockito.{verify, times, when}
 
-  class MockHandle extends ReadHandle {
-    val _messages = new Broker[ReadMessage]
-    val _error = new Broker[Throwable]
+trait CollectionComparison {
+  def sameAs[A](c: Traversable[A], d: Traversable[A]): Boolean = 
+    if (c.isEmpty) d.isEmpty
+    else {
+      val (e, f) = d span (c.head !=)
+      if (f.isEmpty) false else sameAs(c.tail, e ++ f.tail)
+    }
+}
 
-    val messages = _messages.recv
-    val error = _error.recv
-    def close() {} // to spy on!
+@RunWith(classOf[JUnitRunner])
+class MultiReaderTest extends Suites(
+  new StaticReadHandleClusterTest,
+  new VarAddrBasedClusterTest,
+  new DynamicSocketAddressClusterTest
+) 
+
+class MockHandle extends ReadHandle {
+  val _messages = new Broker[ReadMessage]
+  val _error = new Broker[Throwable]
+
+  val messages = _messages.recv
+  val error = _error.recv
+  def close() {} // to spy on!
+}
+
+class StaticReadHandleClusterTest extends FunSuite with MockitoSugar {
+  val N = 3
+  val queueName = "the_queue"
+  val handles = (0 until N) map { _ => mock[MockHandle] }
+  val va: Var[Return[ISet[ReadHandle]]] = Var.value(Return(handles.toSet))
+
+  test("always grab the first available message") {
+    val handle = MultiReaderHelper.merge(va)
+
+    val messages = new ArrayBuffer[ReadMessage]
+    handle.messages foreach { messages += _ }
+
+    // stripe some messages across
+    val sentMessages = 0 until N*100 map { _ => mock[ReadMessage] }
+
+    assert(messages === Seq.empty)
+    sentMessages.zipWithIndex foreach { case (m, i) =>
+      handles(i % handles.size)._messages ! m
+    }
+
+    assert(messages === sentMessages)
   }
 
-  "MultiReader" should {
-    val queueName = "the_queue"
-    "static ReadHandle cluster" in {
-      val N = 3
-      val handles = (0 until N) map { _ => spy(new MockHandle) }
-      val va: Var[Return[ISet[ReadHandle]]] = Var.value(Return(handles.toSet))
+  test("propagate closes") {
+    handles foreach { h => verify(h, times(0)).close() }
+    val handle = MultiReaderHelper.merge(va)
+    handle.close()
+    handles foreach { h => verify(h).close() }
+  }
 
-      "always grab the first available message" in {
-        val handle = MultiReaderHelper.merge(va)
+  test("propagate errors when everything's errored out") {
+    val handle = MultiReaderHelper.merge(va)
+    val e = handle.error.sync()
+    handles foreach { h =>
+      assert(!e.isDefined)
+      h._error ! new Exception("sad panda")
+    }
 
-        val messages = new ArrayBuffer[ReadMessage]
-        handle.messages foreach { messages += _ }
-
-        // stripe some messages across
-        val sentMessages = 0 until N*100 map { _ => mock[ReadMessage] }
-
-        messages must beEmpty
-        sentMessages.zipWithIndex foreach { case (m, i) =>
-          handles(i % handles.size)._messages ! m
-        }
-
-        messages must be_==(sentMessages)
-      }
+    assert(e.isDefined)
+    intercept[AllHandlesDiedException.type] {
+      Await.result(e)
+    }
+  }
+}
 
 // TODO - this test stopped working
 //      // We use frozen time for deterministic randomness.
@@ -74,423 +113,408 @@ class MultiReaderSpec extends SpecificationWithJUnit with Mockito {
 //        }
 //      }
 
-      "propagate closes" in {
-        handles foreach { h => there was no(h).close() }
-        val handle = MultiReaderHelper.merge(va)
-        handle.close()
-        handles foreach { h => there was one(h).close() }
-      }
+class VarAddrBasedClusterTest extends FunSuite with MockitoSugar with ShouldMatchers {
+  val N = 3
+  val queueName = "the_queue"
+  val hosts = 0 until N map { i =>
+    InetSocketAddress.createUnresolved("10.0.0.%d".format(i), 22133)
+  }
 
-      "propagate errors when everything's errored out" in {
-        val handle = MultiReaderHelper.merge(va)
-        val e = handle.error.sync()
-        handles foreach { h =>
-          e.isDefined must beFalse
-          h._error ! new Exception("sad panda")
+  val executor = Executors.newCachedThreadPool()
+
+  def newKestrelService(executor: Option[ExecutorService],
+                        queues: LoadingCache[ChannelBuffer, BlockingDeque[ChannelBuffer]]): Service[Command, Response] = {
+    val interpreter = new Interpreter(queues)
+    new Service[Command, Response] {
+      def apply(request: Command) = {
+        val promise = new Promise[Response]()
+        executor match {
+          case Some(executor) =>
+            executor.submit(new Runnable {
+              def run() {
+                promise.setValue(interpreter(request))
+              }
+            })
+          case None => promise.setValue(interpreter(request))
         }
-
-        e.isDefined must beTrue
-        Await.result(e) must be(AllHandlesDiedException)
+        promise
       }
     }
+  }
 
-    "Var[Addr]-based cluster" in {
-      val N = 3
-      val hosts = 0 until N map { i =>
-        InetSocketAddress.createUnresolved("10.0.0.%d".format(i), 22133)
+  val hostQueuesMap = hosts.map { host =>
+    val queues = CacheBuilder.newBuilder()
+      .build(new CacheLoader[ChannelBuffer, BlockingDeque[ChannelBuffer]] {
+      def load(k: ChannelBuffer) = new LinkedBlockingDeque[ChannelBuffer]
+    })
+    (host, queues)
+  }.toMap
+
+  lazy val mockClientBuilder = {
+    val result = mock[ClientBuilder[Command, Response, Nothing, ClientConfig.Yes, ClientConfig.Yes]]
+
+    hosts.foreach { host =>
+      val mockHostClientBuilder =
+        mock[ClientBuilder[Command, Response, ClientConfig.Yes, ClientConfig.Yes, ClientConfig.Yes]]
+      when(result.hosts(host)).thenReturn(mockHostClientBuilder)
+
+      val queues = hostQueuesMap(host)
+      val factory = new ServiceFactory[Command, Response] {
+        // use an executor so readReliably doesn't block waiting on an empty queue
+        def apply(conn: ClientConnection) =
+          Future.value(newKestrelService(Some(executor), queues))
+        def close(deadline: Time) = Future.Done
+        override def toString = "ServiceFactory for %s".format(host)
       }
+      when(mockHostClientBuilder.buildFactory()).thenReturn(factory)
+    }
+    result
+  }
 
-      val executor = Executors.newCachedThreadPool()
+  val services = hosts.map { host =>
+    val queues = hostQueuesMap(host)
+    // no executor here: this one is used for writing to the queues
+    newKestrelService(None, queues)
+  }
 
-      def newKestrelService(executor: Option[ExecutorService],
-                            queues: LoadingCache[ChannelBuffer, BlockingDeque[ChannelBuffer]]): Service[Command, Response] = {
-        val interpreter = new Interpreter(queues)
-        new Service[Command, Response] {
-          def apply(request: Command) = {
-            val promise = new Promise[Response]()
-            executor match {
-              case Some(executor) =>
-                executor.submit(new Runnable {
-                  def run() {
-                    promise.setValue(interpreter(request))
-                  }
-                })
-              case None => promise.setValue(interpreter(request))
-            }
-            promise
-          }
-        }
-      }
+  def configureMessageReader(handle: ReadHandle): MSet[String] = {
+    val messages = MSet[String]()
+    val UTF8 = Charset.forName("UTF-8")
 
-      val hostQueuesMap = hosts.map { host =>
-        val queues = CacheBuilder.newBuilder()
-          .build(new CacheLoader[ChannelBuffer, BlockingDeque[ChannelBuffer]] {
-          def load(k: ChannelBuffer) = new LinkedBlockingDeque[ChannelBuffer]
-        })
-        (host, queues)
-      }.toMap
+    handle.messages foreach { msg =>
+      val str = msg.bytes.toString(UTF8)
+      messages += str
+      msg.ack.sync()
+    }
+    messages
+  }
 
-      lazy val mockClientBuilder = {
-        val result = mock[ClientBuilder[Command, Response, Nothing, ClientConfig.Yes, ClientConfig.Yes]]
+  test("read messages from a ready cluster") {
+    val va = Var(Addr.Bound(hosts: _*))
+    val handle = MultiReader(va, queueName).clientBuilder(mockClientBuilder).build()
+    val messages = configureMessageReader(handle)
+    val sentMessages = 0 until N*10 map { i => "message %d".format(i) }
+    assert(messages.toSeq === Seq.empty)
 
-        hosts.foreach { host =>
-          val mockHostClientBuilder =
-            mock[ClientBuilder[Command, Response, ClientConfig.Yes, ClientConfig.Yes, ClientConfig.Yes]]
-          result.hosts(host) returns mockHostClientBuilder
-
-          val queues = hostQueuesMap(host)
-          val factory = new ServiceFactory[Command, Response] {
-            // use an executor so readReliably doesn't block waiting on an empty queue
-            def apply(conn: ClientConnection) =
-              Future.value(newKestrelService(Some(executor), queues))
-            def close(deadline: Time) = Future.Done
-            override def toString = "ServiceFactory for %s".format(host)
-          }
-          mockHostClientBuilder.buildFactory() returns factory
-        }
-        result
-      }
-
-      val services = hosts.map { host =>
-        val queues = hostQueuesMap(host)
-        // no executor here: this one is used for writing to the queues
-        newKestrelService(None, queues)
-      }
-
-      def configureMessageReader(handle: ReadHandle): MSet[String] = {
-        val messages = MSet[String]()
-        val UTF8 = Charset.forName("UTF-8")
-
-        handle.messages foreach { msg =>
-          val str = msg.bytes.toString(UTF8)
-          messages += str
-          msg.ack.sync()
-        }
-        messages
-      }
-
-      "read messages from a ready cluster" in {
-        val va = Var(Addr.Bound(hosts: _*))
-        val handle = MultiReader(va, queueName).clientBuilder(mockClientBuilder).build()
-        val messages = configureMessageReader(handle)
-        val sentMessages = 0 until N*10 map { i => "message %d".format(i) }
-        messages must beEmpty
-
-        sentMessages.zipWithIndex foreach { case (m, i) =>
-          Await.result(services(i % services.size).apply(Set(queueName, Time.now, m)))
-        }
-
-        messages must eventually(be_==(sentMessages.toSet))
-      }
-
-
-      "read messages as cluster hosts are added" in {
-        val va = Var(Addr.Bound(hosts.head))
-        val handle = MultiReader(va, queueName).clientBuilder(mockClientBuilder).build()
-        val messages = configureMessageReader(handle)
-        val sentMessages = 0 until N*10 map { i => "message %d".format(i) }
-        messages must beEmpty
-
-        sentMessages.zipWithIndex foreach { case (m, i) =>
-          Await.result(services(i % services.size).apply(Set(queueName, Time.now, m)))
-        }
-
-        // 0, 3, 6 ...
-        messages must eventually(be_==(sentMessages.grouped(N).map { _.head }.toSet))
-        messages.clear()
-
-        va.update(Addr.Bound(hosts: _*))
-
-        // 1, 2, 4, 5, ...
-        messages must eventually(be_==(sentMessages.grouped(N).map { _.tail }.flatten.toSet))
-      }
-
-      "read messages as cluster hosts are removed" in {
-        var mutableHosts: Seq[SocketAddress] = hosts
-        val va = Var(Addr.Bound(mutableHosts: _*))
-        val rest = hosts.tail.reverse
-        val handle = MultiReader(va, queueName).clientBuilder(mockClientBuilder).build()
-
-        val messages = configureMessageReader(handle)
-        val sentMessages = 0 until N*10 map { i => "message %d".format(i) }
-        messages must beEmpty
-
-        sentMessages.zipWithIndex foreach { case (m, i) =>
-          Await.result(services(i % services.size).apply(Set(queueName, Time.now, m)))
-        }
-
-        messages must eventually(be_==(sentMessages.toSet))
-        rest.zipWithIndex.foreach { case (host, hostIndex) =>
-          messages.clear()
-          mutableHosts = (mutableHosts.toSet - host).toSeq
-          va.update(Addr.Bound(mutableHosts: _*))
-
-          // write to all 3
-          sentMessages.zipWithIndex foreach { case (m, i) =>
-            Await.result(services(i % services.size).apply(Set(queueName, Time.now, m)))
-          }
-
-          // expect fewer to be read on each pass
-          val expectFirstN = N - hostIndex - 1
-          messages must eventually(be_==(sentMessages.grouped(N).map { _.take(expectFirstN) }.flatten.toSet))
-        }
-      }
-
-      "wait for cluster to become ready before snapping initial hosts" in {
-        val va = Var(Addr.Bound())
-        val handle = MultiReader(va, queueName).clientBuilder(mockClientBuilder).build()
-        val messages = configureMessageReader(handle)
-        val error = handle.error.sync()
-        val sentMessages = 0 until N*10 map { i => "message %d".format(i) }
-        messages must beEmpty
-
-        sentMessages.zipWithIndex foreach { case (m, i) =>
-          Await.result(services(i % services.size).apply(Set(queueName, Time.now, m)))
-        }
-
-        messages must beEmpty // cluster not ready
-        error.isDefined must beFalse
-
-        va.update(Addr.Bound(hosts: _*))
-
-        messages must eventually(be_==(sentMessages.toSet))
-      }
-
-      "report an error if all hosts are removed" in {
-        val va = Var(Addr.Bound(hosts: _*))
-        val handle = MultiReader(va, queueName).clientBuilder(mockClientBuilder).build()
-        val error = handle.error.sync()
-        va.update(Addr.Bound())
-
-        error.isDefined must beTrue
-        Await.result(error) must be(AllHandlesDiedException)
-      }
-
-      "propagate exception if cluster fails" in {
-        val ex = new Exception("uh oh")
-        val va: Var[Addr] with Updatable[Addr] = Var(Addr.Bound(hosts: _*))
-        val handle = MultiReader(va, queueName).clientBuilder(mockClientBuilder).build()
-        val error = handle.error.sync()
-        va.update(Addr.Failed(ex))
-
-        error.isDefined must beTrue
-        Await.result(error) must be(ex)
-      }
+    sentMessages.zipWithIndex foreach { case (m, i) =>
+      Await.result(services(i % services.size).apply(Set(queueName, Time.now, m)))
     }
 
-    "[deprecated] dynamic SocketAddress cluster" in {
-      class DynamicCluster[U](initial: Seq[U]) extends Cluster[U] {
-        def this() = this(Seq[U]())
+    assert(messages.toList === sentMessages.toList)
+  }
 
-        var set = initial.toSet
-        var s = new Promise[Spool[Cluster.Change[U]]]
+  test("read messages as cluster hosts are added") {
+    val va = Var(Addr.Bound(hosts.head))
+    val handle = MultiReader(va, queueName).clientBuilder(mockClientBuilder).build()
+    val messages = configureMessageReader(handle)
+    val sentMessages = 0 until N*10 map { i => "message %d".format(i) }
+    assert(messages.toSeq === Seq.empty)
 
-        def add(f: U) = {
-          set += f
-          performChange(Cluster.Add(f))
-        }
+    sentMessages.zipWithIndex foreach { case (m, i) =>
+      Await.result(services(i % services.size).apply(Set(queueName, Time.now, m)))
+    }
 
-        def del(f: U) = {
-          set -= f
-          performChange(Cluster.Rem(f))
-        }
+    // 0, 3, 6 ...
+    assert(messages === sentMessages.grouped(N).map { _.head }.toSet)
+    messages.clear()
 
-        private[this] def performChange (change: Cluster.Change[U]) = synchronized {
-          val newTail = new Promise[Spool[Cluster.Change[U]]]
-          s() = Return(change *:: newTail)
-          s = newTail
-        }
+    va.update(Addr.Bound(hosts: _*))
 
-        def snap = (set.toSeq, s)
+    // 1, 2, 4, 5, ...
+    assert(messages === sentMessages.grouped(N).map { _.tail }.flatten.toSet)
+  }
+
+  test("read messages as cluster hosts are removed") {
+    var mutableHosts: Seq[SocketAddress] = hosts
+    val va = Var(Addr.Bound(mutableHosts: _*))
+    val rest = hosts.tail.reverse
+    val handle = MultiReader(va, queueName).clientBuilder(mockClientBuilder).build()
+
+    val messages = configureMessageReader(handle)
+    val sentMessages = 0 until N*10 map { i => "message %d".format(i) }
+    assert(messages === Seq.empty)
+
+    sentMessages.zipWithIndex foreach { case (m, i) =>
+      Await.result(services(i % services.size).apply(Set(queueName, Time.now, m)))
+    }
+
+    assert(messages === sentMessages.toSet)
+    rest.zipWithIndex.foreach { case (host, hostIndex) =>
+      messages.clear()
+      mutableHosts = (mutableHosts.toSet - host).toSeq
+      va.update(Addr.Bound(mutableHosts: _*))
+
+      // write to all 3
+      sentMessages.zipWithIndex foreach { case (m, i) =>
+        Await.result(services(i % services.size).apply(Set(queueName, Time.now, m)))
       }
 
-      val N = 3
-      val hosts = 0 until N map { i => InetSocketAddress.createUnresolved("10.0.0.%d".format(i), 22133) }
+      // expect fewer to be read on each pass
+      val expectFirstN = N - hostIndex - 1
+      assert(messages === sentMessages.grouped(N).map { _.take(expectFirstN) }.flatten.toSet)
+    }
+  }
 
-      val executor = Executors.newCachedThreadPool()
+  test("wait for cluster to become ready before snapping initial hosts") {
+    val va = Var(Addr.Bound())
+    val handle = MultiReader(va, queueName).clientBuilder(mockClientBuilder).build()
+    val messages = configureMessageReader(handle)
+    val error = handle.error.sync()
+    val sentMessages = 0 until N*10 map { i => "message %d".format(i) }
+    assert(messages === Seq.empty)
 
-      def newKestrelService(executor: Option[ExecutorService],
-                            queues: LoadingCache[ChannelBuffer, BlockingDeque[ChannelBuffer]]): Service[Command, Response] = {
-        val interpreter = new Interpreter(queues)
-        new Service[Command, Response] {
-          def apply(request: Command) = {
-            val promise = new Promise[Response]()
-            executor match {
-              case Some(executor) =>
-                executor.submit(new Runnable {
-                  def run() {
-                    promise.setValue(interpreter(request))
-                  }
-                })
-              case None => promise.setValue(interpreter(request))
-            }
-            promise
-          }
+    sentMessages.zipWithIndex foreach { case (m, i) =>
+      Await.result(services(i % services.size).apply(Set(queueName, Time.now, m)))
+    }
+
+    assert(messages === Seq.empty) // cluster not ready
+    assert(!error.isDefined)
+
+    va.update(Addr.Bound(hosts: _*))
+
+    assert(messages === sentMessages.toSet)
+  }
+
+  test("report an error if all hosts are removed") {
+    val va = Var(Addr.Bound(hosts: _*))
+    val handle = MultiReader(va, queueName).clientBuilder(mockClientBuilder).build()
+    val error = handle.error.sync()
+    va.update(Addr.Bound())
+
+    assert(error.isDefined)
+    intercept[AllHandlesDiedException.type] {
+      Await.result(error)
+    }        
+  }
+
+  test("propagate exception if cluster fails") {
+    var ex = new Exception("uh oh")
+    val va: Var[Addr] with Updatable[Addr] = Var(Addr.Bound(hosts: _*))
+    val handle = MultiReader(va, queueName).clientBuilder(mockClientBuilder).build()
+    val error = handle.error.sync()
+    va.update(Addr.Failed(ex))
+
+    assert(error.isDefined)
+    intercept[Exception] {
+      Await.result(error)
+    }
+  }
+}
+
+class DynamicSocketAddressClusterTest extends FunSuite with MockitoSugar {
+  class DynamicCluster[U](initial: Seq[U]) extends Cluster[U] {
+    def this() = this(Seq[U]())
+
+    var set = initial.toSet
+    var s = new Promise[Spool[Cluster.Change[U]]]
+
+    def add(f: U) = {
+      set += f
+      performChange(Cluster.Add(f))
+    }
+
+    def del(f: U) = {
+      set -= f
+      performChange(Cluster.Rem(f))
+    }
+
+    private[this] def performChange (change: Cluster.Change[U]) = synchronized {
+      val newTail = new Promise[Spool[Cluster.Change[U]]]
+      s() = Return(change *:: newTail)
+      s = newTail
+    }
+
+    def snap = (set.toSeq, s)
+  }
+
+  val N = 3
+  val hosts = 0 until N map { i => InetSocketAddress.createUnresolved("10.0.0.%d".format(i), 22133) }
+
+  val executor = Executors.newCachedThreadPool()
+
+  def newKestrelService(executor: Option[ExecutorService],
+                        queues: LoadingCache[ChannelBuffer, BlockingDeque[ChannelBuffer]]): Service[Command, Response] = {
+    val interpreter = new Interpreter(queues)
+    new Service[Command, Response] {
+      def apply(request: Command) = {
+        val promise = new Promise[Response]()
+        executor match {
+          case Some(executor) =>
+            executor.submit(new Runnable {
+              def run() {
+                promise.setValue(interpreter(request))
+              }
+            })
+          case None => promise.setValue(interpreter(request))
         }
-      }
-
-      val hostQueuesMap = hosts.map { host =>
-        val queues = CacheBuilder.newBuilder()
-          .build(new CacheLoader[ChannelBuffer, BlockingDeque[ChannelBuffer]] {
-          def load(k: ChannelBuffer) = new LinkedBlockingDeque[ChannelBuffer]
-        })
-        (host, queues)
-      }.toMap
-
-      lazy val mockClientBuilder = {
-        val result = mock[ClientBuilder[Command, Response, Nothing, ClientConfig.Yes, ClientConfig.Yes]]
-
-        hosts.foreach { host =>
-          val mockHostClientBuilder =
-            mock[ClientBuilder[Command, Response, ClientConfig.Yes, ClientConfig.Yes, ClientConfig.Yes]]
-          result.hosts(host) returns mockHostClientBuilder
-
-          val queues = hostQueuesMap(host)
-          val factory = new ServiceFactory[Command, Response] {
-            // use an executor so readReliably doesn't block waiting on an empty queue
-            def apply(conn: ClientConnection) = Future(newKestrelService(Some(executor), queues))
-            def close(deadline: Time) = Future.Done
-            override def toString = "ServiceFactory for %s".format(host)
-          }
-          mockHostClientBuilder.buildFactory() returns factory
-        }
-        result
-      }
-
-      val services = hosts.map { host =>
-        val queues = hostQueuesMap(host)
-        // no executor here: this one is used for writing to the queues
-        newKestrelService(None, queues)
-      }
-
-      def configureMessageReader(handle: ReadHandle): MSet[String] = {
-        val messages = MSet[String]()
-        val UTF8 = Charset.forName("UTF-8")
-
-        handle.messages foreach { msg =>
-          val str = msg.bytes.toString(UTF8)
-          messages += str
-          msg.ack.sync()
-        }
-        messages
-      }
-
-      "read messages from a ready cluster" in {
-        val cluster = new DynamicCluster[SocketAddress](hosts)
-        val handle = MultiReader(cluster, "the_queue").clientBuilder(mockClientBuilder).build()
-        val messages = configureMessageReader(handle)
-        val sentMessages = 0 until N*10 map { i => "message %d".format(i) }
-        messages must beEmpty
-
-        sentMessages.zipWithIndex foreach { case (m, i) =>
-          Await.result(services(i % services.size).apply(Set("the_queue", Time.now, m)))
-        }
-
-        messages must eventually(be_==(sentMessages.toSet))
-      }
-
-      "read messages as cluster hosts are added" in {
-        val (host, rest) = (hosts.head, hosts.tail)
-        val cluster = new DynamicCluster[SocketAddress](List(host))
-        val handle = MultiReader(cluster, "the_queue").clientBuilder(mockClientBuilder).build()
-        val messages = configureMessageReader(handle)
-        val sentMessages = 0 until N*10 map { i => "message %d".format(i) }
-        messages must beEmpty
-
-        sentMessages.zipWithIndex foreach { case (m, i) =>
-          Await.result(services(i % services.size).apply(Set("the_queue", Time.now, m)))
-        }
-
-        // 0, 3, 6 ...
-        messages must eventually(be_==(sentMessages.grouped(N).map { _.head }.toSet))
-        messages.clear()
-
-        rest.foreach { host => cluster.add(host) }
-
-        // 1, 2, 4, 5, ...
-        messages must eventually(be_==(sentMessages.grouped(N).map { _.tail }.flatten.toSet))
-      }
-
-      "read messages as cluster hosts are removed" in {
-        val cluster = new DynamicCluster[SocketAddress](hosts)
-        val rest = hosts.tail
-        val handle = MultiReader(cluster, "the_queue").clientBuilder(mockClientBuilder).build()
-
-        val messages = configureMessageReader(handle)
-        val sentMessages = 0 until N*10 map { i => "message %d".format(i) }
-        messages must beEmpty
-
-        sentMessages.zipWithIndex foreach { case (m, i) =>
-          Await.result(services(i % services.size).apply(Set("the_queue", Time.now, m)))
-        }
-
-        messages must eventually(be_==(sentMessages.toSet))
-
-        rest.reverse.zipWithIndex.foreach { case (host, hostIndex) =>
-          messages.clear()
-          cluster.del(host)
-
-          // write to all 3
-          sentMessages.zipWithIndex foreach { case (m, i) =>
-            Await.result(services(i % services.size).apply(Set("the_queue", Time.now, m)))
-          }
-
-          // expect fewer to be read on each pass
-          val expectFirstN = N - hostIndex - 1
-          messages must eventually(be_==(sentMessages.grouped(N).map { _.take(expectFirstN) }.flatten.toSet))
-        }
-      }
-
-      "wait for cluster to become ready before snapping initial hosts" in {
-        val cluster = new DynamicCluster[SocketAddress](Seq())
-        val handle = MultiReader(cluster, "the_queue").clientBuilder(mockClientBuilder).build()
-        val messages = configureMessageReader(handle)
-        val errors = handle.error?
-        val sentMessages = 0 until N*10 map { i => "message %d".format(i) }
-        messages must beEmpty
-
-        sentMessages.zipWithIndex foreach { case (m, i) =>
-          Await.result(services(i % services.size).apply(Set("the_queue", Time.now, m)))
-        }
-
-        messages must beEmpty // cluster not ready
-        errors.isDefined must beFalse
-
-        hosts.foreach { host => cluster.add(host) }
-
-        messages must eventually(be_==(sentMessages.toSet))
-      }
-
-      "report an error if all hosts are removed" in {
-        val cluster = new DynamicCluster[SocketAddress](hosts)
-        val handle = MultiReader(cluster, "the_queue").clientBuilder(mockClientBuilder).build()
-        val e = (handle.error?)
-        hosts.foreach { host => cluster.del(host) }
-
-        e.isDefined must beTrue
-        Await.result(e) must be(AllHandlesDiedException)
-      }
-
-      "silently handle the removal of a host that was never added" in {
-        val cluster = new DynamicCluster[SocketAddress](hosts)
-        val handle = MultiReader(cluster, "the_queue").clientBuilder(mockClientBuilder).build()
-
-        val messages = configureMessageReader(handle)
-        val sentMessages = 0 until N*10 map { i => "message %d".format(i) }
-
-        sentMessages.zipWithIndex foreach { case (m, i) =>
-          Await.result(services(i % services.size).apply(Set("the_queue", Time.now, m)))
-        }
-        messages must eventually(be_==(sentMessages.toSet))
-        messages.clear()
-
-        cluster.del(InetSocketAddress.createUnresolved("10.0.0.100", 22133))
-
-        sentMessages.zipWithIndex foreach { case (m, i) =>
-          Await.result(services(i % services.size).apply(Set("the_queue", Time.now, m)))
-        }
-        messages must eventually(be_==(sentMessages.toSet))
+        promise
       }
     }
+  }
+
+  val hostQueuesMap = hosts.map { host =>
+    val queues = CacheBuilder.newBuilder()
+      .build(new CacheLoader[ChannelBuffer, BlockingDeque[ChannelBuffer]] {
+      def load(k: ChannelBuffer) = new LinkedBlockingDeque[ChannelBuffer]
+    })
+    (host, queues)
+  }.toMap
+
+  lazy val mockClientBuilder = {
+    val result = mock[ClientBuilder[Command, Response, Nothing, ClientConfig.Yes, ClientConfig.Yes]]
+
+    hosts.foreach { host =>
+      val mockHostClientBuilder =
+        mock[ClientBuilder[Command, Response, ClientConfig.Yes, ClientConfig.Yes, ClientConfig.Yes]]
+      when(result.hosts(host)).thenReturn(mockHostClientBuilder)
+
+      val queues = hostQueuesMap(host)
+      val factory = new ServiceFactory[Command, Response] {
+        // use an executor so readReliably doesn't block waiting on an empty queue
+        def apply(conn: ClientConnection) = Future(newKestrelService(Some(executor), queues))
+        def close(deadline: Time) = Future.Done
+        override def toString = "ServiceFactory for %s".format(host)
+      }
+      when(mockHostClientBuilder.buildFactory()).thenReturn(factory)
+    }
+    result
+  }
+
+  val services = hosts.map { host =>
+    val queues = hostQueuesMap(host)
+    // no executor here: this one is used for writing to the queues
+    newKestrelService(None, queues)
+  }
+
+  def configureMessageReader(handle: ReadHandle): MSet[String] = {
+    val messages = MSet[String]()
+    val UTF8 = Charset.forName("UTF-8")
+
+    handle.messages foreach { msg =>
+      val str = msg.bytes.toString(UTF8)
+      messages += str
+      msg.ack.sync()
+    }
+    messages
+  }
+
+  test("read messages from a ready cluster") {
+    val cluster = new DynamicCluster[SocketAddress](hosts)
+    val handle = MultiReader(cluster, "the_queue").clientBuilder(mockClientBuilder).build()
+    val messages = configureMessageReader(handle)
+    val sentMessages = 0 until N*10 map { i => "message %d".format(i) }
+    assert(messages === Seq.empty)
+
+    sentMessages.zipWithIndex foreach { case (m, i) =>
+      Await.result(services(i % services.size).apply(Set("the_queue", Time.now, m)))
+    }
+
+    assert(messages === sentMessages.toSet)
+  }
+
+  test("read messages as cluster hosts are added") {
+    val (host, rest) = (hosts.head, hosts.tail)
+    val cluster = new DynamicCluster[SocketAddress](List(host))
+    val handle = MultiReader(cluster, "the_queue").clientBuilder(mockClientBuilder).build()
+    val messages = configureMessageReader(handle)
+    val sentMessages = 0 until N*10 map { i => "message %d".format(i) }
+    assert(messages === Seq.empty)
+
+    sentMessages.zipWithIndex foreach { case (m, i) =>
+      Await.result(services(i % services.size).apply(Set("the_queue", Time.now, m)))
+    }
+
+    // 0, 3, 6 ...
+    assert(messages === sentMessages.grouped(N).map { _.head }.toSet)
+    messages.clear()
+
+    rest.foreach { host => cluster.add(host) }
+
+    // 1, 2, 4, 5, ...
+    assert(messages === sentMessages.grouped(N).map { _.tail }.flatten.toSet)
+  }
+
+  test("read messages as cluster hosts are removed") {
+    val cluster = new DynamicCluster[SocketAddress](hosts)
+    val rest = hosts.tail
+    val handle = MultiReader(cluster, "the_queue").clientBuilder(mockClientBuilder).build()
+
+    val messages = configureMessageReader(handle)
+    val sentMessages = 0 until N*10 map { i => "message %d".format(i) }
+    assert(messages === Seq.empty)
+
+    sentMessages.zipWithIndex foreach { case (m, i) =>
+      Await.result(services(i % services.size).apply(Set("the_queue", Time.now, m)))
+    }
+
+    assert(messages === sentMessages.toSet)
+
+    rest.reverse.zipWithIndex.foreach { case (host, hostIndex) =>
+      messages.clear()
+      cluster.del(host)
+
+      // write to all 3
+      sentMessages.zipWithIndex foreach { case (m, i) =>
+        Await.result(services(i % services.size).apply(Set("the_queue", Time.now, m)))
+      }
+
+      // expect fewer to be read on each pass
+      val expectFirstN = N - hostIndex - 1
+      assert(messages === sentMessages.grouped(N).map { _.take(expectFirstN) }.flatten.toSet)
+    }
+  }
+
+  test("wait for cluster to become ready before snapping initial hosts") {
+    val cluster = new DynamicCluster[SocketAddress](Seq())
+    val handle = MultiReader(cluster, "the_queue").clientBuilder(mockClientBuilder).build()
+    val messages = configureMessageReader(handle)
+    val errors = handle.error?
+    val sentMessages = 0 until N*10 map { i => "message %d".format(i) }
+    assert(messages === Seq.empty)
+
+    sentMessages.zipWithIndex foreach { case (m, i) =>
+      Await.result(services(i % services.size).apply(Set("the_queue", Time.now, m)))
+    }
+
+    assert(messages === Seq.empty) // cluster not ready
+    assert(!errors.isDefined)
+
+    hosts.foreach { host => cluster.add(host) }
+
+    assert(messages === sentMessages.toSet)
+  }
+
+  test("report an error if all hosts are removed") {
+    val cluster = new DynamicCluster[SocketAddress](hosts)
+    val handle = MultiReader(cluster, "the_queue").clientBuilder(mockClientBuilder).build()
+    val e = (handle.error?)
+    hosts.foreach { host => cluster.del(host) }
+
+    assert(e.isDefined)
+    intercept[AllHandlesDiedException.type] {
+      Await.result(e)
+    }
+  }
+
+  test("silently handle the removal of a host that was never added") {
+    val cluster = new DynamicCluster[SocketAddress](hosts)
+    val handle = MultiReader(cluster, "the_queue").clientBuilder(mockClientBuilder).build()
+
+    val messages = configureMessageReader(handle)
+    val sentMessages = 0 until N*10 map { i => "message %d".format(i) }
+
+    sentMessages.zipWithIndex foreach { case (m, i) =>
+      Await.result(services(i % services.size).apply(Set("the_queue", Time.now, m)))
+    }
+    assert(messages === sentMessages.toSet)
+    messages.clear()
+
+    cluster.del(InetSocketAddress.createUnresolved("10.0.0.100", 22133))
+
+    sentMessages.zipWithIndex foreach { case (m, i) =>
+      Await.result(services(i % services.size).apply(Set("the_queue", Time.now, m)))
+    }
+
+    assert(messages === sentMessages.toSet)
   }
 }


### PR DESCRIPTION
So, I did manage to port all tests to ScalaTests. But I understand that I messed up collections assertions in the process. I'm guessing I don't quite understand how lazy collections work in Scala.
What's really weird, when I tried to figure it out, the same tests that fail with assert on collections worked fine when I replaced assert with should equal (BDD style).
Would anyone be so kind to point me in the right direction on these? (discussion of #290)
