### PR TITLE
add SmartNews to the Adopters list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -30,6 +30,8 @@ URLs if possible) and [submit a pull request][1]!
 * [Reputation.com](https://www.reputation.com/)
 * [Sharethrough](https://www.sharethrough.com/)
   * ["Finagle @ Sharethrough: Twitter #Conf Presentation"][5]
+* [SmartNews](https://www.smartnews.com/en/)
+  * ["Scala (Finagle) @ SmartNews"][12]
 * [SoundCloud](https://soundcloud.com/)
   * ["Building Products at SoundCloud—Part III: Microservices in Scala and
     Finagle"][6]
@@ -59,3 +61,4 @@ URLs if possible) and [submit a pull request][1]!
 [9]: https://typesafe.com/blog/tapad_turns_to_typesafe_platform
 [10]: https://typesafe.com/
 [11]: https://blog.twitter.com/2011/finagle-a-protocol-agnostic-rpc-system
+[12]: https://www.slideshare.net/ShigekazuTakei/scalafinaglesmartnewsenglish


### PR DESCRIPTION
Please add SmartNews, Inc. to the adopters list.

SmartNews, Inc. really loves Finagle,
and would like to say "thank you" to all Finagle developers.