### PR TITLE
Make ServiceFactoryCache publicly accessible.

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/factory/ServiceFactoryCache.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/factory/ServiceFactoryCache.scala
@@ -58,7 +58,7 @@ private class IdlingFactory[Req, Rep](self: ServiceFactory[Req, Rep])
  * performance: one-shots could be created constantly for a hot cache
  * key, but should work well when there are a few hot keys.
  */
-private class ServiceFactoryCache[Key, Req, Rep](
+class ServiceFactoryCache[Key, Req, Rep](
     newFactory: Key => ServiceFactory[Req, Rep],
     statsReceiver: StatsReceiver = NullStatsReceiver,
     maxCacheSize: Int = 8)


### PR DESCRIPTION
Problem

The logic encapsulated by `ServiceFactoryCache` is generally useful to
applications that build clients in dynamic ways.

Solution

Drop the 'private' classifier from the `ServiceFactoryCache` definition.