### PR TITLE
Whitespace fix.

### DIFF
--- a/finagle-thrift/src/main/scala/com/twitter/finagle/Thrift.scala
+++ b/finagle-thrift/src/main/scala/com/twitter/finagle/Thrift.scala
@@ -199,7 +199,7 @@ object Thrift extends Client[ThriftClientRequest, Array[Byte]] with ThriftRichCl
     def withBufferedTransport(): Server = copy(framed=false)
   }
 
-  val  server = Server()
+  val server = Server()
 
   def serve(addr: SocketAddress, service: ServiceFactory[Array[Byte], Array[Byte]])
     : ListeningServer = server.serve(addr, service)


### PR DESCRIPTION
Problem

There are 2 spaces after the val in 'val  server' for the Thrift
object in finagle-thrift.

Solution

Remove one of the spaces.