### PR TITLE
finagle-core: Set finite SSL handshake timeout. Fixes #345

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -71,6 +71,10 @@ Runtime Behavior Changes
     includes time spent in name resolution, which is now covered by
     "namer/bind_latency_us" as discussed above.
 
+  * finagle-core: `com.twitter.finagle.netty3.Netty3Transporter` now sets a 10 second
+    SSL handshake timeout to avoid getting stuck in "connecting" state. This timeout
+    may be reconfigured using `c.t.f.client.Transporter.SSLHandshakeTimeout` stack param.
+
 Deprecations
 ~~~~~~~~~~~~
 

--- a/finagle-core/src/main/scala/com/twitter/finagle/client/Transporter.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/client/Transporter.scala
@@ -54,6 +54,17 @@ object Transporter {
   }
 
   /**
+   * $param SSL handshake timeout, if TLS is enabled.
+   */
+  case class SSLHandshakeTimeout(howlong: Duration) {
+    def mk(): (SSLHandshakeTimeout, Stack.Param[SSLHandshakeTimeout]) =
+      (this, SSLHandshakeTimeout.param)
+  }
+  object SSLHandshakeTimeout {
+    implicit val param = Stack.Param(SSLHandshakeTimeout(10.seconds))
+  }
+
+  /**
    * $param hostname verification, if TLS is enabled.
    * @see [[com.twitter.finagle.transport.Transport#TLSEngine]]
    */


### PR DESCRIPTION
Problem

Netty3Transporter does not set explicit handshake timeout on SslHandler.

If a channel configured this way establishes TCP connection with a
remote that does not respond to a handshake, the channel would get stuck
in "connecting" state indefinitely.

Solution

Add Transporter.SSLHandshakeTimeout stack param. Set its value to
10 seconds by default. Use this param to configure SslHandler.

Result

Connections do not get stuck in SSL handshake.
Fixes #345