### PR TITLE
Fix memcached error parsing

### DIFF
--- a/finagle-memcachedx/src/main/scala/com/twitter/finagle/memcachedx/protocol/text/client/DecodingToResponse.scala
+++ b/finagle-memcachedx/src/main/scala/com/twitter/finagle/memcachedx/protocol/text/client/DecodingToResponse.scala
@@ -73,6 +73,6 @@ class DecodingToResponse extends AbstractDecodingToResponse[Response] {
   }
 
   private[this] def parseErrorMessage(tokens: Seq[Buf]) =
-    tokens.lastOption map { case Buf.Utf8(s) => s } getOrElse("")
+    tokens.drop(1).map { case Buf.Utf8(s) => s }.mkString(" ")
 
 }


### PR DESCRIPTION
Problem
parseErrorMessage only returns the last string, instead of the entire message.
i.e. FAT [20150721-20:26:43.792] memcache: com.twitter.finagle.memcached.protocol.ServerError: object

Solution
Parse all of the tokens instead of the head.

Result
com.twitter.finagle.memcached.protocol.ServerError: out of memory storing object