### PR TITLE
Update write statistics when write request fulfilled

### DIFF
--- a/finagle-core/src/test/scala/com/twitter/finagle/channel/ChannelStatsHandlerTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/channel/ChannelStatsHandlerTest.scala
@@ -69,5 +69,25 @@ class ChannelStatsHandlerTest extends FunSpec with MockitoSugar {
         }
       }
     }
+
+    it("should count written bytes") {
+      val sr = new InMemoryStatsReceiver
+
+      val handler = new ChannelStatsHandler(sr)
+
+      val ctx = mock[ChannelHandlerContext]
+      val al = new AtomicLong
+
+      val counters = (al, al).asInstanceOf[Object]
+      when(ctx.getAttachment()).thenReturn(counters, counters)
+
+      val evt = mock[WriteCompletionEvent]
+      when(evt.getWrittenAmount).thenReturn(42)
+
+      handler.writeComplete(ctx, evt)
+
+      assert(sr.counter("sent_bytes")() == 42)
+      assert(al.get == 42)
+    }
   }
 }


### PR DESCRIPTION
### Problem 

Currently, when writing instance of `FileRegion` (in custom Codec for example), handler logs many annoying messages:
```
WAR [20141220-05:51:59.151] channel: ChannelStatsHandler received non-channelbuffer write
```
And sent bytes count from FileRegion  not included in `sent_bytes` counter.

### Solution

Override `SimpleChannelUpstreamHandler.writeComplete()` instead `writeRequested()` and count amount of sent bytes via `WriteCompletionEvent.getWrittenAmount()` (according @trustin advice - https://github.com/twitter/finagle/pull/329)

### Result

Sent bytes from FileRegion are included in `sent_bytes` and `connection_sent_bytes` counters
