### PR TITLE
Redis hyperloglog support

### DIFF
--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/Client.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/Client.scala
@@ -37,6 +37,7 @@ class Client(service: Service[Command, Reply])
   with Lists
   with Sets
   with BtreeSortedSetCommands
+  with HyperLogLogs
 
 /**
  * Connects to a single Redis host

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/HyperLogLogCommands.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/HyperLogLogCommands.scala
@@ -1,8 +1,7 @@
 package com.twitter.finagle.redis
 
 import _root_.java.lang.{Long => JLong,Boolean => JBoolean}
-import com.twitter.finagle.redis.protocol.{StatusReply, IntegerReply}
-import com.twitter.finagle.redis.protocol.commands.{PFMerge, PFCount, PFAdd}
+import com.twitter.finagle.redis.protocol.{IntegerReply, PFMerge, PFCount, PFAdd, StatusReply}
 import com.twitter.util.Future
 import org.jboss.netty.buffer.ChannelBuffer
 

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/HyperLogLogCommands.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/HyperLogLogCommands.scala
@@ -1,0 +1,48 @@
+package com.twitter.finagle.redis
+
+import _root_.java.lang.{Long => JLong,Boolean => JBoolean}
+import com.twitter.finagle.redis.protocol.{StatusReply, IntegerReply}
+import com.twitter.finagle.redis.protocol.commands.{PFMerge, PFCount, PFAdd}
+import com.twitter.util.Future
+import org.jboss.netty.buffer.ChannelBuffer
+
+trait HyperLogLogs { self: BaseClient =>
+
+  /**
+   * Adds elements to a HyperLogLog data structure.
+   *
+   * @param key
+   * @param elements
+   * @return True if a bit was set in the HyperLogLog data structure
+   * @see http://redis.io/commands/pfadd
+   */
+  def pfAdd(key: ChannelBuffer, elements: List[ChannelBuffer]): Future[JBoolean] =
+    doRequest(PFAdd(key, elements)) {
+      case IntegerReply(n) => Future.value(n == 1)
+    }
+
+
+  /**
+   * Get the approximated cardinality of sets observed by the HyperLogLog at key(s)
+   * @param keys
+   * @return Approximated number of unique elements
+   * @see http://redis.io/commands/pfcount
+   */
+  def pfCount(keys: Seq[ChannelBuffer]): Future[JLong] =
+    doRequest(PFCount(keys)) {
+      case IntegerReply(n) => Future.value(n)
+    }
+
+
+  /**
+   * Merge HyperLogLogs at srcKeys to create a new HyperLogLog at destKey
+   * @param destKey
+   * @param srcKeys
+   * @see http://redis.io/commands/pfmerge
+   */
+  def pfMerge(destKey: ChannelBuffer, srcKeys: Seq[ChannelBuffer]): Future[Unit] =
+    doRequest(PFMerge(destKey, srcKeys)) {
+      case StatusReply(_) => Future.Unit
+    }
+
+}

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/Command.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/Command.scala
@@ -136,6 +136,11 @@ object Commands {
   val UNWATCH           = "UNWATCH"
   val WATCH             = "WATCH"
 
+  // HyperLogLogs
+  val PFADD             = "PFADD"
+  val PFCOUNT           = "PFCOUNT"
+  val PFMERGE           = "PFMERGE"
+
   val commandMap: Map[String, Function1[List[Array[Byte]],Command]] = Map(
     // key commands
     DEL               -> {Del(_)},
@@ -255,7 +260,12 @@ object Commands {
     EXEC              -> {_ => Exec},
     MULTI             -> {_ => Multi},
     UNWATCH           -> {_ => UnWatch},
-    WATCH             -> {Watch(_)}
+    WATCH             -> {Watch(_)},
+
+    // HyperLogLogs
+    PFADD             -> {PFAdd(_)},
+    PFCOUNT           -> {PFCount(_)},
+    PFMERGE           -> {PFMerge(_)}
 
   )
 
@@ -395,6 +405,11 @@ object CommandBytes {
   val MULTI             = StringToChannelBuffer("MULTI")
   val UNWATCH           = StringToChannelBuffer("UNWATCH")
   val WATCH             = StringToChannelBuffer("WATCH")
+
+  // HyperLogLogs
+  val PFADD             = StringToChannelBuffer("PFADD")
+  val PFCOUNT           = StringToChannelBuffer("PFCOUNT")
+  val PFMERGE           = StringToChannelBuffer("PFMERGE")
 }
 
 

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/HyperLogLog.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/HyperLogLog.scala
@@ -1,4 +1,4 @@
-package com.twitter.finagle.redis.protocol.commands
+package com.twitter.finagle.redis.protocol
 
 import com.twitter.finagle.redis.ClientError
 import com.twitter.finagle.redis.protocol._

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/HyperLogLog.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/HyperLogLog.scala
@@ -1,0 +1,49 @@
+package com.twitter.finagle.redis.protocol.commands
+
+import com.twitter.finagle.redis.ClientError
+import com.twitter.finagle.redis.protocol._
+import org.jboss.netty.buffer.{ChannelBuffers, ChannelBuffer}
+
+case class PFAdd(key: ChannelBuffer, elements: Seq[ChannelBuffer]) extends StrictKeyCommand {
+  val command = Commands.PFADD
+
+  override def toChannelBuffer = RedisCodec.toUnifiedFormat(Seq(CommandBytes.PFADD, key) ++ elements)
+}
+
+object PFAdd {
+  def apply(args: Seq[Array[Byte]]): PFAdd = args match {
+    case head :: tail =>
+      PFAdd(ChannelBuffers.wrappedBuffer(head), tail map ChannelBuffers.wrappedBuffer)
+
+    case _ =>
+      throw ClientError("Invalid use of PFAdd")
+  }
+}
+
+case class PFCount(keys: Seq[ChannelBuffer]) extends StrictKeysCommand {
+  val command = Commands.PFCOUNT
+
+  override def toChannelBuffer = RedisCodec.toUnifiedFormat(CommandBytes.PFCOUNT +: keys)
+}
+
+object PFCount {
+  def apply(args: => Seq[Array[Byte]]): PFCount = PFCount(args map ChannelBuffers.wrappedBuffer)
+}
+
+case class PFMerge(destKey: ChannelBuffer, srcKeys: Seq[ChannelBuffer]) extends Command {
+  val command = Commands.PFMERGE
+
+  RequireClientProtocol(srcKeys.size > 0, "srcKeys must not be empty")
+
+  def toChannelBuffer = RedisCodec.toUnifiedFormat(Seq(CommandBytes.PFMERGE, destKey) ++ srcKeys)
+}
+
+object PFMerge {
+  def apply(args: Seq[Array[Byte]]): PFMerge = args match {
+    case head :: tail =>
+      PFMerge(ChannelBuffers.wrappedBuffer(head), tail map ChannelBuffers.wrappedBuffer)
+
+    case _ =>
+      throw ClientError("Invalid use of PFMerge")
+  }
+}

--- a/finagle-redis/src/test/scala/com/twitter/finagle/redis/commands/hyperloglog/HyperLogLogClientIntegrationSuite.scala
+++ b/finagle-redis/src/test/scala/com/twitter/finagle/redis/commands/hyperloglog/HyperLogLogClientIntegrationSuite.scala
@@ -14,7 +14,7 @@ final class HyperLogLogClientIntegrationSuite extends RedisClientTest {
 
   test("Correctly perform the PFADD command", RedisTest, ClientTest) {
     withRedisClient { client =>
-      assert(Await.result(client.pfAdd(foo, List(bar))) === 1)
+      assert(Await.result(client.pfAdd(foo, List(bar))))
     }
   }
 
@@ -29,7 +29,7 @@ final class HyperLogLogClientIntegrationSuite extends RedisClientTest {
     withRedisClient { client =>
       val addHll = List((foo, List(bar, baz)), (bar, List(foo, baz))) map (client.pfAdd _).tupled
       val pfMergeResult = Future.collect(addHll).flatMap(_ => client.pfMerge(baz, List(foo, bar)))
-      assert(Await.result(pfMergeResult) === 3)
+      assert(Await.result(pfMergeResult) === ())
     }
   }
 }

--- a/finagle-redis/src/test/scala/com/twitter/finagle/redis/commands/hyperloglog/HyperLogLogClientIntegrationSuite.scala
+++ b/finagle-redis/src/test/scala/com/twitter/finagle/redis/commands/hyperloglog/HyperLogLogClientIntegrationSuite.scala
@@ -1,0 +1,21 @@
+package com.twitter.finagle.redis.integration
+
+import com.twitter.finagle.redis.naggati.RedisClientTest
+import com.twitter.finagle.redis.protocol.BitOp
+import com.twitter.finagle.redis.tags.{RedisTest, ClientTest}
+import com.twitter.util.Await
+import com.twitter.finagle.redis.util.{CBToString, StringToChannelBuffer}
+import org.junit.Ignore
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@Ignore
+@RunWith(classOf[JUnitRunner])
+final class HyperLogLogClientIntegrationSuite extends RedisClientTest {
+
+  test("Correctly perform the PFADD command", RedisTest, ClientTest) {
+    withRedisClient { client =>
+      Await.result(client.pfAdd(foo, List(bar)))
+    }
+  }
+}

--- a/finagle-redis/src/test/scala/com/twitter/finagle/redis/commands/hyperloglog/HyperLogLogClientIntegrationSuite.scala
+++ b/finagle-redis/src/test/scala/com/twitter/finagle/redis/commands/hyperloglog/HyperLogLogClientIntegrationSuite.scala
@@ -15,7 +15,22 @@ final class HyperLogLogClientIntegrationSuite extends RedisClientTest {
 
   test("Correctly perform the PFADD command", RedisTest, ClientTest) {
     withRedisClient { client =>
-      Await.result(client.pfAdd(foo, List(bar)))
+      assert(Await.result(client.pfAdd(foo, List(bar))) === 1)
+    }
+  }
+
+  test("Correctly perform the PFCOUNT command", RedisTest, ClientTest) {
+    withRedisClient { client =>
+      val pfCountResult = client.pfAdd(foo, List(bar, baz)).flatMap(_ => client.pfCount(List(foo)))
+      assert(Await.result(pfCountResult) === 2)
+    }
+  }
+
+  test("Correctly perform the PFMERGE command", RedisTest, ClientTest) {
+    withRedisClient { client =>
+      val setup = List((foo, List(bar, baz)), (bar, List(foo, baz))) map client.pfAdd.tupled
+      val pfMergeResult = client.pfMerge(baz, List(foo, bar))
+      assert(Await.result(pfMergeResult) === 3)
     }
   }
 }

--- a/finagle-redis/src/test/scala/com/twitter/finagle/redis/commands/hyperloglog/HyperLogLogClientIntegrationSuite.scala
+++ b/finagle-redis/src/test/scala/com/twitter/finagle/redis/commands/hyperloglog/HyperLogLogClientIntegrationSuite.scala
@@ -1,10 +1,9 @@
 package com.twitter.finagle.redis.integration
 
 import com.twitter.finagle.redis.naggati.RedisClientTest
-import com.twitter.finagle.redis.protocol.BitOp
-import com.twitter.finagle.redis.tags.{RedisTest, ClientTest}
-import com.twitter.util.Await
-import com.twitter.finagle.redis.util.{CBToString, StringToChannelBuffer}
+import com.twitter.finagle.redis.tags.{ClientTest, RedisTest}
+import com.twitter.util.{Future, Await}
+
 import org.junit.Ignore
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
@@ -28,8 +27,8 @@ final class HyperLogLogClientIntegrationSuite extends RedisClientTest {
 
   test("Correctly perform the PFMERGE command", RedisTest, ClientTest) {
     withRedisClient { client =>
-      val setup = List((foo, List(bar, baz)), (bar, List(foo, baz))) map client.pfAdd.tupled
-      val pfMergeResult = client.pfMerge(baz, List(foo, bar))
+      val addHll = List((foo, List(bar, baz)), (bar, List(foo, baz))) map (client.pfAdd _).tupled
+      val pfMergeResult = Future.collect(addHll).flatMap(_ => client.pfMerge(baz, List(foo, bar)))
       assert(Await.result(pfMergeResult) === 3)
     }
   }

--- a/finagle-redis/src/test/scala/com/twitter/finagle/redis/commands/hyperloglog/HyperLogLogClientServerIntegrationSuite.scala
+++ b/finagle-redis/src/test/scala/com/twitter/finagle/redis/commands/hyperloglog/HyperLogLogClientServerIntegrationSuite.scala
@@ -1,12 +1,12 @@
 package com.twitter.finagle.redis.integration
 
-import com.twitter.finagle.redis.ClientError
 import com.twitter.finagle.redis.naggati.RedisClientServerIntegrationTest
 import com.twitter.finagle.redis.protocol._
 import com.twitter.finagle.redis.tags.{ClientServerTest, RedisTest}
-import com.twitter.finagle.redis.util.{BytesToString, StringToChannelBuffer}
-import com.twitter.util.{Future, Await}
+import com.twitter.finagle.redis.util.StringToChannelBuffer
+import com.twitter.util.{Await, Future}
 import org.jboss.netty.buffer.ChannelBuffer
+
 import org.junit.Ignore
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
@@ -24,7 +24,8 @@ final class HyperLogLogClientServerIntegrationSuite extends RedisClientServerInt
 
   test("PFCOUNT should work correctly", ClientServerTest, RedisTest) {
     withRedisClient { client =>
-      val pfCountResult = client(PFAdd("foo", List("bar", "baz"))).flatMap(_ => client(PFCount(List("foo"))))
+      val pfCountResult = client(PFAdd("foo", List("bar", "baz")))
+        .flatMap(_ => client(PFCount(List(StringToChannelBuffer("foo")))))
       assert(Await.result(pfCountResult) === IntegerReply(2))
     }
   }

--- a/finagle-redis/src/test/scala/com/twitter/finagle/redis/commands/hyperloglog/HyperLogLogClientServerIntegrationSuite.scala
+++ b/finagle-redis/src/test/scala/com/twitter/finagle/redis/commands/hyperloglog/HyperLogLogClientServerIntegrationSuite.scala
@@ -1,0 +1,24 @@
+package com.twitter.finagle.redis.integration
+
+import com.twitter.finagle.redis.ClientError
+import com.twitter.finagle.redis.naggati.RedisClientServerIntegrationTest
+import com.twitter.finagle.redis.protocol._
+import com.twitter.finagle.redis.tags.{ClientServerTest, RedisTest}
+import com.twitter.finagle.redis.util.{BytesToString, StringToChannelBuffer}
+import com.twitter.util.Await
+import org.jboss.netty.buffer.ChannelBuffer
+import org.junit.Ignore
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@Ignore
+@RunWith(classOf[JUnitRunner])
+final class HyperLogLogClientServerIntegrationSuite extends RedisClientServerIntegrationTest {
+  implicit def convertToChannelBuffer(s: String): ChannelBuffer = StringToChannelBuffer(s)
+
+  test("PFADD should work correctly", ClientServerTest, RedisTest) {
+    withRedisClient { client =>
+      assert(Await.result(client(PFAdd(foo, List(bar)))) === IntegerReply(1))
+    }
+  }
+}

--- a/finagle-redis/src/test/scala/com/twitter/finagle/redis/commands/hyperloglog/HyperLogLogClientServerIntegrationSuite.scala
+++ b/finagle-redis/src/test/scala/com/twitter/finagle/redis/commands/hyperloglog/HyperLogLogClientServerIntegrationSuite.scala
@@ -30,7 +30,7 @@ final class HyperLogLogClientServerIntegrationSuite extends RedisClientServerInt
     }
   }
 
-  test("PFMerge should work correctly", ClientServerTest, RedisTest) {
+  test("PFMERGE should work correctly", ClientServerTest, RedisTest) {
     withRedisClient { client =>
       val setup = List(PFAdd("foo", List("bar")), PFAdd("bar", List("baz"))) map client
       val pfMergeResult = Future.collect(setup).flatMap(_ => client(PFMerge("baz", List("foo", "bar"))))

--- a/finagle-redis/src/test/scala/com/twitter/finagle/redis/commands/hyperloglog/HyperLogLogCodecSuite.scala
+++ b/finagle-redis/src/test/scala/com/twitter/finagle/redis/commands/hyperloglog/HyperLogLogCodecSuite.scala
@@ -1,0 +1,85 @@
+package com.twitter.finagle.redis.protocol
+
+import com.twitter.finagle.redis.ClientError
+import com.twitter.finagle.redis.naggati.RedisRequestTest
+import com.twitter.finagle.redis.tags.CodecTest
+import com.twitter.finagle.redis.util.CBToString
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+final class HyperLogLogCodecSuite extends RedisRequestTest {
+
+  test("Throw a ClientError if PFADD is called with no arguments", CodecTest) {
+    intercept[ClientError] {
+      codec(wrap("PFADD\r\n"))
+    }
+  }
+
+  test("Correctly encode PFADD with one element", CodecTest) {
+    unwrap(codec(wrap("PFADD foo bar\r\n"))) {
+      case PFAdd(key, List(element)) =>
+        assert(CBToString(key) === "foo")
+        assert(CBToString(element) === "bar")
+    }
+  }
+
+  test("Correctly encode PFADD with two elements", CodecTest) {
+    unwrap(codec(wrap("PFADD foo bar baz\r\n"))) {
+      case PFAdd(key, elements) =>
+        assert(CBToString(key) === "foo")
+        assert(CBToString(elements(0)) === "bar")
+        assert(CBToString(elements(1)) === "baz")
+    }
+  }
+
+  test("Throw a ClientError if PFCOUNT is called with no arguments", CodecTest) {
+    intercept[ClientError] {
+      codec(wrap("PFCOUNT\r\n"))
+    }
+  }
+
+  test("Correctly encode PFCOUNT with one key", CodecTest) {
+    unwrap(codec(wrap("PFCOUNT foo\r\n"))) {
+      case PFCount(List(key)) =>
+        assert(CBToString(key) === "foo")
+    }
+  }
+
+  test("Correctly encode PFCOUNT with two keys", CodecTest) {
+    unwrap(codec(wrap("PFCOUNT foo bar\r\n"))) {
+      case PFCount(keys) =>
+        assert(CBToString(keys(0)) === "foo")
+        assert(CBToString(keys(1)) === "bar")
+    }
+  }
+
+  test("Throw a ClientError if PFMERGE is called with no arguments", CodecTest) {
+    intercept[ClientError] {
+      codec(wrap("PFMERGE\r\n"))
+    }
+  }
+
+  test("Throw a ClientError if PFMERGE is called with one argument", CodecTest) {
+    intercept[ClientError] {
+      codec(wrap("PFMERGE foo\r\n"))
+    }
+  }
+
+  test("Correctly encode PFMERGE with one source key", CodecTest) {
+    unwrap(codec(wrap("PFMERGE foo bar\r\n"))) {
+      case PFMerge(destKey, List(srcKey)) =>
+        assert(CBToString(destKey) === "foo")
+        assert(CBToString(srcKey) === "bar")
+    }
+  }
+
+  test("Correctly encode PFMERGE with two source keys", CodecTest) {
+    unwrap(codec(wrap("PFMERGE foo bar baz\r\n"))) {
+      case PFMerge(destKey, srcKeys) =>
+        assert(CBToString(destKey) === "foo")
+        assert(CBToString(srcKeys(0)) === "bar")
+        assert(CBToString(srcKeys(1)) === "baz")
+    }
+  }
+}


### PR DESCRIPTION
Problem:

- Finagle-redis currently lacks support for HyperLogLog commands
(http://redis.io/commands#hyperloglog).
- First pull request #358 did not adhere to contribution guidelines

Solution:

- Add code to enable calling PFADD, PFCOUNT and PFMERGE from RedisClient
- Pull suggested refactoring from https://github.com/travisbrown/finagle/commit/556761c94d0d37bc6b8c3369ccc66ee5d7a540a8 and add ScalaTest integration tests

Result:

RedisClient API will have three new methods:

- pfAdd
- pfCount
- pfMerge