### PR TITLE
finagle-core: make ApertureLoadBandBalancer public

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/Aperture.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/Aperture.scala
@@ -67,7 +67,6 @@ object ApertureBalancerFactory extends WeightedLoadBalancerFactory {
 }
 
 
-
 /**
  * The aperture load-band balancer balances load to the smallest
  * subset ("aperture") of services so that:
@@ -102,7 +101,7 @@ object ApertureBalancerFactory extends WeightedLoadBalancerFactory {
  *     arranges load in a manner that ensures a higher level of per-service
  *     concurrency.
  */
-private class ApertureLoadBandBalancer[Req, Rep](
+class ApertureLoadBandBalancer[Req, Rep](
     protected val activity: Activity[Traversable[(ServiceFactory[Req, Rep], Double)]],
     protected val smoothWin: Duration = 5.seconds,
     protected val lowLoad: Double = 0.5,
@@ -143,7 +142,7 @@ object Aperture {
  * harmless to adjust apertures frequently, since underlying nodes
  * are typically backed by pools, and will be warm on average.
  */
-private trait Aperture[Req, Rep] { self: Balancer[Req, Rep] =>
+trait Aperture[Req, Rep] { self: Balancer[Req, Rep] =>
   import Aperture._
 
   protected def rng: Rng


### PR DESCRIPTION
Problem
I want to use the Aperture LoadBalancerFactory with custom values.
The class is private, so we are unable to create a new object that instantiates the ApertureLoadBandBalancer class.
I also want to experiment with creating load balancers with the Aperture trait mixed in, however I am unable to do that because it's private as well.

Solution
Make both the class and the trait public.

Result
You should be able to instantiate ApertureLoadBandBalancer and also create a custom load balancer with the Aperture trait mixed in.