### PR TITLE
Add get Function to Aperture.scala for Java access

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/Aperture.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/Aperture.scala
@@ -28,6 +28,11 @@ object ApertureBalancerFactory extends WeightedLoadBalancerFactory {
     new ApertureLoadBandBalancer(activity,
       statsReceiver = statsReceiver,
       emptyException = emptyException)
+  
+  /**
+   * Used for Java access.
+   */
+  def get() = this
 }
 
 

--- a/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/Aperture.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/Aperture.scala
@@ -28,11 +28,11 @@ object ApertureBalancerFactory extends WeightedLoadBalancerFactory {
     new ApertureLoadBandBalancer(activity,
       statsReceiver = statsReceiver,
       emptyException = emptyException)
-  
+
   /**
    * Used for Java access.
    */
-  def get() = this
+  def get(): ApertureBalancerFactory.type = this
 }
 
 


### PR DESCRIPTION
Problem
We want to use the Aperture LoadBalancerFactory in a Java client. 

Solution
Implement a get function in the object, so it can have Java access.

Result
You should be able to call ApertureBalancerFactory.get() and return the object, which is very useful for Java development.