### PR TITLE
Update domain to raw.githubusercontent.com

### DIFF
--- a/doc/src/sphinx/Quickstart.rst
+++ b/doc/src/sphinx/Quickstart.rst
@@ -37,7 +37,7 @@ here_, or:
 
 ::
 
-	$ curl https://raw.github.com/twitter/finagle/master/doc/src/sphinx/code/quickstart/sbt > code/sbt
+	$ curl https://raw.githubusercontent.com/twitter/finagle/master/doc/src/sphinx/code/quickstart/sbt > code/sbt
 	$ chmod u+rx code/sbt
 
 .. _here: https://raw.github.com/twitter/finagle/master/doc/src/sphinx/code/quickstart/sbt


### PR DESCRIPTION
This PR addresses issue #275 

The domain has been changed from raw.github.com to raw.githubusercontent.com

No functional changes, just information changes.