### PR TITLE
Expose a means to configure MaskCancelFilter in the Finagle 6 APIs

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/filter/MaskCancelFilter.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/filter/MaskCancelFilter.scala
@@ -8,8 +8,8 @@ object MaskCancelFilter {
 
   // TODO: we should simply transform the stack for boolean
   // stackables like this.
-  private[finagle] case class Param(yesOrNo: Boolean)
-  private[finagle] implicit object Param extends Stack.Param[Param] {
+  case class Param(yesOrNo: Boolean)
+  implicit object Param extends Stack.Param[Param] {
     val default = Param(false)
   }
 
@@ -17,7 +17,7 @@ object MaskCancelFilter {
    * Creates a [[com.twitter.finagle.Stackable]]
    * [[com.twitter.finagle.filter.MaskCancelFilter]].
    */
-  private[finagle] def module[Req, Rep]: Stackable[ServiceFactory[Req, Rep]] =
+  def module[Req, Rep]: Stackable[ServiceFactory[Req, Rep]] =
     new Stack.Module1[Param, ServiceFactory[Req, Rep]] {
       val role = MaskCancelFilter.role
       val description = "Prevent cancellations from propagating to other services"


### PR DESCRIPTION
Problem

The "cancel on hangup" feature afforded by `c.t.f.filter.MaskCancelFilter`
is not configurable with the Finagle 6 APIs. This represents a lack of
parity with ServerBuilder, which offers a `cancelOnHangup()` function.

Solution

Make the `MaskCancelFilter` Param/module trimmings public.