### PR TITLE
Adding Hopper to Finagle adopters

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -15,6 +15,7 @@ URLs if possible) and [submit a pull request][1]!
 * [Green Man Gaming](http://www.greenmangaming.com/)
 * [Gutefrage.net](http://www.gutefrage.net/)
   * ["Introducing Gutefrage.net's Service-Oriented Architecture"][2]
+* [Hopper](https://www.hopper.com/)
 * [Magine TV](https://magine.com/)
 * [Nest](https://nest.com/)
 * The [New York Times](http://www.nytimes.com/)


### PR DESCRIPTION
Hopper uses Finagle for almost all services and service clients, including its mobile app API.