### PR TITLE
Removes zipkin annotation.duration

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -26,6 +26,9 @@ Breaking API Changes
     parameterization facilitates using the request to determine if retrying is
     safe (i.e. the request is idempotent).
 
+  * finagle-zipkin: Drops `c.t.zipkin.thrift.Annotation.duration` and associated thrift field
+    `c.t.f.thrift.thrift.Annotation.duration`. ``#420``
+
 Runtime Behavior Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/finagle-thrift/src/main/java/com/twitter/finagle/thrift/thrift/Annotation.java
+++ b/finagle-thrift/src/main/java/com/twitter/finagle/thrift/thrift/Annotation.java
@@ -34,19 +34,16 @@ public class Annotation implements TBase<Annotation, Annotation._Fields>, java.i
   private static final TField TIMESTAMP_FIELD_DESC = new TField("timestamp", TType.I64, (short)1);
   private static final TField VALUE_FIELD_DESC = new TField("value", TType.STRING, (short)2);
   private static final TField HOST_FIELD_DESC = new TField("host", TType.STRUCT, (short)3);
-  private static final TField DURATION_FIELD_DESC = new TField("duration", TType.I32, (short)4);
 
   public long timestamp;
   public String value;
   public Endpoint host;
-  public int duration;
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements TFieldIdEnum {
     TIMESTAMP((short)1, "timestamp"),
     VALUE((short)2, "value"),
-    HOST((short)3, "host"),
-    DURATION((short)4, "duration");
+    HOST((short)3, "host");
 
     private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
 
@@ -67,8 +64,6 @@ public class Annotation implements TBase<Annotation, Annotation._Fields>, java.i
           return VALUE;
         case 3: // HOST
           return HOST;
-        case 4: // DURATION
-          return DURATION;
         default:
           return null;
       }
@@ -122,8 +117,6 @@ public class Annotation implements TBase<Annotation, Annotation._Fields>, java.i
         new FieldValueMetaData(TType.STRING)));
     tmpMap.put(_Fields.HOST, new FieldMetaData("host", TFieldRequirementType.OPTIONAL,
         new StructMetaData(TType.STRUCT, Endpoint.class)));
-    tmpMap.put(_Fields.DURATION, new FieldMetaData("duration", TFieldRequirementType.OPTIONAL,
-        new FieldValueMetaData(TType.I32)));
     metaDataMap = Collections.unmodifiableMap(tmpMap);
     FieldMetaData.addStructMetaDataMap(Annotation.class, metaDataMap);
   }
@@ -154,7 +147,6 @@ public class Annotation implements TBase<Annotation, Annotation._Fields>, java.i
     if (other.isSetHost()) {
       this.host = new Endpoint(other.host);
     }
-    this.duration = other.duration;
   }
 
   public Annotation deepCopy() {
@@ -167,8 +159,6 @@ public class Annotation implements TBase<Annotation, Annotation._Fields>, java.i
     this.timestamp = 0;
     this.value = null;
     this.host = null;
-    setDurationIsSet(false);
-    this.duration = 0;
   }
 
   public long getTimestamp() {
@@ -242,29 +232,6 @@ public class Annotation implements TBase<Annotation, Annotation._Fields>, java.i
     }
   }
 
-  public int getDuration() {
-    return this.duration;
-  }
-
-  public Annotation setDuration(int duration) {
-    this.duration = duration;
-    setDurationIsSet(true);
-    return this;
-  }
-
-  public void unsetDuration() {
-    __isset_bit_vector.clear(__DURATION_ISSET_ID);
-  }
-
-  /** Returns true if field duration is set (has been asigned a value) and false otherwise */
-  public boolean isSetDuration() {
-    return __isset_bit_vector.get(__DURATION_ISSET_ID);
-  }
-
-  public void setDurationIsSet(boolean value) {
-    __isset_bit_vector.set(__DURATION_ISSET_ID, value);
-  }
-
   public void setFieldValue(_Fields field, Object value) {
     switch (field) {
     case TIMESTAMP:
@@ -291,14 +258,6 @@ public class Annotation implements TBase<Annotation, Annotation._Fields>, java.i
       }
       break;
 
-    case DURATION:
-      if (value == null) {
-        unsetDuration();
-      } else {
-        setDuration((Integer)value);
-      }
-      break;
-
     }
   }
 
@@ -312,9 +271,6 @@ public class Annotation implements TBase<Annotation, Annotation._Fields>, java.i
 
     case HOST:
       return getHost();
-
-    case DURATION:
-      return new Integer(getDuration());
 
     }
     throw new IllegalStateException();
@@ -333,8 +289,6 @@ public class Annotation implements TBase<Annotation, Annotation._Fields>, java.i
       return isSetValue();
     case HOST:
       return isSetHost();
-    case DURATION:
-      return isSetDuration();
     }
     throw new IllegalStateException();
   }
@@ -376,15 +330,6 @@ public class Annotation implements TBase<Annotation, Annotation._Fields>, java.i
       if (!(this_present_host && that_present_host))
         return false;
       if (!this.host.equals(that.host))
-        return false;
-    }
-
-    boolean this_present_duration = true && this.isSetDuration();
-    boolean that_present_duration = true && that.isSetDuration();
-    if (this_present_duration || that_present_duration) {
-      if (!(this_present_duration && that_present_duration))
-        return false;
-      if (this.duration != that.duration)
         return false;
     }
 
@@ -434,16 +379,6 @@ public class Annotation implements TBase<Annotation, Annotation._Fields>, java.i
         return lastComparison;
       }
     }
-    lastComparison = Boolean.valueOf(isSetDuration()).compareTo(typedOther.isSetDuration());
-    if (lastComparison != 0) {
-      return lastComparison;
-    }
-    if (isSetDuration()) {
-      lastComparison = TBaseHelper.compareTo(this.duration, typedOther.duration);
-      if (lastComparison != 0) {
-        return lastComparison;
-      }
-    }
     return 0;
   }
 
@@ -484,14 +419,6 @@ public class Annotation implements TBase<Annotation, Annotation._Fields>, java.i
             TProtocolUtil.skip(iprot, field.type);
           }
           break;
-        case 4: // DURATION
-          if (field.type == TType.I32) {
-            this.duration = iprot.readI32();
-            setDurationIsSet(true);
-          } else {
-            TProtocolUtil.skip(iprot, field.type);
-          }
-          break;
         default:
           TProtocolUtil.skip(iprot, field.type);
       }
@@ -522,11 +449,6 @@ public class Annotation implements TBase<Annotation, Annotation._Fields>, java.i
         oprot.writeFieldEnd();
       }
     }
-    if (isSetDuration()) {
-      oprot.writeFieldBegin(DURATION_FIELD_DESC);
-      oprot.writeI32(this.duration);
-      oprot.writeFieldEnd();
-    }
     oprot.writeFieldStop();
     oprot.writeStructEnd();
   }
@@ -555,12 +477,6 @@ public class Annotation implements TBase<Annotation, Annotation._Fields>, java.i
       } else {
         sb.append(this.host);
       }
-      first = false;
-    }
-    if (isSetDuration()) {
-      if (!first) sb.append(", ");
-      sb.append("duration:");
-      sb.append(this.duration);
       first = false;
     }
     sb.append(")");

--- a/finagle-thrift/src/main/thrift/tracing.thrift
+++ b/finagle-thrift/src/main/thrift/tracing.thrift
@@ -48,7 +48,7 @@ struct Annotation {
   1: i64 timestamp                 // microseconds from epoch
   2: string value                  // what happened at the timestamp?
   3: optional Endpoint host        // host this happened on
-  4: optional i32 duration         // how long did the operation take? microseconds
+  // don't reuse 4: optional i32 OBSOLETE_duration         // how long did the operation take? microseconds
 }
 
 enum AnnotationType { BOOL, BYTES, I16, I32, I64, DOUBLE, STRING }

--- a/finagle-zipkin/src/main/scala/com/twitter/finagle/zipkin/thrift/Annotation.scala
+++ b/finagle-zipkin/src/main/scala/com/twitter/finagle/zipkin/thrift/Annotation.scala
@@ -1,7 +1,7 @@
 package com.twitter.finagle.zipkin.thrift
 
 import com.twitter.finagle.thrift.thrift
-import com.twitter.util.{Duration, Time}
+import com.twitter.util.Time
 import java.nio.ByteBuffer
 
 /**
@@ -10,8 +10,7 @@ import java.nio.ByteBuffer
 case class ZipkinAnnotation(
   timestamp: Time,
   value:     String,
-  endpoint:  Endpoint,
-  duration:  Option[Duration]
+  endpoint:  Endpoint
 ) {
 
   def toThrift: thrift.Annotation = {
@@ -20,7 +19,6 @@ case class ZipkinAnnotation(
     thriftAnnotation.setTimestamp(timestamp.inMicroseconds)
     thriftAnnotation.setValue(value)
     thriftAnnotation.setHost(localEndpoint)
-    duration foreach { d => thriftAnnotation.setDuration(d.inMicroseconds.toInt) }
 
     thriftAnnotation
   }

--- a/finagle-zipkin/src/main/scala/com/twitter/finagle/zipkin/thrift/DeadlineSpanMap.scala
+++ b/finagle-zipkin/src/main/scala/com/twitter/finagle/zipkin/thrift/DeadlineSpanMap.scala
@@ -66,7 +66,7 @@ private class DeadlineSpanMap(
       val span = kv.getValue
       if (span.started <= deadline) {
         spanMap.remove(kv.getKey, span)
-        span.addAnnotation(ZipkinAnnotation(deadline, "finagle.flush", span.endpoint, None))
+        span.addAnnotation(ZipkinAnnotation(deadline, "finagle.flush", span.endpoint))
         ss.append(span.toSpan)
       }
     }

--- a/finagle-zipkin/src/main/scala/com/twitter/finagle/zipkin/thrift/RawZipkinTracer.scala
+++ b/finagle-zipkin/src/main/scala/com/twitter/finagle/zipkin/thrift/RawZipkinTracer.scala
@@ -308,7 +308,7 @@ private[thrift] class RawZipkinTracer(
    */
   protected def annotate(record: Record, value: String) {
     spanMap.update(record.traceId) { span =>
-      span.addAnnotation(ZipkinAnnotation(record.timestamp, value, span.endpoint, record.duration))
+      span.addAnnotation(ZipkinAnnotation(record.timestamp, value, span.endpoint))
     }
   }
 }

--- a/finagle-zipkin/src/test/scala/com/twitter/finagle/zipkin/thrift/AnnotationTest.scala
+++ b/finagle-zipkin/src/test/scala/com/twitter/finagle/zipkin/thrift/AnnotationTest.scala
@@ -2,14 +2,13 @@ package com.twitter.finagle.zipkin.thrift
 
 import org.scalatest.FunSuite
 import com.twitter.util.Time
-import com.twitter.util.TimeConversions._
 import org.scalatest.junit.JUnitRunner
 import org.junit.runner.RunWith
 
 @RunWith(classOf[JUnitRunner])
 class AnnotationTest extends FunSuite {
   test("ZipkinAnnotation should serialize properly") {
-    val ann = ZipkinAnnotation(Time.fromSeconds(123), "value", Endpoint(123, 123), Some(1.second))
+    val ann = ZipkinAnnotation(Time.fromSeconds(123), "value", Endpoint(123, 123))
     val tann = ann.toThrift
 
     assert(tann.isSetHost)
@@ -19,7 +18,5 @@ class AnnotationTest extends FunSuite {
     assert(tann.value === ann.value)
     assert(tann.isSetTimestamp)
     assert(tann.timestamp === ann.timestamp.inMicroseconds)
-    assert(tann.isSetDuration)
-    assert(tann.duration === ann.duration.get.inMicroseconds)
   }
 }

--- a/finagle-zipkin/src/test/scala/com/twitter/finagle/zipkin/thrift/RawZipkinTracerTest.scala
+++ b/finagle-zipkin/src/test/scala/com/twitter/finagle/zipkin/thrift/RawZipkinTracerTest.scala
@@ -34,11 +34,11 @@ class RawZipkinTracerTest extends FunSuite {
     val remoteEndpoint = Endpoint(333, 22)
 
     val annotations = Seq(
-      ZipkinAnnotation(Time.fromSeconds(123), "cs", localEndpoint, None),
-      ZipkinAnnotation(Time.fromSeconds(126), "cr", localEndpoint, None),
-      ZipkinAnnotation(Time.fromSeconds(123), "ss", remoteEndpoint, None),
-      ZipkinAnnotation(Time.fromSeconds(124), "sr", remoteEndpoint, None),
-      ZipkinAnnotation(Time.fromSeconds(123), "llamas", localEndpoint, None)
+      ZipkinAnnotation(Time.fromSeconds(123), "cs", localEndpoint),
+      ZipkinAnnotation(Time.fromSeconds(126), "cr", localEndpoint),
+      ZipkinAnnotation(Time.fromSeconds(123), "ss", remoteEndpoint),
+      ZipkinAnnotation(Time.fromSeconds(124), "sr", remoteEndpoint),
+      ZipkinAnnotation(Time.fromSeconds(123), "llamas", localEndpoint)
     )
 
     val span = Span(

--- a/finagle-zipkin/src/test/scala/com/twitter/finagle/zipkin/thrift/SpanTest.scala
+++ b/finagle-zipkin/src/test/scala/com/twitter/finagle/zipkin/thrift/SpanTest.scala
@@ -3,14 +3,13 @@ package com.twitter.finagle.zipkin.thrift
 import org.scalatest.FunSuite
 import com.twitter.util.Time
 import com.twitter.finagle.tracing.{Flags, SpanId, TraceId}
-import com.twitter.util.TimeConversions._
 import org.scalatest.junit.JUnitRunner
 import org.junit.runner.RunWith
 
 @RunWith(classOf[JUnitRunner])
 class SpanTest extends FunSuite {
   test("Span should serialize properly") {
-    val ann = ZipkinAnnotation(Time.now, "value", Endpoint(1, 2), Some(1.second))
+    val ann = ZipkinAnnotation(Time.now, "value", Endpoint(1, 2))
     val traceId = TraceId(Some(SpanId(123)), Some(SpanId(123)), SpanId(123), None, Flags().setDebug)
     val span = Span(traceId, Some("service"), Some("name"), Seq(ann), Seq(), Endpoint(123, 123))
 
@@ -18,7 +17,6 @@ class SpanTest extends FunSuite {
     assert(tspan.isSetAnnotations)
     val host = tspan.getAnnotations.get(0).getHost
     assert(host.getService_name === "service")
-    assert(tspan.getAnnotations.get(0).getDuration === 1 * 1000 * 1000)
     assert(tspan.isSetName)
     assert(tspan.getName === "name")
     !tspan.isSetBinary_annotations


### PR DESCRIPTION
The OpenZipkin project dropped support for Annotation.duration. This
field was rarely used, and when used often incorrectly. Moreover, the
zipkin query and web interfaces didn't support it. Dropping it
implicitly fixed bugs and confusion around the topic. This happened in
zipkin 1.9, and finagle-zipkin is the last trace instrumentation library
left to adjust.

See https://github.com/openzipkin/zipkin/pull/717