### PR TITLE
Add Content-Type: application/json response header to stats JsonExporter

### DIFF
--- a/finagle-stats/src/main/scala/com/twitter/finagle/stats/JsonExporter.scala
+++ b/finagle-stats/src/main/scala/com/twitter/finagle/stats/JsonExporter.scala
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.twitter.app.GlobalFlag
 import com.twitter.common.metrics.Metrics
 import com.twitter.finagle.Service
+import com.twitter.finagle.http.MediaType
 import com.twitter.util.Future
 import org.jboss.netty.buffer.ChannelBuffers
 import org.jboss.netty.handler.codec.http._
@@ -33,6 +34,7 @@ class JsonExporter(registry: Metrics) extends Service[HttpRequest, HttpResponse]
 
   def apply(request: HttpRequest): Future[HttpResponse] = {
     val response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK)
+    response.headers.add(HttpHeaders.Names.CONTENT_TYPE, MediaType.Json)
 
     val pretty = readBooleanParam(request, name = "pretty", default = false)
     val filtered = readBooleanParam(request, name = "filtered", default = false)

--- a/finagle-stats/src/test/scala/com/twitter/finagle/stats/JsonExporterTest.scala
+++ b/finagle-stats/src/test/scala/com/twitter/finagle/stats/JsonExporterTest.scala
@@ -1,11 +1,12 @@
 package com.twitter.finagle.stats
 
 import com.twitter.common.metrics.Metrics
+import org.jboss.netty.handler.codec.http.HttpHeaders
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.FunSuite
 import scala.util.matching.Regex
-import com.twitter.finagle.http.{Response, Request}
+import com.twitter.finagle.http.{MediaType, Response, Request}
 import com.twitter.util.Await
 
 @RunWith(classOf[JUnitRunner])
@@ -47,8 +48,11 @@ class JsonExporterTest extends FunSuite {
     assert(! responseFiltered.contains("jvm_gcs"), "'jvm_gcs' should be present - jvm.* matches it")
 
     val requestUnfiltered = Request("/admin/metrics.json")
-    val responseUnfiltered = Response(Await.result(exporter.apply(requestUnfiltered))).contentString
-    assert(responseUnfiltered.contains("views"), "'Views' should be present - 'vie' is not a match")
-    assert(responseUnfiltered.contains("jvm_gcs"), "'jvm_gcs' should be present - jvm.* matches it")
+    val responseUnfiltered = Response(Await.result(exporter.apply(requestUnfiltered)))
+    assert(MediaType.Json.equals(responseUnfiltered.headers().get(HttpHeaders.Names.CONTENT_TYPE)))
+
+    val responseUnfilteredContent = responseUnfiltered.contentString
+    assert(responseUnfilteredContent.contains("views"), "'Views' should be present - 'vie' is not a match")
+    assert(responseUnfilteredContent.contains("jvm_gcs"), "'jvm_gcs' should be present - jvm.* matches it")
   }
 }


### PR DESCRIPTION
Problem

The stats JsonExporter does not add a Content-Type: header to it's response... when it always produces application/json.

Solution

Add the header!

Result

The Content-Type: header will be present in the response
