### PR TITLE
Updated fingalge-thrift server/client examples

### DIFF
--- a/finagle-example/src/main/scala/com/twitter/finagle/example/thrift/ThriftClient.scala
+++ b/finagle-example/src/main/scala/com/twitter/finagle/example/thrift/ThriftClient.scala
@@ -1,15 +1,33 @@
 package com.twitter.finagle.example.thrift
 
+import java.net.InetSocketAddress
+
+import org.apache.thrift.protocol.TBinaryProtocol
+
+import com.twitter.finagle.{Service}
+import com.twitter.finagle.builder.ClientBuilder
 import com.twitter.finagle.example.thriftscala.Hello
-import com.twitter.finagle.Thrift
+import com.twitter.finagle.thrift.{ThriftClientFramedCodec, ThriftClientRequest}
 import com.twitter.util.Future
+
 
 object ThriftClient {
   def main(args: Array[String]) {
     //#thriftclientapi
-    val client = Thrift.newIface[Hello.FutureIface]("localhost:8080")
+    val service: Service[ThriftClientRequest, Array[Byte]] = ClientBuilder()
+      .hosts(new InetSocketAddress(8080))
+      .build()
+
+    val client = new Hello.FinagledClient(
+      service, new TBinaryProtocol.Factory()
+    )
+
     client.hi() onSuccess { response =>
       println("Received response: " + response)
+      service.close()
+    } onFailure { exp =>
+      println("Received exception: " + exp)
+      service.close()
     }
     //#thriftclientapi
   }

--- a/finagle-example/src/main/scala/com/twitter/finagle/example/thrift/ThriftServer.scala
+++ b/finagle-example/src/main/scala/com/twitter/finagle/example/thrift/ThriftServer.scala
@@ -1,16 +1,30 @@
 package com.twitter.finagle.example.thrift
 
+import java.net.InetSocketAddress
+
+import org.apache.thrift.protocol.TBinaryProtocol
+
+import com.twitter.finagle.builder.{ServerBuilder, Server}
 import com.twitter.finagle.example.thriftscala.Hello
-import com.twitter.finagle.Thrift
+import com.twitter.finagle.thrift.ThriftServerFramedCodec
 import com.twitter.util.{Await, Future}
 
 object ThriftServer {
   def main(args: Array[String]) {
     //#thriftserverapi
-    val server = Thrift.serveIface("localhost:8080", new Hello[Future] {
-      def hi() = Future.value("hi")
-    })
-    Await.ready(server)
+    val impl = new Hello.FutureIface {
+      def hi() = {
+        Future("hi")
+      }
+    }
+
+    val service = new Hello.FinagledService(impl, new TBinaryProtocol.Factory())
+
+    val server: Server = ServerBuilder()
+      .bindTo(new InetSocketAddress(8080))
+      .codec(ThriftServerFramedCodec())
+      .name(Hello.toString)
+      .build(service)
     //#thriftserverapi
   }
 }


### PR DESCRIPTION
## Problem

Was getting the following error when executing the `finagle-thrift` examples. Not sure what was happening. 

```
finagle (develop|+1) ~࿔ ./sbt "finagle-example/run-main com.twitter.finagle.example.thrift.ThriftClient"
[info] Loading global plugins from /Users/adamc/.sbt/0.13/plugins
[info] Loading project definition from /git/finagle/project
[info] Set current project to finagle (in build file:/git/finagle/)
[warn] Multiple resolvers having different access mechanism configured with same name 'publish-m2-local'. To avoid conflict, Remove duplicate project resolvers (`resolvers`) or rename publishing resolver (`publishTo`).
...
[warn] Multiple resolvers having different access mechanism configured with same name 'publish-m2-local'. To avoid conflict, Remove duplicate project resolvers (`resolvers`) or rename publishing resolver (`publishTo`).
[info] Running com.twitter.finagle.example.thrift.ThriftClient
Jul 10, 2015 3:30:11 PM com.twitter.finagle.Init$$anonfun$1 apply$mcV$sp
INFO: Finagle version 6.26.0-SNAPSHOT (rev=26dae347b9ce7806d02f781ebbe528e86b724924) built at 20150710-153010
Jul 10, 2015 3:30:11 PM com.twitter.finagle.AsyncInetResolver <init>
INFO: networkaddress.cache.ttl is not set, DNS cache refresh turned off
[success] Total time: 2 s, completed Jul 10, 2015 3:30:11 PM
```

## Solution

Went ahead and updated the examples using the server/client builder API. It is a little more complicated, though seems to work now...

## Result

```
finagle (develop|+3) ~࿔ ./sbt "finagle-example/run-main com.twitter.finagle.example.thrift.ThriftClient"
[info] Loading global plugins from /Users/adamc/.sbt/0.13/plugins
[info] Loading project definition from /git/finagle/project
[info] Set current project to finagle (in build file:/git/finagle/)
[warn] Multiple resolvers having different access mechanism configured with same name 'publish-m2-local'. To avoid conflict, Remove duplicate project resolvers (`resolvers`) or rename publishing resolver (`publishTo`).
...
[warn] Multiple resolvers having different access mechanism configured with same name 'publish-m2-local'. To avoid conflict, Remove duplicate project resolvers (`resolvers`) or rename publishing resolver (`publishTo`).
[info] Running com.twitter.finagle.example.thrift.ThriftClient
Jul 10, 2015 4:18:13 PM com.twitter.finagle.Init$$anonfun$1 apply$mcV$sp
INFO: Finagle version 6.26.0-SNAPSHOT (rev=26dae347b9ce7806d02f781ebbe528e86b724924) built at 20150710-161812
Received response: hi
```

Can add tests if necessary. 


To execute client code
`./sbt "finagle-example/run-main com.twitter.finagle.example.thrift.ThriftClient"`

To execute server code
`./sbt "finagle-example/run-main com.twitter.finagle.example.thrift.ThriftServer"`