### PR TITLE
Added ability to add to the ignored packages sequence for LoadService

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/util/LoadService.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/util/LoadService.scala
@@ -29,16 +29,13 @@ import com.twitter.app.GlobalFlag
  */
 private object ClassPath {
 
-  private[util] var ignoredPackages = Seq(
+  private val defaultIgnoredPackages = Seq(
     "apple/", "ch/epfl/", "com/apple/", "com/oracle/",
     "com/sun/", "java/", "javax/", "scala/", "sun/", "sunw/")
 
-  /**
-   * Adding additional packages to be ignored.
-   */
-  def addIgnoredPackages(packages: String*) = {
-    ignoredPackages = ignoredPackages ++ packages
-  }
+  private[util] def ignoredPackages =
+    if (ignoredPaths.isDefined) defaultIgnoredPackages ++ ignoredPaths()
+    else defaultIgnoredPackages
 
   /**
    * Information about a classpath entry.
@@ -188,7 +185,8 @@ private object ClassPath {
   }
 }
 
-object ignoredPaths extends GlobalFlag("", "Additional packages to be excluded from recursive directory scan")
+object ignoredPaths extends GlobalFlag(Seq.empty[String],
+    "Additional packages to be excluded from recursive directory scan")
 
 /**
  * Load a singleton class in the manner of [[java.util.ServiceLoader]]. It is

--- a/finagle-core/src/main/scala/com/twitter/finagle/util/LoadService.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/util/LoadService.scala
@@ -22,9 +22,16 @@ import scala.reflect.ClassTag
  */
 private object ClassPath {
 
-  private val ignoredPackages = Seq(
+  private var ignoredPackages = Seq(
     "apple/", "ch/epfl/", "com/apple/", "com/oracle/",
     "com/sun/", "java/", "javax/", "scala/", "sun/", "sunw/")
+
+  /**
+   * Adding additional packages to be ignored.
+   */
+  def addIgnoredPackages(packages: String*) = {
+    ignoredPackages = ignoredPackages ++ packages
+  }
 
   /**
    * Information about a classpath entry.
@@ -184,6 +191,11 @@ object LoadService {
 
   def apply[T: ClassTag](): Seq[T] = synchronized {
     val iface = implicitly[ClassTag[T]].runtimeClass.asInstanceOf[Class[T]]
+
+  def addIgnoredPaths(paths: String*) = {
+    ClassPath.addIgnoredPackages(paths: _*)
+  }
+
     val ifaceName = iface.getName
     val loader = iface.getClassLoader
 

--- a/finagle-core/src/main/scala/com/twitter/finagle/util/LoadService.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/util/LoadService.scala
@@ -27,9 +27,7 @@ private object ClassPath {
     "apple/", "ch/epfl/", "com/apple/", "com/oracle/",
     "com/sun/", "java/", "javax/", "scala/", "sun/", "sunw/")
 
-  private[util] def ignoredPackages =
-    if (ignoredPaths.isDefined) defaultIgnoredPackages ++ ignoredPaths()
-    else defaultIgnoredPackages
+  private[util] def ignoredPackages = defaultIgnoredPackages ++ ignoredPaths()
 
   /**
    * Information about a classpath entry.

--- a/finagle-core/src/main/scala/com/twitter/finagle/util/LoadService.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/util/LoadService.scala
@@ -1,5 +1,6 @@
 package com.twitter.finagle.util
 
+import com.twitter.app.GlobalFlag
 import com.twitter.logging.Level
 import com.twitter.util.NonFatal
 import com.twitter.util.registry.GlobalRegistry
@@ -7,18 +8,11 @@ import java.io.{File, IOException}
 import java.net.{URI, URISyntaxException, URLClassLoader}
 import java.nio.charset.MalformedInputException
 import java.util.ServiceConfigurationError
-<<<<<<< HEAD
 import java.util.jar.JarFile
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.io.Source
 import scala.reflect.ClassTag
-=======
-import scala.collection.JavaConverters._
-import scala.collection.mutable
-import scala.io.Source
-import com.twitter.app.GlobalFlag
->>>>>>> added ignoredPaths GlobalFlag and unit test
 
 /**
  * Inspect and load the classpath. Inspired by Guava's ClassPath
@@ -198,17 +192,6 @@ object LoadService {
 
   def apply[T: ClassTag](): Seq[T] = synchronized {
     val iface = implicitly[ClassTag[T]].runtimeClass.asInstanceOf[Class[T]]
-
-  def addIgnoredPaths(paths: String*) = {
-    ClassPath.addIgnoredPackages(paths: _*)
-
-  private[util] def updateIgnoredPackages = {
-    Option(ignoredPaths()) filter (_.trim.nonEmpty) foreach { ips =>
-      val packages = ips.split(',') map(_.trim)
-      ClassPath.addIgnoredPackages(packages: _*)
-    }
-  }
-  updateIgnoredPackages
 
     val ifaceName = iface.getName
     val loader = iface.getClassLoader

--- a/finagle-core/src/main/scala/com/twitter/finagle/util/LoadService.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/util/LoadService.scala
@@ -27,7 +27,7 @@ private object ClassPath {
     "apple/", "ch/epfl/", "com/apple/", "com/oracle/",
     "com/sun/", "java/", "javax/", "scala/", "sun/", "sunw/")
 
-  private[util] def ignoredPackages = defaultIgnoredPackages ++ ignoredPaths()
+  private[util] def ignoredPackages = defaultIgnoredPackages ++ loadServiceIgnoredPaths()
 
   /**
    * Information about a classpath entry.
@@ -177,7 +177,7 @@ private object ClassPath {
   }
 }
 
-object ignoredPaths extends GlobalFlag(Seq.empty[String],
+object loadServiceIgnoredPaths extends GlobalFlag(Seq.empty[String],
     "Additional packages to be excluded from recursive directory scan")
 
 /**

--- a/finagle-core/src/main/scala/com/twitter/finagle/util/LoadService.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/util/LoadService.scala
@@ -7,11 +7,18 @@ import java.io.{File, IOException}
 import java.net.{URI, URISyntaxException, URLClassLoader}
 import java.nio.charset.MalformedInputException
 import java.util.ServiceConfigurationError
+<<<<<<< HEAD
 import java.util.jar.JarFile
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.io.Source
 import scala.reflect.ClassTag
+=======
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+import scala.io.Source
+import com.twitter.app.GlobalFlag
+>>>>>>> added ignoredPaths GlobalFlag and unit test
 
 /**
  * Inspect and load the classpath. Inspired by Guava's ClassPath
@@ -22,7 +29,7 @@ import scala.reflect.ClassTag
  */
 private object ClassPath {
 
-  private var ignoredPackages = Seq(
+  private[util] var ignoredPackages = Seq(
     "apple/", "ch/epfl/", "com/apple/", "com/oracle/",
     "com/sun/", "java/", "javax/", "scala/", "sun/", "sunw/")
 
@@ -181,6 +188,8 @@ private object ClassPath {
   }
 }
 
+object ignoredPaths extends GlobalFlag("", "Additional packages to be excluded from recursive directory scan")
+
 /**
  * Load a singleton class in the manner of [[java.util.ServiceLoader]]. It is
  * more resilient to varying Java packaging configurations than ServiceLoader.
@@ -194,7 +203,14 @@ object LoadService {
 
   def addIgnoredPaths(paths: String*) = {
     ClassPath.addIgnoredPackages(paths: _*)
+
+  private[util] def updateIgnoredPackages = {
+    Option(ignoredPaths()) filter (_.trim.nonEmpty) foreach { ips =>
+      val packages = ips.split(',') map(_.trim)
+      ClassPath.addIgnoredPackages(packages: _*)
+    }
   }
+  updateIgnoredPackages
 
     val ifaceName = iface.getName
     val loader = iface.getClassLoader
@@ -240,3 +256,4 @@ object LoadService {
     result
   }
 }
+

--- a/finagle-core/src/test/scala/com/twitter/finagle/util/LoadServiceTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/util/LoadServiceTest.scala
@@ -161,7 +161,7 @@ class LoadServiceTest extends FunSuite with MockitoSugar {
   }
 
   test("LoadService should ignore packages according to ignoredPaths GlobalFlag") {
-    ignoredPaths.let(Seq("foo/", "/bar")){
+    loadServiceIgnoredPaths.let(Seq("foo/", "/bar")){
       assert(ClassPath.ignoredPackages.takeRight(2) == Seq("foo/", "/bar"))
     }
   }

--- a/finagle-core/src/test/scala/com/twitter/finagle/util/LoadServiceTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/util/LoadServiceTest.scala
@@ -1,6 +1,7 @@
 package com.twitter.finagle.util
 
 import com.google.common.io.ByteStreams
+import com.twitter.app.GlobalFlag
 import com.twitter.finagle.{Announcement, Announcer, Resolver}
 import com.twitter.util.Future
 import com.twitter.util.registry.{GlobalRegistry, SimpleRegistry, Entry}
@@ -15,7 +16,6 @@ import org.scalatest.junit.JUnitRunner
 import org.scalatest.mock.MockitoSugar
 import scala.collection.mutable
 import scala.util.Random
-import com.twitter.app.GlobalFlag
 
 trait LoadServiceRandomInterface
 

--- a/finagle-core/src/test/scala/com/twitter/finagle/util/LoadServiceTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/util/LoadServiceTest.scala
@@ -158,6 +158,15 @@ class LoadServiceTest extends FunSuite with MockitoSugar {
       jar2.delete
     }
   }
+
+  test("LoadService should ignore packages according to ignoredPaths GlobalFlag") {
+    val ips = ClassPath.ignoredPackages
+    ignoredPaths.let("foo/ , /bar "){
+      LoadService.updateIgnoredPackages
+      assert(ClassPath.ignoredPackages.takeRight(2) == Seq("foo/", "/bar"))
+    }
+    ClassPath.ignoredPackages = ips
+  }
 }
 
 class LoadServiceCallable extends Callable[Seq[Any]] {
@@ -199,3 +208,4 @@ class FooAnnouncer extends Announcer {
 
   override def announce(addr: InetSocketAddress, name: String): Future[Announcement] = null
 }
+

--- a/finagle-core/src/test/scala/com/twitter/finagle/util/LoadServiceTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/util/LoadServiceTest.scala
@@ -15,6 +15,7 @@ import org.scalatest.junit.JUnitRunner
 import org.scalatest.mock.MockitoSugar
 import scala.collection.mutable
 import scala.util.Random
+import com.twitter.app.GlobalFlag
 
 trait LoadServiceRandomInterface
 
@@ -160,12 +161,9 @@ class LoadServiceTest extends FunSuite with MockitoSugar {
   }
 
   test("LoadService should ignore packages according to ignoredPaths GlobalFlag") {
-    val ips = ClassPath.ignoredPackages
-    ignoredPaths.let("foo/ , /bar "){
-      LoadService.updateIgnoredPackages
+    ignoredPaths.let(Seq("foo/", "/bar")){
       assert(ClassPath.ignoredPackages.takeRight(2) == Seq("foo/", "/bar"))
     }
-    ClassPath.ignoredPackages = ips
   }
 }
 


### PR DESCRIPTION
Problem

The problem being fixed here is something we ran into while working with finagle in our application similar to the issue posted in the following issue https://github.com/twitter/finagle/issues/309. In our case it was not the /sys directory however but an extremely huge FS mounted on the project root and LoadService was getting stuck descending into that directory structure everytime.

Solution

This pull request adds the ability to add additional packages/paths to the 'ignoredPackages' sequence in LoadService via a method called 'addIgnoredPaths' in LoadService. This method can take a single or multiple paths as String arguments and add them to the private sequence (which is now mutable).

Result

After this change, users would be able to customize the ignoredPackages for the recursive directory scan that LoadService performs (in several flows) and avoid getting stuck in directory structures that they do not want scanned.