### PR TITLE
Bugfix memcached Zipkin integration.

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/Codec.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/Codec.scala
@@ -73,7 +73,15 @@ trait Codec[Req, Rep] {
    * A hack to allow for overriding the TraceInitializerFilter when using
    * Client/Server Builders rather than stacks.
    */
+  @deprecated(message="Replaced by stackRolesToReplace which is more generic.", since = "6.26.0")
   def newTraceInitializer: Stackable[ServiceFactory[Req, Rep]] = TraceInitializerFilter.clientModule[Req, Rep]
+
+  /**
+   * Supports overriding Stack roles when using Client/Server Builders
+   * rather than stacks.
+   */
+  def stackRolesToReplace: Map[Stack.Role, Stackable[ServiceFactory[Req, Rep]]] = Map()
+
 }
 
 /**

--- a/finagle-core/src/test/scala/com/twitter/finagle/integration/Base.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/integration/Base.scala
@@ -60,6 +60,7 @@ trait IntegrationBase extends FunSuite with MockitoSugar {
     }
 
     when(codec.newTraceInitializer) thenReturn TraceInitializerFilter.clientModule[String, String]
+    when(codec.stackRolesToReplace) thenReturn Map[Stack.Role, Stackable[ServiceFactory[String, String]]]()
 
     val clientAddress = new SocketAddress {}
 

--- a/finagle-memcached/src/main/scala/com/twitter/finagle/Memcached.scala
+++ b/finagle-memcached/src/main/scala/com/twitter/finagle/Memcached.scala
@@ -1,63 +1,22 @@
 package com.twitter.finagle
 
-import _root_.java.net.{InetSocketAddress, SocketAddress}
+import _root_.java.net.SocketAddress
 import com.twitter.concurrent.Broker
 import com.twitter.conversions.time._
 import com.twitter.finagle.client._
 import com.twitter.finagle.dispatch.{SerialServerDispatcher, PipeliningDispatcher}
+import com.twitter.finagle.memcached._
 import com.twitter.finagle.memcached.protocol.text.{
   MemcachedClientPipelineFactory, MemcachedServerPipelineFactory}
-import com.twitter.finagle.memcached.protocol.{Command, Response, RetrievalCommand, Values}
-import com.twitter.finagle.memcached.{Client => MClient, Server => MServer, _}
+import com.twitter.finagle.memcached.protocol.{Command, Response}
 import com.twitter.finagle.netty3._
 import com.twitter.finagle.pool.SingletonPool
 import com.twitter.finagle.server._
 import com.twitter.finagle.stats.{ClientStatsReceiver, StatsReceiver}
-import com.twitter.finagle.tracing._
 import com.twitter.finagle.util.DefaultTimer
 import com.twitter.hashing.KeyHasher
-import com.twitter.io.Charsets.Utf8
-import com.twitter.util.{Duration, Future}
-import scala.collection.mutable
+import com.twitter.util.Duration
 
-private[finagle] object MemcachedTraceInitializer {
-  object Module extends Stack.Module1[param.Tracer, ServiceFactory[Command, Response]] {
-    val role = TraceInitializerFilter.role
-    val description = "Initialize traces for the client and record hits/misses"
-    def make(_tracer: param.Tracer, next: ServiceFactory[Command, Response]) = {
-      val param.Tracer(tracer) = _tracer
-      val filter = new Filter(tracer)
-      filter andThen next
-    }
-  }
-
-  class Filter(tracer: Tracer) extends SimpleFilter[Command, Response] {
-    def apply(command: Command, service: Service[Command, Response]): Future[Response] =
-      Trace.letTracerAndNextId(tracer) {
-        Trace.recordRpc(command.name)
-  
-        val response = service(command)
-        command match {
-          case command: RetrievalCommand if Trace.isActivelyTracing =>
-            response onSuccess {
-              case Values(vals) =>
-                val cmd = command.asInstanceOf[RetrievalCommand]
-                val misses = mutable.Set.empty[String]
-                cmd.keys foreach { key => misses += key.toString(Utf8) }
-                vals foreach { value =>
-                  val key = value.key.toString(Utf8)
-                  Trace.recordBinary(key, "Hit")
-                  misses.remove(key)
-                }
-                misses foreach { Trace.recordBinary(_, "Miss") }
-              case _ =>
-            }
-          case _ =>
-        }
-        response
-      }
-    }
-}
 
 trait MemcachedRichClient { self: Client[Command, Response] =>
   def newRichClient(group: Group[SocketAddress]): memcached.Client = memcached.Client(newClient(group).toService)
@@ -128,8 +87,7 @@ object MemcachedClient extends DefaultClient[Command, Response](
   name = "memcached",
   endpointer = Bridge[Command, Response, Command, Response](
     MemcachedTransporter, new PipeliningDispatcher(_)),
-  pool = (sr: StatsReceiver) => new SingletonPool(_, sr),
-  newTraceInitializer = MemcachedTraceInitializer.Module
+  pool = (sr: StatsReceiver) => new SingletonPool(_, sr)
 ) with MemcachedRichClient with MemcachedKetamaClient
 
 private[finagle] object MemcachedFailureAccrualClient {
@@ -158,8 +116,7 @@ private[finagle] class MemcachedFailureAccrualClient(
       failureAccrualParams._1,
       failureAccrualParams._2,
       DefaultTimer.twitter, key, broker)
-  },
-  newTraceInitializer = MemcachedTraceInitializer.Module
+  }
 ) with MemcachedRichClient
 
 object MemcachedListener extends Netty3Listener[Response, Command](


### PR DESCRIPTION
Problem

The memcached Zipkin integration was broken. When getting a value from memcached
the cache hit/miss annotation was submitted after the cr annotation was submitted.
This had as a result that a new span was created with same id which was eventually
submitted by the DeadlineSpanMap once the deadline was exceeded. The span submitted
by the DeadlineSpanMap overrides the duration of the earlier submitted span and messes
it up. It also makes the zipkin-web trace overview almost unusable.

Solution

Instead of submitting the cache hit/miss annotations using the TraceInitializerFilter.role,
submit them using ClientTracingFilter.role before the cr annotation is submitted.
This means the memcached specific tracing filter submits following annotations:
cs -> memcache specific annotations -> cr. To be able to do this I updated the Codec trait
to be able to override filters which have a custom role and not the TraceInitializerFilter.role.

Result

The memcached span does not end up in the DeadlineSpanMap and the spans are correctly
submitted now including cache hit/miss annotations.  The duration is correct and the
trace overview in zipkin-web looks good again.