### PR TITLE
Redis newRichClient should take be a raw service.

### DIFF
--- a/finagle-redis/src/main/scala/com/twitter/finagle/Redis.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/Redis.scala
@@ -17,6 +17,9 @@ trait RedisRichClient { self: Client[Command, Reply] =>
 
   def newRichClient(dest: Name, label: String): redis.Client =
     redis.Client(newService(dest, label))
+    
+  def newRichClient(raw: Service[Command, Reply]): redis.Client =
+    redis.Client(raw)
 }
 
 object RedisTransporter extends Netty3Transporter[Command, Reply]("redis", redis.RedisClientPipelineFactory)


### PR DESCRIPTION
Problem
We want to create a customized Redis client using the client builder, but still use it with the RedisClient object.

Solution
Define a new constructor that takes an already created service.

Result
RedisClient.newRichClient(someService)