### PR TITLE
Fix Travis CI config and add missing dependency to SBT build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 
 scala:
-  - 2.9.2
+  - 2.10.4
 
 jdk:
   - oraclejdk7

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -50,6 +50,7 @@ object Finagle extends Build {
     crossScalaVersions := Seq("2.10.4"),
     scalaVersion := "2.10.4",
     libraryDependencies ++= Seq(
+      "org.scalacheck" %% "scalacheck" % "1.11.3" % "test",
       "org.scalatest" %% "scalatest" % "2.2.2" % "test",
       "org.scala-tools.testing" %% "specs" % "1.6.9" % "test",
       "junit" % "junit" % "4.10" % "test",


### PR DESCRIPTION
Problem

We're no longer cross-building against 2.9.2, but that's what's in the Travis
configuration. The SBT build is also missing the ScalaCheck dependency.

Solution

Update the version, add the dependency.

Result

Tests run as expected on Travis.
