### PR TITLE
LoadService may fail with StackOverflowError's

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/util/LoadService.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/util/LoadService.scala
@@ -68,7 +68,13 @@ private object ClassPath {
     ents
   }
 
-  private[finagle] def browseUri(uri: URI, loader: ClassLoader, buf: mutable.Buffer[Info], history: mutable.Set[String] = mutable.Set[String]()) {
+  private[finagle] def browseUri(
+    uri: URI,
+    loader: ClassLoader,
+    buf: mutable.Buffer[Info],
+    history: mutable.Set[String] = mutable.Set[String]()
+  ): Unit = {
+
     if (uri.getScheme != "file")
       return
     val f = new File(uri)

--- a/finagle-core/src/main/scala/com/twitter/finagle/util/LoadService.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/util/LoadService.scala
@@ -68,17 +68,22 @@ private object ClassPath {
     ents
   }
 
-  private[finagle] def browseUri(uri: URI, loader: ClassLoader, buf: mutable.Buffer[Info]) {
+  private[finagle] def browseUri(uri: URI, loader: ClassLoader, buf: mutable.Buffer[Info], history: mutable.Set[String] = mutable.Set[String]()) {
     if (uri.getScheme != "file")
       return
     val f = new File(uri)
     if (!(f.exists() && f.canRead))
       return
+    val path = f.getCanonicalPath
+    if (history.contains(path))
+      return
+
+    history.add(path)
 
     if (f.isDirectory)
       browseDir(f, loader, "", buf)
     else
-      browseJar(f, loader, buf)
+      browseJar(f, loader, buf, history)
   }
 
   private def browseDir(
@@ -97,14 +102,14 @@ private object ClassPath {
       }
   }
 
-  private def browseJar(file: File, loader: ClassLoader, buf: mutable.Buffer[Info]) {
+  private def browseJar(file: File, loader: ClassLoader, buf: mutable.Buffer[Info], history: mutable.Set[String]) {
     val jarFile = try new JarFile(file) catch {
       case _: IOException => return  // not a Jar file
     }
 
     try {
       for (uri <- jarClasspath(file, jarFile.getManifest))
-        browseUri(uri, loader, buf)
+        browseUri(uri, loader, buf, history)
 
       for {
         e <- jarFile.entries.asScala


### PR DESCRIPTION
When some jars in classpath reference each other by the Class-Path manifest header,
the LoadService may result in infinite loop and fail with a StackOverflowError.

Solution

Keep a track of the browsed files, and do nothing if the referenced jar has
already been browsed.