### PR TITLE
[WIP] Typeclass-based value extraction for finagle-mysql datatypes.

### DIFF
--- a/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/TypeExtractor.scala
+++ b/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/TypeExtractor.scala
@@ -1,0 +1,71 @@
+package com.twitter.finagle.exp.mysql
+
+import annotation.implicitNotFound
+import java.sql.Timestamp
+
+@implicitNotFound(msg = "Don't know how to extract ${T} from a Value.")
+trait TypeExtractor[T] {
+  def extractFrom(v: Value): Option[T]
+}
+
+object TypeExtractor {
+  implicit object StringExtractor extends TypeExtractor[String] {
+    def extractFrom(v: Value): Option[String] = v match {
+      case StringValue(s) => Some(s)
+      case _              => None
+    }
+  }
+  implicit object BooleanExtractor extends TypeExtractor[Boolean] {
+    def extractFrom(v: Value): Option[Boolean] = v match {
+      case ByteValue(b) => Some(b == 1)
+      case _            => None
+    }
+  }
+  implicit object ByteExtractor extends TypeExtractor[Byte] {
+    def extractFrom(v: Value): Option[Byte] = v match {
+      case ByteValue(b) => Some(b) 
+      case _            => None
+    }
+  }
+  implicit object ShortExtractor extends TypeExtractor[Short] {
+    def extractFrom(v: Value): Option[Short] = v match {
+      case ShortValue(s) => Some(s)
+      case _             => None
+    }
+  }
+  implicit object IntExtractor extends TypeExtractor[Int] {
+    def extractFrom(v: Value): Option[Int] = v match {
+      case IntValue(i) => Some(i)
+      case _           => None
+    }
+  }
+  implicit object LongExtractor extends TypeExtractor[Long] {
+    def extractFrom(v: Value): Option[Long] = v match {
+      case LongValue(l) => Some(l)
+      case _ => None
+    }
+  }
+  implicit object FloatExtractor extends TypeExtractor[Float] {
+    def extractFrom(v: Value): Option[Float] = v match {
+      case FloatValue(f) => Some(f)
+      case _             => None
+    }
+  }
+  implicit object DoubleExtractor extends TypeExtractor[Double] {
+    def extractFrom(v: Value): Option[Double] = v match {
+      case DoubleValue(d) => Some(d)
+      case _              => None
+    }
+  }
+  implicit object TimestampExtractor extends TypeExtractor[Timestamp] {
+    private val UTC = java.util.TimeZone.getTimeZone("UTC")
+    private val timestampValue = new TimestampValue(UTC, UTC)
+    def extractFrom(v: Value): Option[Timestamp] = timestampValue.unapply(v)
+  }
+  implicit def nullableExtractor[T : TypeExtractor]: TypeExtractor[Option[T]] = new TypeExtractor[Option[T]] {
+    override def extractFrom(v: Value) = Option(v match {
+      case NullValue | EmptyValue => None
+      case v => implicitly[TypeExtractor[T]].extractFrom(v)
+    })
+  }
+}

--- a/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Value.scala
+++ b/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Value.scala
@@ -12,7 +12,11 @@ import com.twitter.finagle.exp.mysql.transport.{Buffer, BufferReader, BufferWrit
  * Defines a Value ADT that represents the domain of values
  * received from a mysql server.
  */
-sealed trait Value
+sealed trait Value {
+  def mapToOpt[T : TypeExtractor]: Option[T] = mapTo[Option[T]]
+  def mapTo[T : TypeExtractor]: T =
+    implicitly[TypeExtractor[T]].extractFrom(this).getOrElse(throw new RuntimeException(s"Cannot extract a requested value from $this"))
+}
 case class ByteValue(b: Byte) extends Value
 case class ShortValue(s: Short) extends Value
 case class IntValue(i: Int) extends Value


### PR DESCRIPTION
Here's one piece of code we found useful at SoundCloud when converting between scala types and finagle-mysql types. /cc @fwbrasil @williamboxhall

```scala
> finagle-mysql/console
[info] Starting scala interpreter...
[info]
Welcome to Scala version 2.10.4 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_20).
Type in expressions to have them evaluated.
Type :help for more information.

scala> import com.twitter.finagle.exp.mysql._
import com.twitter.finagle.exp.mysql._

scala> NullValue.mapToOpt[String]
res0: Option[String] = None

scala> StringValue("Hej").mapTo[String]
res1: String = Hej

scala> StringValue("Hej").mapTo[Option[Int]]
res2: Option[Int] = None

scala> StringValue("Hej").mapToOpt[String]
res3: Option[String] = Some(Hej)

scala> EmptyValue.mapTo[Int]
java.lang.RuntimeException: Cannot extract a requested value from EmptyValue
```