### PR TITLE
Add support for Redis HyperLogLog commands

### DIFF
--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/Client.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/Client.scala
@@ -37,6 +37,7 @@ class Client(service: Service[Command, Reply])
   with Lists
   with Sets
   with BtreeSortedSetCommands
+  with HyperLogLogs
 
 /**
  * Connects to a single Redis host

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/HyperLogLogCommands.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/HyperLogLogCommands.scala
@@ -1,0 +1,48 @@
+package com.twitter.finagle.redis
+
+import _root_.java.lang.{Long => JLong,Boolean => JBoolean}
+import com.twitter.finagle.redis.protocol.{StatusReply, IntegerReply}
+import com.twitter.finagle.redis.protocol.commands.{PFMerge, PFCount, PFAdd}
+import com.twitter.util.Future
+import org.jboss.netty.buffer.ChannelBuffer
+
+trait HyperLogLogs { self: BaseClient =>
+
+  /**
+   * Adds elements to a HyperLogLog data structure.
+   *
+   * @param key
+   * @param elements
+   * @return True if a bit was set in the HyperLogLog data structure
+   * @see http://redis.io/commands/pfadd
+   */
+  def pfAdd(key: ChannelBuffer, elements: List[ChannelBuffer]): Future[JBoolean] =
+    doRequest(PFAdd(key, elements)) {
+      case IntegerReply(n) => Future.value(n == 1)
+    }
+
+
+  /**
+   * Get the approximated cardinality of sets observed by the HyperLogLog at key(s)
+   * @param keys
+   * @return Approximated number of unique elements
+   * @see http://redis.io/commands/pfcount
+   */
+  def pfCount(keys: Seq[ChannelBuffer]): Future[JLong] =
+    doRequest(PFCount(keys)) {
+      case IntegerReply(n) => Future.value(n)
+    }
+
+
+  /**
+   * Merge HyperLogLogs at srcKeys to create a new HyperLogLog at destKey
+   * @param destKey
+   * @param srcKeys
+   * @see http://redis.io/commands/pfmerge
+   */
+  def pfMerge(destKey: ChannelBuffer, srcKeys: Seq[ChannelBuffer]): Future[Unit] =
+    doRequest(PFMerge(destKey, srcKeys)) {
+      case StatusReply(_) => Future.Unit
+    }
+
+}

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/Command.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/Command.scala
@@ -135,6 +135,11 @@ object Commands {
   val UNWATCH           = "UNWATCH"
   val WATCH             = "WATCH"
 
+  // HyperLogLogs
+  val PFADD             = "PFADD"
+  val PFCOUNT           = "PFCOUNT"
+  val PFMERGE           = "PFMERGE"
+
   val commandMap: Map[String, Function1[List[Array[Byte]],Command]] = Map(
     // key commands
     DEL               -> {Del(_)},
@@ -253,7 +258,12 @@ object Commands {
     EXEC              -> {_ => Exec},
     MULTI             -> {_ => Multi},
     UNWATCH           -> {_ => UnWatch},
-    WATCH             -> {Watch(_)}
+    WATCH             -> {Watch(_)},
+
+    // HyperLogLogs
+    PFADD             -> {PFAdd(_)},
+    PFCOUNT           -> {PFCount(_)},
+    PFMERGE           -> {PFMerge(_)}
 
   )
 
@@ -392,6 +402,11 @@ object CommandBytes {
   val MULTI             = StringToChannelBuffer("MULTI")
   val UNWATCH           = StringToChannelBuffer("UNWATCH")
   val WATCH             = StringToChannelBuffer("WATCH")
+
+  // HyperLogLogs
+  val PFADD             = StringToChannelBuffer("PFADD")
+  val PFCOUNT           = StringToChannelBuffer("PFCOUNT")
+  val PFMERGE           = StringToChannelBuffer("PFMERGE")
 }
 
 

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/HyperLogLog.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/HyperLogLog.scala
@@ -1,0 +1,49 @@
+package com.twitter.finagle.redis.protocol.commands
+
+import com.twitter.finagle.redis.ClientError
+import com.twitter.finagle.redis.protocol._
+import org.jboss.netty.buffer.{ChannelBuffers, ChannelBuffer}
+
+case class PFAdd(key: ChannelBuffer, elements: Seq[ChannelBuffer]) extends StrictKeyCommand {
+  val command = Commands.PFADD
+
+  override def toChannelBuffer = RedisCodec.toUnifiedFormat(Seq(CommandBytes.PFADD, key) ++ elements)
+}
+
+object PFAdd {
+  def apply(args: Seq[Array[Byte]]): PFAdd = args match {
+    case head :: tail =>
+      PFAdd(ChannelBuffers.wrappedBuffer(head), tail map ChannelBuffers.wrappedBuffer)
+
+    case _ =>
+      throw ClientError("Invalid use of PFAdd")
+  }
+}
+
+case class PFCount(keys: Seq[ChannelBuffer]) extends StrictKeysCommand {
+  val command = Commands.PFCOUNT
+
+  override def toChannelBuffer = RedisCodec.toUnifiedFormat(CommandBytes.PFCOUNT +: keys)
+}
+
+object PFCount {
+  def apply(args: => Seq[Array[Byte]]): PFCount = PFCount(args map ChannelBuffers.wrappedBuffer)
+}
+
+case class PFMerge(destKey: ChannelBuffer, srcKeys: Seq[ChannelBuffer]) extends Command {
+  val command = Commands.PFMERGE
+
+  RequireClientProtocol(srcKeys.size > 0, "srcKeys must not be empty")
+
+  def toChannelBuffer = RedisCodec.toUnifiedFormat(Seq(CommandBytes.PFMERGE, destKey) ++ srcKeys)
+}
+
+object PFMerge {
+  def apply(args: Seq[Array[Byte]]): PFMerge = args match {
+    case head :: tail =>
+      PFMerge(ChannelBuffers.wrappedBuffer(head), tail map ChannelBuffers.wrappedBuffer)
+
+    case _ =>
+      throw ClientError("Invalid use of PFMerge")
+  }
+}


### PR DESCRIPTION
Problem:

Finagle-redis currently lacks support for HyperLogLog commands
(http://redis.io/commands#hyperloglog).

Solution:

Add code to enable calling PFADD, PFCOUNT and PFMERGE from RedisClient

Result:

RedisClient API will have three new methods:
- pfAdd
- pfCount
- pfMerge