### PR TITLE
Made RetryingFilter extendable.

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/service/RetryingFilter.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/service/RetryingFilter.scala
@@ -55,7 +55,7 @@ class RetryingFilter[Req, Rep](
     } else f
   }
 
-  private[this] def dispatch(
+  protected def dispatch(
     req: Req,
     service: Service[Req, Rep],
     policy: RetryPolicy[Try[Nothing]],


### PR DESCRIPTION
Problem

The main logic of the RetryingFilter is good enough for me, however it does not
pass the request to the policy. In my case I always want to retry GET requests.
Therefore, I want to extend the RetryingFilter such that the new apply() method
can use the request to create a new policy. In the current situation that is not
possible because the dispatch method is private. Consequently, the
RetryingFilter is not extendable.

Solution

Changed the access modifier from private to protected.

Result

Classes that extend the RetryingFilter can now call dispatch.