### PR TITLE
Changed localhost to 127.0.0.1 to prevent ipv6 from being added to the pool

### DIFF
--- a/finagle-core/src/test/scala/com/twitter/finagle/client/StackClientTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/client/StackClientTest.scala
@@ -27,19 +27,20 @@ class StackClientTest extends FunSuite
 
   test("client stats are scoped to label")(new Ctx {
     // use dest when no label is set
-    client.newService("inet!localhost:8080")
+    client.newService("inet!127.0.0.1:8080")
     eventually {
-      assert(sr.counters(Seq("inet!localhost:8080", "loadbalancer", "adds")) === 1)
+      val counter = sr.counters(Seq("inet!127.0.0.1:8080", "loadbalancer", "adds"))
+      assert(counter == 1, s"The instance should be to the loadbalancer once instead of $counter times.")
     }
 
     // use param.Label when set
-    client.configured(param.Label("myclient")).newService("localhost:8080")
+    client.configured(param.Label("myclient")).newService("127.0.0.1:8080")
     eventually {
       assert(sr.counters(Seq("myclient", "loadbalancer", "adds")) === 1)
     }
 
     // use evaled label when both are set
-    client.configured(param.Label("myclient")).newService("othername=localhost:8080")
+    client.configured(param.Label("myclient")).newService("othername=127.0.0.1:8080")
     eventually {
       assert(sr.counters(Seq("othername", "loadbalancer", "adds")) === 1)
     }


### PR DESCRIPTION
Problem

When running the tests on my machine, which has both an ipv4 and 6 interface,
the tests fail because the endpoints are added to the load-balancer twice and
therefore the tests fail with the message that 2 != 1.

Solution

I've changed the hostname from localhost to 127.0.0.1 in the afflicted test. If
this is really the solution than there are probably more tests where tests where
this should be fixed. Additionally I added a better error message to the
assertion.

Result

Tests will run on my machine.