### PR TITLE
Introduce ServiceFactorySocketAddress so that Names may bind local services.

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/Namer.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/Namer.scala
@@ -247,8 +247,11 @@ abstract class AbstractNamer extends Namer
  *
  * Implementers with a 0-argument constructor may be named and
  * auto-loaded with `/$/pkg.cls` syntax.
+ *
+ * Note that this can't actually be accomplished in a type-safe manner
+ * since the naming step obscures the service's type to observers.
  */
-trait ServiceNamer[-Req, +Rep] extends Namer {
+trait ServiceNamer[Req, Rep] extends Namer {
 
   def lookupService(path: Path): Option[Service[Req, Rep]]
 
@@ -262,6 +265,8 @@ trait ServiceNamer[-Req, +Rep] extends Namer {
       Activity.value(NameTree.Leaf(name))
   }
 }
+
+
 
 package namer {
   final class global extends Namer {

--- a/finagle-core/src/main/scala/com/twitter/finagle/Namer.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/Namer.scala
@@ -242,6 +242,27 @@ object Namer  {
  */
 abstract class AbstractNamer extends Namer
 
+/**
+ * Base-trait for Namers that bind to a local Service.
+ *
+ * Implementers with a 0-argument constructor may be named and
+ * auto-loaded with `/$/pkg.cls` syntax.
+ */
+trait ServiceNamer[-Req, +Rep] extends Namer {
+
+  def lookupService(path: Path): Option[Service[Req, Rep]]
+
+  def lookup(path: Path): Activity[NameTree[Name]] = lookupService(path) match {
+    case None =>
+      Activity.value(NameTree.Neg)
+    case Some(svc) =>
+      val factory = ServiceFactory(() => Future.value(svc))
+      val addr = Addr.Bound(ServiceFactorySocketAddress(factory))
+      val name = Name.Bound(Var.value(addr), factory, path)
+      Activity.value(NameTree.Leaf(name))
+  }
+}
+
 package namer {
   final class global extends Namer {
     def lookup(path: Path) = Namer.global.lookup(path)

--- a/finagle-core/src/main/scala/com/twitter/finagle/Service.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/Service.scala
@@ -223,6 +223,9 @@ abstract class ServiceFactoryProxy[-Req, +Rep](_self: ServiceFactory[Req, Rep])
   def self: ServiceFactory[Req, Rep] = _self
 }
 
+case class ServiceFactorySocketAddress[-Req, +Rep](factory: ServiceFactory[Req, Rep])
+  extends SocketAddress
+
 object FactoryToService {
   val role = Stack.Role("FactoryToService")
 

--- a/finagle-core/src/main/scala/com/twitter/finagle/Service.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/Service.scala
@@ -223,7 +223,7 @@ abstract class ServiceFactoryProxy[-Req, +Rep](_self: ServiceFactory[Req, Rep])
   def self: ServiceFactory[Req, Rep] = _self
 }
 
-case class ServiceFactorySocketAddress[-Req, +Rep](factory: ServiceFactory[Req, Rep])
+case class ServiceFactorySocketAddress[Req, Rep](factory: ServiceFactory[Req, Rep])
   extends SocketAddress
 
 object FactoryToService {

--- a/finagle-core/src/test/scala/com/twitter/finagle/NamerTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/NamerTest.scala
@@ -1,6 +1,6 @@
 package com.twitter.finagle
 
-import com.twitter.util.{Return, Throw, Activity, Witness, Try}
+import com.twitter.util.{Await, Future, Return, Throw, Activity, Witness, Try}
 import java.net.{InetSocketAddress, SocketAddress}
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
@@ -194,6 +194,53 @@ class NamerTest extends FunSuite with AssertionsForJUnit {
       === NameTree.Leaf(Name.Path(Path.Utf8("bar"))))
   }
 
+  test("Namer.global: /$/{className} ServiceNamer") {
+    val dst = Path.read("/$/com.twitter.finagle.PathServiceNamer/foo")
+    Namer.global.lookup(dst).sample() match {
+      case NameTree.Leaf(bound: Name.Bound) =>
+        assert(bound.path == Path.Utf8("foo"))
+        bound.addr.sample() match {
+          case bound: Addr.Bound =>
+            assert(bound.addrs.size == 1)
+            bound.addrs.head match {
+              case ServiceFactorySocketAddress(sf: ServiceFactory[Path, Path]) =>
+                val svc = Await.result(sf())
+                val rsp = Await.result(svc(Path.Utf8("yodles")))
+                assert(rsp == Path.Utf8("foo", "yodles"))
+
+              case sa =>
+                fail("$sa not a ServiceFactorySocketAddress")
+            }
+        }
+      case nt =>
+        fail(s"$nt is not NameTree.Leaf")
+    }
+  }
+
+  test("Namer.global: /$/{className} ServiceNamer of incompatible type raises ClassCastException") {
+    val dst = Path.read("/$/com.twitter.finagle.PathServiceNamer/foo")
+    Namer.global.lookup(dst).sample() match {
+      case NameTree.Leaf(bound: Name.Bound) =>
+        assert(bound.path == Path.Utf8("foo"))
+        bound.addr.sample() match {
+          case bound: Addr.Bound =>
+            assert(bound.addrs.size == 1)
+            bound.addrs.head match {
+              case ServiceFactorySocketAddress(sf: ServiceFactory[Int, Int]) =>
+                val svc = Await.result(sf())
+                intercept [ClassCastException] {
+                  val rsp = Await.result(svc(3))
+                }
+
+              case sa =>
+                fail("$sa not a ServiceFactorySocketAddress")
+            }
+        }
+      case nt =>
+        fail(s"$nt is not NameTree.Leaf")
+    }
+  }
+
   test("Namer.global: negative resolution") {
     assert(Namer.global.lookup(Path.read("/foo/bar/bah/blah")).sample()
         === NameTree.Neg)
@@ -216,4 +263,11 @@ class TestNamer extends Namer {
         case Path.Utf8("foo") => NameTree.Leaf(Name.Path(Path.Utf8("bar")))
         case _ => NameTree.Neg
       })
+}
+
+class PathServiceNamer extends ServiceNamer[Path, Path] {
+  def lookupService(pfx: Path) = {
+    val svc = Service.mk[Path, Path] { req => Future.value(pfx ++ req) }
+    Some(svc)
+  }
 }

--- a/finagle-core/src/test/scala/com/twitter/finagle/client/StackClientTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/client/StackClientTest.scala
@@ -399,7 +399,7 @@ class StackClientTest extends FunSuite
       client.configured[param.Label]((param.Label("foo"), param.Label.param))
   }
 
-  test("ServiceFactorySocketAddress bypasses transporter") {
+  test("StackClient binds to a local service via ServiceFactorySocketAddress") {
     val reverser = Service.mk[String, String] { in => Future.value(in.reverse) }
     val sf = ServiceFactory[String, String](() => Future.value(reverser))
     val sa = ServiceFactorySocketAddress[String, String](sf)

--- a/finagle-core/src/test/scala/com/twitter/finagle/client/StackClientTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/client/StackClientTest.scala
@@ -1,5 +1,6 @@
 package com.twitter.finagle.client
 
+import com.twitter.conversions.time._
 import com.twitter.finagle.Stack.Module0
 import com.twitter.finagle._
 import com.twitter.finagle.factory.BindingFactory
@@ -396,5 +397,17 @@ class StackClientTest extends FunSuite
       client.configured(param.Label("foo"))
     val client3: StackClient[String, String] =
       client.configured[param.Label]((param.Label("foo"), param.Label.param))
+  }
+
+  test("ServiceFactorySocketAddress bypasses transporter") {
+    val reverser = Service.mk[String, String] { in => Future.value(in.reverse) }
+    val sf = ServiceFactory[String, String](() => Future.value(reverser))
+    val sa = ServiceFactorySocketAddress[String, String](sf)
+    val addr = Var.value(Addr.Bound(sa))
+    val name = Name.Bound(addr, new {})
+    val service = stringClient.newService(name, "sfsa-test")
+    val forward = "a man a plan a canal: panama"
+    val reversed = Await.result(service(forward), 1.second)
+    assert(reversed == forward.reverse)
   }
 }


### PR DESCRIPTION
Problem:

When building a client using a Name--i.e. via Dtabs--there is no mechanism to
cause a client to bind to a local Service reference.  Consider the following example:

A program--zoo--that exposes exposes an http endpoint /api/birds; and satisfying these requests requires a downstream client to a service--/s/birds.

We may typically run zoo with a base dtab like:

  /s => /$/io.bouyant.sd

/s/birds may be served by a downstream service, but it may also be
served from directly within the process (e.g. by an in-memory buffer).
This situation may arise when migrating functionality between
processes (e.g. decomposing a service) or mocking downstream
clients. In these cases, we want these requests routed in-process with
a dentry like:

  /s/birds => /$/io.buoyant.birds.local

The workaround today is to have zoo bind to an ephemeral port and
control redirects to that ephemeral port:

  /localPort => /$/inet/127.1
  /s/birds => /localPort/${birdsPort}

However, this approach incurs a full roundtrip through the networking stack.

Solution:

Introduce a SocketAddress type that encapsulates a ServiceFactory.
StdStackClient's default endpointer bypasses the client's Transporter when such
an address is encountered.

Result:

Local services may be named.