### PR TITLE
Fix build.sbt in doc for quickstart

### DIFF
--- a/doc/src/sphinx/Quickstart.rst
+++ b/doc/src/sphinx/Quickstart.rst
@@ -26,9 +26,9 @@ a fresh directory:
 
 .. parsed-literal::
 
-	name = "quickstart"
+	name := "quickstart"
 
-	version = "1.0"
+	version := "1.0"
 
 	libraryDependencies += "com.twitter" %% "finagle-httpx" % "|release|"
 


### PR DESCRIPTION
Replace '=' with ':='