### PR TITLE
Target move database should be an integer string

### DIFF
--- a/finagle-redis/src/test/scala/com/twitter/finagle/redis/integration/ClientSpec.scala
+++ b/finagle-redis/src/test/scala/com/twitter/finagle/redis/integration/ClientSpec.scala
@@ -134,7 +134,7 @@ class ClientSpec extends SpecificationWithJUnit {
         Await.result(client.del(Seq(foo)))
         Await.result(client.select(fromDb))
 
-        Await.result(client.move(foo, bar)) mustEqual false
+        Await.result(client.move(foo, StringToChannelBuffer(toDb.toString))) mustEqual false
         Await.result(client.set(foo, bar))
         Await.result(client.move(foo, StringToChannelBuffer(toDb.toString))) mustEqual true
         Await.result(client.del(Seq(foo)))


### PR DESCRIPTION
Problem

Redis integration tests are failing with an exception. Usage of the "move"
command expects an integer string as the second parameter, but we give it
alphabet characters. Redis' response to this is undefined.

Solution

Changed the second parameter to the `toDb` index, which was probably the
original intention.

Result

Integration tests now pass.