### PR TITLE
Check !flags.isDebug directly in Trace.isActivelyTracing.

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/tracing/Trace.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/tracing/Trace.scala
@@ -217,7 +217,7 @@ object Trace  {
   def isActivelyTracing: Boolean = {
     if (!tracingEnabled) false else { // short circuit
       local() match {
-        case Some(State(Some(TraceId(_, _, _, Some(false), Flags(0L))), _, _)) => false
+        case Some(State(Some(TraceId(_, _, _, Some(false), flags: Flags)), _, _)) if !flags.isDebug => false
         case None => false
         case Some(State(_, _, Nil)) => false
         case Some(State(_, _, List(NullTracer))) => false

--- a/finagle-core/src/test/scala/com/twitter/finagle/tracing/TraceTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/tracing/TraceTest.scala
@@ -297,4 +297,15 @@ class TraceTest extends FunSuite with MockitoSugar with BeforeAndAfter with OneI
     when(tracer.sampleTrace(any[TraceId])).thenReturn(Some(false))
     assert(Trace.isActivelyTracing === true) // false/true again prefer the id's opinion
   }
+
+  test("Trace.isActivelyTracing: trace id with SamplingKnown flag set") {
+    val id = TraceId(Some(SpanId(12)), Some(SpanId(13)), SpanId(14), Some(true), Flags(Flags.SamplingKnown | Flags.Sampled))
+    val tracer = mock[Tracer]
+    Trace.clear()
+    Trace.pushTracer(tracer)
+    Trace.setId(id)
+    assert(Trace.isActivelyTracing === true)
+    Trace.setId(id.copy(_sampled = Some(false), flags = Flags(Flags.SamplingKnown)))
+    assert(Trace.isActivelyTracing === false)
+  }
 }


### PR DESCRIPTION
Problem

Non-debug TraceIds with _sampled=Some(false) sent over the wire have the
SamplingKnown flag set. Trace.isActivelyTracing would match Some(false)
but only if flags is zero, but here it is two.

Solution

The case clause to find non-sampled, non-debug TraceIds was changed to
directly check flags.isDebug instead of restricting flags to zero.
