### PR TITLE
Update statistics for org.jboss.netty.channel.FileRegion writes

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/channel/ChannelStatsHandler.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/channel/ChannelStatsHandler.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
 import java.util.logging.{Level, Logger}
 import org.jboss.netty.buffer.ChannelBuffer
 import org.jboss.netty.channel.{ChannelHandlerContext, ChannelStateEvent,
-  ExceptionEvent, MessageEvent, SimpleChannelHandler}
+  ExceptionEvent, MessageEvent, SimpleChannelHandler, FileRegion}
 
 /**
  * A [[org.jboss.netty.channel.ChannelHandler]] that tracks channel/connection
@@ -65,8 +65,12 @@ class ChannelStatsHandler(statsReceiver: StatsReceiver)
         val readableBytes = buffer.readableBytes
         channelWriteCount.getAndAdd(readableBytes)
         sentBytes.incr(readableBytes)
+      case region: FileRegion =>
+        val bytesToTransfer = region.getCount.toInt
+        channelWriteCount.getAndAdd(bytesToTransfer)
+        sentBytes.incr(bytesToTransfer)
       case _ =>
-        log.warning("ChannelStatsHandler received non-channelbuffer write")
+        log.warning("ChannelStatsHandler received non-channelbuffer and non-fileregion write")
     }
 
     super.writeRequested(ctx, e)

--- a/finagle-core/src/test/scala/com/twitter/finagle/channel/ChannelStatsHandlerTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/channel/ChannelStatsHandlerTest.scala
@@ -54,6 +54,26 @@ class ChannelStatsHandlerTest extends FunSpec with MockitoSugar {
       connectionsIs(0)
     }
 
+    it("should count bytes to transfer for file region") {
+      var sr = new InMemoryStatsReceiver()
+
+      val handler = new ChannelStatsHandler(sr)
+
+      val ctx = mock[ChannelHandlerContext]
+      val al = new AtomicLong()
+      val obj = (al, al).asInstanceOf[Object]
+      when(ctx.getAttachment()).thenReturn(obj, obj)
+
+      val evt = mock[MessageEvent]
+      val region = mock[FileRegion]
+      when(evt.getMessage()).thenReturn(region, region)
+      when(region.getCount()).thenReturn(42, 42)
+
+      handler.writeRequested(ctx, evt)
+
+      assert(sr.counter("sent_bytes")() === 42)
+    }
+
     it("should check the counters are collected correctly") {
       val time = Time.now
       Time.withTimeFunction(time) { control =>


### PR DESCRIPTION
Handle FileRegion writes in ChannelStatsHandler

### Problem 

Currently, when writing instance of `FileRegion` (in custom Codec for example), handler logs many annoying messages:
```
WAR [20141220-05:51:59.151] channel: ChannelStatsHandler received non-channelbuffer write
```
And sent bytes count from FileRegion  not included in `sent_bytes` counter.

### Solution

Check if message is instance of `FileRegion` and increment stats counters by `FileRegion.getCount` value

### Result

Sent bytes from FileRegion are included in `sent_bytes` and `connection_sent_bytes` counters

