### PR TITLE
fixing erroneous direct construction of Netty3Listener without params in finagle-thrift

### DIFF
--- a/finagle-thrift/src/main/scala/com/twitter/finagle/Thrift.scala
+++ b/finagle-thrift/src/main/scala/com/twitter/finagle/Thrift.scala
@@ -229,7 +229,7 @@ object Thrift extends Client[ThriftClientRequest, Array[Byte]] with ThriftRichCl
         if (framed) thrift.ThriftServerFramedPipelineFactory
         else thrift.ThriftServerBufferedPipelineFactory(protocolFactory)
 
-      Netty3Listener("thrift", pipeline)
+      Netty3Listener(pipeline, params)
     }
 
     protected def newDispatcher(


### PR DESCRIPTION
Greetings Finagle masters,

TL;DR In finagle-thrift (and none of the other protocol libraries), `Netty3Listener` was being constructed directly, without passing in the `params`.

I was originally trying to test the official solution to https://github.com/twitter/finagle/issues/175 and was able to get TLS over Thrift and extraction of the client certificate working using the old builder API, but _not with the new Finagle 6 API_. Eventually I discovered that `apply` on the `Netty3Listener` object was never being called, which led to this adjustment.

@mosesn and I discussed the removal of the hard-coded "thrift" label, and since it's only used as a backup scope for the stats receiver if the `ServerRegistry` doesn't have one for the listening address, and because it's manually configurable by the user, it seemed safe to remove it. I think it was probably only put there anyway because direct use of the constructor requires it.

Thanks to @mosesn @jeremyrsmith for helping me run this to ground.