### PR TITLE
Make Trace's internal stack thread local

### DIFF
--- a/finagle-thrift/src/main/ruby/.gitignore
+++ b/finagle-thrift/src/main/ruby/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/finagle-thrift/src/main/ruby/Gemfile
+++ b/finagle-thrift/src/main/ruby/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in finagle-thrift.gemspec
+gemspec
+

--- a/finagle-thrift/src/main/ruby/lib/finagle-thrift/version.rb
+++ b/finagle-thrift/src/main/ruby/lib/finagle-thrift/version.rb
@@ -1,4 +1,4 @@
 module FinagleThrift
-  VERSION = "1.4.0"
+  VERSION = "1.4.1"
 end
 

--- a/finagle-thrift/src/main/ruby/test/test_helper.rb
+++ b/finagle-thrift/src/main/ruby/test/test_helper.rb
@@ -1,0 +1,10 @@
+base_dir = File.expand_path(File.join(File.dirname(__FILE__), ".."))
+lib_dir  = File.join(base_dir, "lib")
+test_dir = File.join(base_dir, "test")
+
+$LOAD_PATH.unshift(lib_dir)
+
+require 'test/unit'
+require 'rubygems'
+require 'thrift'
+require 'finagle-thrift'

--- a/finagle-thrift/src/main/ruby/test/trace_test.rb
+++ b/finagle-thrift/src/main/ruby/test/trace_test.rb
@@ -1,7 +1,4 @@
-require 'rubygems'
-require 'thrift'
-require 'finagle-thrift'
-require 'test/unit'
+require_relative 'test_helper'
 
 class TraceIdTest < Test::Unit::TestCase
   def test_debug_flag
@@ -21,5 +18,19 @@ class TraceIdTest < Test::Unit::TestCase
     id = Trace::SpanId.new(Trace.generate_id)
     id2 = Trace::SpanId.from_value(id.to_s)
     assert_equal id.to_i, id2.to_i
+  end
+end
+
+class TraceTest < Test::Unit::TestCase
+  def test_stack_object_id
+    obj_id1 = Thread.new { Trace.id; Trace.send(:stack).object_id }.value
+    obj_id2 = Thread.new { Trace.id; Trace.send(:stack).object_id }.value
+    assert_not_equal obj_id1, obj_id2
+  end
+
+  def test_stack=
+    Trace.send("stack=",[1])
+    stack = Trace.send(:stack)
+    assert_equal [1], stack
   end
 end


### PR DESCRIPTION
Trace's global stack variable is not thread safe. Changing to be thread local for thread safety.  

We are using finagle-thrift as part of tracing service calls with Zipkin.

This issue manifested itself with Jruby 1.7 and a multi-threaded application.