### PR TITLE
Server-side wire tracing.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,9 @@ Runtime Behavior Changes
   * finagle-core: `RetryPolicy.tries` now uses jittered backoffs instead of
     having no delay. ``RB_ID=752629``
 
+  * finagle-core: Introduce WireRecv & WireSend tracing into Finagle servers.  Now WireRecv
+    annotations are always recorded on message ingress and WireSend on egress.
+
 Breaking API Changes
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/finagle-core/src/main/scala/com/twitter/finagle/client/StackClient.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/client/StackClient.scala
@@ -52,7 +52,7 @@ object StackClient {
 
     val stk = new StackBuilder[ServiceFactory[Req, Rep]](nilStack[Req, Rep])
     stk.push(Role.prepConn, identity[ServiceFactory[Req, Rep]](_))
-    stk.push(WireTracingFilter.module)
+    stk.push(WireTracingFilter.clientModule)
     stk.push(ExpiringService.module)
     stk.push(FailFastFactory.module)
     stk.push(DefaultPool.module)

--- a/finagle-core/src/main/scala/com/twitter/finagle/server/StackServer.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/server/StackServer.scala
@@ -66,10 +66,10 @@ object StackServer {
     stk.push(Role.protoTracing, identity[ServiceFactory[Req, Rep]](_))
     stk.push(ServerTracingFilter.module)
     stk.push(Role.preparer, identity[ServiceFactory[Req, Rep]](_))
+    stk.push(WireTracingFilter.serverModule)
     // The TraceInitializerFilter must be pushed after most other modules so that
     // any Tracing produced by those modules is enclosed in the appropriate
     // span.
-    stk.push(WireTracingFilter.serverModule)
     stk.push(TraceInitializerFilter.serverModule)
     stk.push(MonitorFilter.module)
     stk.result

--- a/finagle-core/src/main/scala/com/twitter/finagle/server/StackServer.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/server/StackServer.scala
@@ -44,6 +44,7 @@ object StackServer {
    * @see [[com.twitter.finagle.filter.ExceptionSourceFilter]]
    * @see [[com.twitter.finagle.filter.MkJvmFilter]]
    * @see [[com.twitter.finagle.tracing.ServerTracingFilter]]
+   * @see [[com.twitter.finagle.tracing.WireTracingFilter]]
    * @see [[com.twitter.finagle.tracing.TraceInitializerFilter]]
    * @see [[com.twitter.finagle.filter.MonitorFilter]]
    * @see [[com.twitter.finagle.filter.ServerStatsFilter]]

--- a/finagle-core/src/main/scala/com/twitter/finagle/server/StackServer.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/server/StackServer.scala
@@ -52,7 +52,6 @@ object StackServer {
     val stk = new StackBuilder[ServiceFactory[Req, Rep]](
       stack.nilStack[Req, Rep])
 
-    stk.push(WireTracingFilter.serverModule)
     stk.push(Role.serverDestTracing, ((next: ServiceFactory[Req, Rep]) =>
       new ServerDestTracingProxy[Req, Rep](next)))
     stk.push(TimeoutFilter.serverModule)
@@ -70,6 +69,7 @@ object StackServer {
     // The TraceInitializerFilter must be pushed after most other modules so that
     // any Tracing produced by those modules is enclosed in the appropriate
     // span.
+    stk.push(WireTracingFilter.serverModule)
     stk.push(TraceInitializerFilter.serverModule)
     stk.push(MonitorFilter.module)
     stk.result

--- a/finagle-core/src/main/scala/com/twitter/finagle/server/StackServer.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/server/StackServer.scala
@@ -52,6 +52,7 @@ object StackServer {
     val stk = new StackBuilder[ServiceFactory[Req, Rep]](
       stack.nilStack[Req, Rep])
 
+    stk.push(WireTracingFilter.serverModule)
     stk.push(Role.serverDestTracing, ((next: ServiceFactory[Req, Rep]) =>
       new ServerDestTracingProxy[Req, Rep](next)))
     stk.push(TimeoutFilter.serverModule)

--- a/finagle-core/src/main/scala/com/twitter/finagle/server/StackServer.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/server/StackServer.scala
@@ -44,6 +44,7 @@ object StackServer {
    * @see [[com.twitter.finagle.filter.ExceptionSourceFilter]]
    * @see [[com.twitter.finagle.filter.MkJvmFilter]]
    * @see [[com.twitter.finagle.tracing.ServerTracingFilter]]
+   * @see [[com.twitter.finagle.filter.HandletimeFilter]]
    * @see [[com.twitter.finagle.tracing.WireTracingFilter]]
    * @see [[com.twitter.finagle.tracing.TraceInitializerFilter]]
    * @see [[com.twitter.finagle.filter.MonitorFilter]]

--- a/finagle-core/src/main/scala/com/twitter/finagle/tracing/TraceInitializerFilter.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/tracing/TraceInitializerFilter.scala
@@ -258,11 +258,11 @@ private[finagle] object WireTracingFilter {
       def make(next: ServiceFactory[Req, Rep]) = filter andThen next
 
       object filter extends Filter[Req, Rep, Req, Rep] {
+        private[this] def recv(): Unit = Trace.record(Annotation.WireRecv)
+        private[this] def send(rsp: Rep): Unit = Trace.record(Annotation.WireSend)
         def apply(req: Req, service: Service[Req, Rep]) = {
-          Trace.record(Annotation.WireRecv)
-          service(req).onSuccess { _ =>
-            Trace.record(Annotation.WireSend)
-          }
+          recv()
+          service(req).onSuccess(send)
         }
       }
     }

--- a/finagle-core/src/main/scala/com/twitter/finagle/tracing/TraceInitializerFilter.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/tracing/TraceInitializerFilter.scala
@@ -255,13 +255,12 @@ private[finagle] object WireTracingFilter {
     new Stack.Module0[ServiceFactory[Req, Rep]] {
       val role = WireTracingFilter.role
       val description = "Report wire recv/send events"
+      def make(next: ServiceFactory[Req, Rep]) = filter andThen next
       val filter = Filter.mk[Req, Rep, Req, Rep] { (req, svc) =>
         Trace.record(Annotation.WireRecv)
         svc(req) onSuccess { _ =>
-          Trace.record(Annotation.WireRecv)
+          Trace.record(Annotation.WireSend)
         }
       }
-      def make(next: ServiceFactory[Req, Rep]) =
-        filter andThen next
     }
 }

--- a/finagle-core/src/main/scala/com/twitter/finagle/tracing/TraceInitializerFilter.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/tracing/TraceInitializerFilter.scala
@@ -241,7 +241,7 @@ private[finagle] object WireTracingFilter {
     finagleVersion,
     false)
 
-  def module[Req, Rep]: Stackable[ServiceFactory[Req, Rep]] =
+  def clientModule[Req, Rep]: Stackable[ServiceFactory[Req, Rep]] =
     new Stack.Module1[param.Label, ServiceFactory[Req, Rep]] {
       val role = WireTracingFilter.role
       val description = "Report finagle information and wire send/recv events"

--- a/finagle-core/src/main/scala/com/twitter/finagle/tracing/TraceInitializerFilter.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/tracing/TraceInitializerFilter.scala
@@ -257,10 +257,12 @@ private[finagle] object WireTracingFilter {
       val description = "Report wire recv/send events"
       def make(next: ServiceFactory[Req, Rep]) = filter andThen next
 
-      val filter = Filter.mk[Req, Rep, Req, Rep] { (req, svc) =>
-        Trace.record(Annotation.WireRecv)
-        svc(req) onSuccess { _ =>
-          Trace.record(Annotation.WireSend)
+      object filter extends Filter[Req, Rep, Req, Rep] {
+        def apply(req: Req, service: Service[Req, Rep]) = {
+          Trace.record(Annotation.WireRecv)
+          service(req).onSuccess { _ =>
+            Trace.record(Annotation.WireSend)
+          }
         }
       }
     }


### PR DESCRIPTION
Problem:

Clients annotate WireSend and WireRecv at the bottom of the finagle
stack.  There is no analog on the server-side (i.e. a top-of-the-stack
indicator).

Furthermore, it looks like WireTracingFilter.module was using the
ClientTracingFilter.role instead of WireTracingFilter.role. This may
cause client tracing issues?

Solution:

Introduce WireTracingFilter.serverModule at the top of the default
server stack.  This module installs a filter that annotates WireRecv
on receipt and WireSend on success.

Result:

Tracers have a definitive 'top of stack' marker.