### PR TITLE
Making PreparedStatement parameters type-safe

### DIFF
--- a/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/CanBeParameter.scala
+++ b/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/CanBeParameter.scala
@@ -1,0 +1,182 @@
+package com.twitter.finagle.exp.mysql
+
+import com.twitter.finagle.exp.mysql.transport.{Buffer, BufferWriter}
+
+trait CanBeParameter[-A] { outer =>
+  /**
+   * Returns the size of the given parameter in its MySQL binary representation.
+   **/
+  def sizeOf(param: A): Int
+
+  /**
+   * Retrieves the MySQL type code for the given parameter.
+   * */
+  def typeCode(param: A): Short
+
+  def write(writer: BufferWriter, param: A): Unit
+}
+
+object CanBeParameter {
+  implicit val stringCanBeParameter = {
+    new CanBeParameter[String] {
+      def sizeOf(param: String): Int = {
+        val bytes = param.getBytes(Charset.defaultCharset)
+        Buffer.sizeOfLen(bytes.size) + bytes.size
+      }
+
+      def typeCode(param: String) = Type.VarChar
+      def write(writer: BufferWriter, param: String) = writer.writeLengthCodedString(param)
+    }
+  }
+
+  implicit val booleanCanBeParameter = {
+    new CanBeParameter[Boolean] {
+      def sizeOf(param: Boolean) = 1
+      def typeCode(param: Boolean) = Type.Tiny
+      def write(writer: BufferWriter, param: Boolean) = writer.writeBoolean(param)
+    }
+  }
+
+  implicit val byteCanBeParameter = {
+    new CanBeParameter[Byte] {
+      def sizeOf(param: Byte) = 1
+      def typeCode(param: Byte) = Type.Tiny
+      def write(writer: BufferWriter, param: Byte) = writer.writeByte(param)
+    }
+  }
+
+  implicit val shortCanBeParameter = {
+    new CanBeParameter[Short] {
+      def sizeOf(param: Short) = 2
+      def typeCode(param: Short) = Type.Short
+      def write(writer: BufferWriter, param: Short) = writer.writeShort(param)
+    }
+  }
+
+  implicit val intCanBeParameter = {
+    new CanBeParameter[Int] {
+      def sizeOf(param: Int) = 4
+      def typeCode(param: Int) = Type.Long
+      def write(writer: BufferWriter, param: Int) = writer.writeInt(param)
+    }
+  }
+
+  implicit val longCanBeParameter = {
+    new CanBeParameter[Long] {
+      def sizeOf(param: Long) = 8
+      def typeCode(param: Long) = Type.LongLong
+      def write(writer: BufferWriter, param: Long) = writer.writeLong(param)
+    }
+  }
+
+  implicit val floatCanBeParameter = {
+    new CanBeParameter[Float] {
+      def sizeOf(param: Float) = 4
+      def typeCode(param: Float) = Type.Float
+      def write(writer: BufferWriter, param: Float) = writer.writeFloat(param)
+    }
+  }
+
+  implicit val doubleCanBeParameter = {
+    new CanBeParameter[Double] {
+      def sizeOf(param: Double) = 8
+      def typeCode(param: Double) = Type.Double
+      def write(writer: BufferWriter, param: Double) = writer.writeDouble(param)
+    }
+  }
+
+  implicit val byteArrayCanBeParameter = {
+    new CanBeParameter[Array[Byte]] {
+      def sizeOf(param: Array[Byte]) = Buffer.sizeOfLen(param.length) + param.length
+      def typeCode(param: Array[Byte]) = {
+        if (param.length <= 255) Type.TinyBlob
+        else if (param.length <= 65535) Type.Blob
+        else if (param.length <= 16777215) Type.MediumBlob
+        else -1
+      }
+      def write(writer: BufferWriter, param: Array[Byte]) = writer.writeLengthCodedBytes(param)
+    }
+  }
+
+  implicit val valueCanBeParameter = {
+    new CanBeParameter[Value] {
+      def sizeOf(param: Value) = param match {
+        case RawValue(_, _, true, b) => Buffer.sizeOfLen(b.length) + b.length
+        case StringValue(s)          => val bytes = s.getBytes(Charset.defaultCharset); Buffer.sizeOfLen(bytes.size) + bytes.size
+        case ByteValue(_)            => 1
+        case ShortValue(_)           => 2
+        case IntValue(_)             => 4
+        case LongValue(_)            => 8
+        case FloatValue(_)           => 4
+        case DoubleValue(_)          => 8
+        case NullValue               => 0
+        case _                       => 0
+      }
+
+      def typeCode(param: Value) = param match {
+        case RawValue(typ, _, _, _) => typ
+        case StringValue(_)         => Type.VarChar
+        case ByteValue(_)           => Type.Tiny
+        case ShortValue(_)          => Type.Short
+        case IntValue(_)            => Type.Long
+        case LongValue(_)           => Type.LongLong
+        case FloatValue(_)          => Type.Float
+        case DoubleValue(_)         => Type.Double
+        case EmptyValue             => -1
+        case NullValue              => Type.Null
+      }
+
+      def write(writer: BufferWriter, param: Value) = param match {
+        // allows for generic binary values as params to a prepared statement.
+        case RawValue(_, _, true, bytes) => writer.writeLengthCodedBytes(bytes)
+        // allows for Value types as params to prepared statements
+        case ByteValue(b)                => writer.writeByte(b)
+        case ShortValue(s)               => writer.writeShort(s)
+        case IntValue(i)                 => writer.writeInt(i)
+        case LongValue(l)                => writer.writeLong(l)
+        case FloatValue(f)               => writer.writeFloat(f)
+        case DoubleValue(d)              => writer.writeDouble(d)
+        case StringValue(s)              => writer.writeLengthCodedString(s)
+        case _                           => ()
+      }
+    }
+  }
+
+  implicit val timestampCanBeParameter = {
+    new CanBeParameter[java.sql.Timestamp] {
+      def sizeOf(param: java.sql.Timestamp) = 12
+      def typeCode(param: java.sql.Timestamp) = Type.Timestamp
+      def write(writer: BufferWriter, param: java.sql.Timestamp) = {
+        valueCanBeParameter.write(writer, TimestampValue(param))
+      }
+    }
+  }
+
+  implicit val sqlDateCanBeParameter = {
+    new CanBeParameter[java.sql.Date] {
+      def sizeOf(param: java.sql.Date) = 5
+      def typeCode(param: java.sql.Date) = Type.Date
+      def write(writer: BufferWriter, param: java.sql.Date) = {
+        valueCanBeParameter.write(writer, DateValue(param))
+      }
+    }
+  }
+
+  implicit val javaDateCanBeParameter = {
+    new CanBeParameter[java.util.Date] {
+      def sizeOf(param: java.util.Date) = 12
+      def typeCode(param: java.util.Date) = Type.DateTime
+      def write(writer: BufferWriter, param: java.util.Date) = {
+        valueCanBeParameter.write(writer, TimestampValue(new java.sql.Timestamp(param.getTime)))
+      }
+    }
+  }
+
+  implicit val nullCanBeParameter = {
+    new CanBeParameter[Null] {
+      def sizeOf(param: Null) = 0
+      def typeCode(param: Null) = Type.Null
+      def write(writer: BufferWriter, param: Null): Unit = ()
+    }
+  }
+}

--- a/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/CanBeParameter.scala
+++ b/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/CanBeParameter.scala
@@ -2,15 +2,15 @@ package com.twitter.finagle.exp.mysql
 
 import com.twitter.finagle.exp.mysql.transport.{Buffer, BufferWriter}
 
-trait CanBeParameter[A] { outer =>
+trait CanBeParameter[-A] { outer =>
   /**
    * Returns the size of the given parameter in its MySQL binary representation.
-   **/
+   */
   def sizeOf(param: A): Int
 
   /**
    * Retrieves the MySQL type code for the given parameter.
-   * */
+   */
   def typeCode(param: A): Short
 
   def write(writer: BufferWriter, param: A): BufferWriter

--- a/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Client.scala
+++ b/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Client.scala
@@ -23,7 +23,7 @@ object Client {
 
     def prepare(sql: String): PreparedStatement = new PreparedStatement {
       def apply(ps: Parameter*): Future[Result] = factory() flatMap { svc =>
-        svc(PrepareRequest(sql)) flatMap {
+        svc(PrepareRequest(sql)).flatMap {
           case ok: PrepareOK => svc(ExecuteRequest(ok.id, ps.toIndexedSeq))
           case r => Future.exception(new Exception("Unexpected result %s when preparing %s"
             .format(r, sql)))

--- a/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Client.scala
+++ b/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Client.scala
@@ -22,7 +22,7 @@ object Client {
       }
 
     def prepare(sql: String): PreparedStatement = new PreparedStatement {
-      def apply(ps: Any*): Future[Result] = factory() flatMap { svc =>
+      def apply(ps: Parameter*): Future[Result] = factory() flatMap { svc =>
         svc(PrepareRequest(sql)) flatMap {
           case ok: PrepareOK => svc(ExecuteRequest(ok.id, ps.toIndexedSeq))
           case r => Future.exception(new Exception("Unexpected result %s when preparing %s"

--- a/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Parameter.scala
+++ b/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Parameter.scala
@@ -1,0 +1,37 @@
+package com.twitter.finagle.exp.mysql
+
+import com.twitter.finagle.exp.mysql.transport.BufferWriter
+import language.implicitConversions
+
+trait Parameter {
+  type A
+  def value: A
+  def evidence: CanBeParameter[A]
+
+  final def writeTo(writer: BufferWriter): Unit = {
+    evidence.write(writer, value)
+  }
+
+  final def size = evidence.sizeOf(value)
+  final def typeCode = evidence.typeCode(value)
+}
+
+object Parameter {
+  implicit def wrap[_A](_value: _A)(implicit _evidence: CanBeParameter[_A]): Parameter = {
+    if (_value == null) {
+      NullParameter
+    } else {
+      new Parameter {
+        type A = _A
+        def value: A = _value
+        def evidence: CanBeParameter[A] = _evidence
+      }
+    }
+  }
+
+  object NullParameter extends Parameter {
+    type A = Null
+    def value = null
+    def evidence = CanBeParameter.nullCanBeParameter
+  }
+}

--- a/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Parameter.scala
+++ b/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Parameter.scala
@@ -3,7 +3,11 @@ package com.twitter.finagle.exp.mysql
 import com.twitter.finagle.exp.mysql.transport.BufferWriter
 import language.implicitConversions
 
-trait Parameter {
+/**
+ * A value of type `A` can implicitly convert to a `Parameter` if an evidence `CanBeParameter[A]` is
+ * available in scope. This type is not be instantiated in any other manner.
+ */
+sealed trait Parameter {
   type A
   def value: A
   def evidence: CanBeParameter[A]
@@ -12,8 +16,8 @@ trait Parameter {
     evidence.write(writer, value)
   }
 
-  final def size = evidence.sizeOf(value)
-  final def typeCode = evidence.typeCode(value)
+  final def size: Int = evidence.sizeOf(value)
+  final def typeCode: Short = evidence.typeCode(value)
 }
 
 object Parameter {

--- a/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Parameter.scala
+++ b/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Parameter.scala
@@ -17,14 +17,14 @@ trait Parameter {
 }
 
 object Parameter {
-  implicit def wrap[_A](_value: _A)(implicit _evidence: CanBeParameter[_A]): Parameter = {
-    if (_value == null) {
+  implicit def wrap[A0](value0: A0)(implicit evidence0: CanBeParameter[A0]): Parameter = {
+    if (value0 == null) {
       NullParameter
     } else {
       new Parameter {
-        type A = _A
-        def value: A = _value
-        def evidence: CanBeParameter[A] = _evidence
+        type A = A0
+        def value: A = value0
+        def evidence: CanBeParameter[A] = evidence0
       }
     }
   }

--- a/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/PreparedStatement.scala
+++ b/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/PreparedStatement.scala
@@ -12,7 +12,7 @@ trait PreparedStatement {
    * Executes the prepared statement with the
    * given `params`.
    */
-  def apply(params: Any*): Future[Result]
+  def apply(params: Parameter*): Future[Result]
 
   /**
    * Executes the prepared statement with the
@@ -20,8 +20,8 @@ trait PreparedStatement {
    * of the returned ResultSet. If no ResultSet
    * is returned, the function returns an empty Seq.
    */
-  def select[T](params: Any*)(f: Row => T): Future[Seq[T]] =
-    apply(params:_*) map {
+  def select[T](params: Parameter*)(f: Row => T): Future[Seq[T]] =
+    apply(params: _*) map {
       case rs: ResultSet => rs.rows.map(f)
       case _ => Seq.empty
     }

--- a/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Request.scala
+++ b/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Request.scala
@@ -151,33 +151,31 @@ case class HandshakeResponse(
  * a prepared statement.
  * [[http://dev.mysql.com/doc/internals/en/com-stmt-execute.html]]
  */
-case class ExecuteRequest(
-  stmtId: Int,
-  params: IndexedSeq[Any] = IndexedSeq.empty,
-  hasNewParams: Boolean = true,
-  flags: Byte = 0
+class ExecuteRequest(
+  val stmtId: Int,
+  val params: IndexedSeq[Parameter],
+  val hasNewParams: Boolean,
+  val flags: Byte
 ) extends CommandRequest(Command.COM_STMT_EXECUTE) {
     private[this] val log = Logger.getLogger("finagle-mysql")
 
-    private[this] def isNull(param: Any): Boolean = param match {
-      case null => true
-      case _ => false
-    }
-
-    private[this] def makeNullBitmap(parameters: IndexedSeq[Any]): Array[Byte] = {
+    private[this] def makeNullBitmap(parameters: IndexedSeq[Parameter]): Array[Byte] = {
       val bitmap = new Array[Byte]((parameters.size + 7) / 8)
       val ps = parameters.zipWithIndex
-      for ((p, idx) <- ps if isNull(p)) {
-        val bytePos = idx / 8
-        val bitPos = idx % 8
-        val byte = bitmap(bytePos)
-        bitmap(bytePos) = (byte | (1 << bitPos)).toByte
+      ps foreach {
+        case (Parameter.NullParameter, idx) =>
+          val bytePos = idx / 8
+          val bitPos = idx % 8
+          val byte = bitmap(bytePos)
+          bitmap(bytePos) = (byte | (1 << bitPos)).toByte
+        case _ =>
+          ()
       }
       bitmap
     }
 
-    private[this] def writeTypeCode(param: Any, writer: BufferWriter): Unit = {
-      val typeCode = Type.getCode(param)
+    private[this] def writeTypeCode(param: Parameter, writer: BufferWriter): Unit = {
+      val typeCode = param.typeCode
       if (typeCode != -1)
         writer.writeShort(typeCode)
       else {
@@ -192,40 +190,15 @@ case class ExecuteRequest(
      * Returns sizeof all the parameters according to
      * mysql binary encoding.
      */
-    private[this] def sizeOfParameters(parameters: IndexedSeq[Any]): Int =
-      parameters.foldLeft(0) { (sum, param) =>
-        sum + Type.sizeOf(param)
-      }
+    private[this] def sizeOfParameters(parameters: IndexedSeq[Parameter]): Int =
+      parameters.foldLeft(0)(_ + _.size)
 
     /**
      * Writes the parameter into its MySQL binary representation.
      */
-    private[this] def writeParam(param: Any, writer: BufferWriter): BufferWriter = param match {
-      case s: String      => writer.writeLengthCodedString(s)
-      case b: Boolean     => writer.writeBoolean(b)
-      case b: Byte        => writer.writeByte(b)
-      case s: Short       => writer.writeShort(s)
-      case i: Int         => writer.writeInt(i)
-      case l: Long        => writer.writeLong(l)
-      case f: Float       => writer.writeFloat(f)
-      case d: Double      => writer.writeDouble(d)
-      case b: Array[Byte] => writer.writeLengthCodedBytes(b)
-      // Dates
-      case t: java.sql.Timestamp    => writeParam(TimestampValue(t), writer)
-      case d: java.sql.Date         => writeParam(DateValue(d), writer)
-      case d: java.util.Date        => writeParam(TimestampValue(new java.sql.Timestamp(d.getTime)), writer)
-      // allows for generic binary values as params to a prepared statement.
-      case RawValue(_, _, true, bytes) => writer.writeLengthCodedBytes(bytes)
-      // allows for Value types as params to prepared statements
-      case ByteValue(b) => writer.writeByte(b)
-      case ShortValue(s) => writer.writeShort(s)
-      case IntValue(i) => writer.writeInt(i)
-      case LongValue(l) => writer.writeLong(l)
-      case FloatValue(f) => writer.writeFloat(f)
-      case DoubleValue(d) => writer.writeDouble(d)
-      case StringValue(s) => writer.writeLengthCodedString(s)
-      // skip null and unknown values
-      case _  => writer
+    private[this] def writeParam(param: Parameter, writer: BufferWriter): BufferWriter = {
+      param.writeTo(writer)
+      writer
     }
 
     def toPacket = {
@@ -256,6 +229,20 @@ case class ExecuteRequest(
       }
       Packet(seq, composite)
     }
+}
+
+object ExecuteRequest {
+  def apply(stmtId: Int, params: IndexedSeq[Parameter] = IndexedSeq.empty, hasNewParams: Boolean = true, flags: Byte = 0) = {
+    val sanitizedParams = params.map {
+      case null  => Parameter.NullParameter
+      case other => other
+    }
+    new ExecuteRequest(stmtId, sanitizedParams, hasNewParams, flags)
+  }
+
+  def unapply(executeRequest: ExecuteRequest): Option[(Int, IndexedSeq[Parameter], Boolean, Byte)] = {
+    Some((executeRequest.stmtId, executeRequest.params, executeRequest.hasNewParams, executeRequest.flags))
+  }
 }
 
 /**

--- a/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Request.scala
+++ b/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Request.scala
@@ -232,10 +232,12 @@ class ExecuteRequest private(
 }
 
 object ExecuteRequest {
-  def apply(stmtId: Int,
-            params: IndexedSeq[Parameter] = IndexedSeq.empty,
-            hasNewParams: Boolean = true,
-            flags: Byte = 0): ExecuteRequest = {
+  def apply(
+    stmtId: Int,
+    params: IndexedSeq[Parameter] = IndexedSeq.empty,
+    hasNewParams: Boolean = true,
+    flags: Byte = 0
+  ): ExecuteRequest = {
 
     val sanitizedParams = params.map {
       case null  => Parameter.NullParameter

--- a/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Type.scala
+++ b/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Type.scala
@@ -36,44 +36,6 @@ object Type {
   val String: Short     = 0xfe
   val Geometry: Short   = 0xff
 
-  /**
-   * Returns the sizeof the given parameter in
-   * its MySQL binary representation. If the size
-   * is unknown or the value is null, 0 is returned.
-   */
-  private[mysql] def sizeOf(any: Any): Int = any match {
-    case b: Boolean     => 1
-    case b: Byte        => 1
-    case s: Short       => 2
-    case i: Int         => 4
-    case l: Long        => 8
-    case f: Float       => 4
-    case d: Double      => 8
-    case t: java.sql.Timestamp    => 12
-    case d: java.sql.Date         => 5
-    case d: java.util.Date        => 12
-    case s: String =>
-      val bytes = s.getBytes(Charset.defaultCharset)
-      Buffer.sizeOfLen(bytes.size) + bytes.size
-    case b: Array[Byte] =>
-      Buffer.sizeOfLen(b.size) + b.size
-    case RawValue(_, _, true, b)  =>
-      Buffer.sizeOfLen(b.size) + b.size
-    case StringValue(s) =>
-      val bytes = s.getBytes(Charset.defaultCharset)
-      Buffer.sizeOfLen(bytes.size) + bytes.size
-    case ByteValue(_) => 1
-    case ShortValue(_) => 2
-    case IntValue(_) => 4
-    case LongValue(_) => 8
-    case FloatValue(_) => 4
-    case DoubleValue(_) => 8
-    case NullValue => 0
-    case null => 0
-    // This is safe because unknown
-    // values are serialized as null.
-    case _ => 0
-  }
 
   /**
    * Retrieves the MySQL type code for the

--- a/finagle-mysql/src/test/scala/com/twitter/finagle/mysql/ParameterTest.scala
+++ b/finagle-mysql/src/test/scala/com/twitter/finagle/mysql/ParameterTest.scala
@@ -1,0 +1,28 @@
+package com.twitter.finagle.mysql
+
+import com.twitter.finagle.exp.mysql.Parameter
+import com.twitter.finagle.exp.mysql.Parameter.NullParameter
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class ParameterTest extends FunSuite {
+  test("Parameter coercion") {
+    locally {
+      val x: Parameter = null
+      assert(x == null)
+    }
+
+    locally {
+      val y: String = null
+      val x: Parameter = y
+      assert(x == NullParameter)
+    }
+
+    locally {
+      val x: Parameter = "Howdy"
+      assert(x.value == "Howdy")
+    }
+  }
+}

--- a/finagle-mysql/src/test/scala/com/twitter/finagle/mysql/ParameterTest.scala
+++ b/finagle-mysql/src/test/scala/com/twitter/finagle/mysql/ParameterTest.scala
@@ -8,21 +8,21 @@ import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class ParameterTest extends FunSuite {
-  test("Parameter coercion") {
-    locally {
-      val x: Parameter = null
-      assert(x == null)
-    }
+  test("null, when directly given a type Parameter, stays unchanged") {
+    val x: Parameter = null
+    assert(x == null)
+  }
 
-    locally {
-      val y: String = null
-      val x: Parameter = y
-      assert(x == NullParameter)
-    }
+  test("null with a static type that is coercible to Parameter, " +
+    "when given a type Parameter, coerces to NullParameter") {
+    val y: String = null
+    val x: Parameter = y
+    assert(x == NullParameter)
+  }
 
-    locally {
-      val x: Parameter = "Howdy"
-      assert(x.value == "Howdy")
-    }
+  test("A value with a static type that is coercible to Parameter, " +
+    "when given a type Parameter, coerces while preserving original value internally") {
+    val x: Parameter = "Howdy"
+    assert(x.value == "Howdy")
   }
 }

--- a/finagle-mysql/src/test/scala/com/twitter/finagle/mysql/unit/RequestTest.scala
+++ b/finagle-mysql/src/test/scala/com/twitter/finagle/mysql/unit/RequestTest.scala
@@ -1,12 +1,13 @@
 package com.twitter.finagle.exp.mysql
 
+import com.twitter.finagle.exp.mysql.Parameter.NullParameter
+import com.twitter.finagle.exp.mysql.transport.{Buffer, BufferReader}
+
 import java.sql.{Timestamp, Date => SQLDate}
 import java.util.{Calendar, Date, TimeZone}
-import com.twitter.finagle.exp.mysql.Parameter.NullParameter
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
-import com.twitter.finagle.exp.mysql.transport.{Buffer, BufferReader}
 
 @RunWith(classOf[JUnitRunner])
 class SimpleCommandRequestTest extends FunSuite {


### PR DESCRIPTION
## Problem 

In the current Finagle MySQL, `PreparedStatement#apply` has a type `Seq[Any] => Future[Result]`. This means that one might accidentally end up passing things that cannot be written, and be in for surprises. (Happened to us quite a few times now.) This might be revealed in the warnings and the tests, but we can do much better: We can eliminate such errors at compile time itself.

## Solution

Change `PreparedToStatement#apply` to have type `Seq[Parameter] => Future[Result]`. `Parameter` is a class [that makes use of existential types](http://iveselov.info/posts/2012-08-30-existential-types.html) and packs a value `A` and an implicit instance `CanBeParameter[A]` together. `CanBeParameter` is a type-class. If you have an instance of `CanBeParameter[A]` available, that serves as an evidence that, well, a value of `A` can be a used as a parameter. 

**This PR ensures that all the types that were supported before are still supported the same way.**

`null` required special handling in a couple of places:

1. `Parameter.wrap` doesn't kick in for `null` because `null` is already a member of `Parameter` type. So we need to sanitize the `Seq[Parameter]` in `ExecuteRequest#apply`, and replace all `null`s with `NullParameter`.
2. If there is a `null` with a static type `A` for which there is a `CanBeParameter[A]` evidence available, then we might end up with, for example, a `stringCanBeParameter` instance (if `A` is `String`) and `typeCode` etc will yield wrong values. To avoid this, `Parameter.wrap` has to guard for `null` and return a `NullParameter` in that case.

This PR retains the support for `null` as is, for backwards compatibility. 

Going forward, we could stop supporting `null` altogether and avoid the complications I talked about before. We could instead support `Option` which is a more principled way to deal with these sort of things.