### PR TITLE
Optimize Filter.andThen

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/Filter.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/Filter.scala
@@ -52,6 +52,8 @@ abstract class Filter[-ReqIn, +RepOut, +ReqOut, -RepIn]
    */
   def andThen[Req2, Rep2](next: Filter[ReqOut, RepIn, Req2, Rep2]): Filter[ReqIn, RepOut, Req2, Rep2] =
     if (next eq Filter.identity) this.asInstanceOf[Filter[ReqIn, RepOut, Req2, Rep2]]
+    // Rewrites Filter composition via `andThen` with AndThen's composition
+    // which is just function composition.
     else AndThen(service => andThen(next.andThen(service)))
 
   /**
@@ -109,15 +111,17 @@ abstract class Filter[-ReqIn, +RepOut, +ReqOut, -RepIn]
 abstract class SimpleFilter[Req, Rep] extends Filter[Req, Rep, Req, Rep]
 
 object Filter {
+  // `AndThen` is a function that represents the prefix of the filter chain to
+  // transform a terminal Service received as an argument.
   private case class AndThen[ReqIn, RepOut, ReqOut, RepIn](
-      build: Service[ReqOut, RepIn] => Service[ReqIn, RepOut]
-  )
+      build: Service[ReqOut, RepIn] => Service[ReqIn, RepOut])
     extends Filter[ReqIn, RepOut, ReqOut, RepIn]
   {
     override def andThen[Req2, Rep2](
       next: Filter[ReqOut, RepIn, Req2, Rep2]
     ): Filter[ReqIn, RepOut, Req2, Rep2] =
-      AndThen(service => build(next.andThen(service)))
+      if (next eq Filter.identity) this.asInstanceOf[Filter[ReqIn, RepOut, Req2, Rep2]]
+      else AndThen(service => build(next.andThen(service)))
 
     override def andThen(service: Service[ReqOut, RepIn]): Service[ReqIn, RepOut] =
       build(service)
@@ -141,15 +145,13 @@ object Filter {
 
   private case object Identity extends SimpleFilter[Any, Nothing] {
     override def andThen[Req2, Rep2](
-      next: Filter[Any, Nothing, Req2, Rep2]
-    ): Filter[Any, Nothing, Req2, Rep2] = next
+      next: Filter[Any, Nothing, Req2, Rep2]): Filter[Any, Nothing, Req2, Rep2] = next
 
     override def andThen(service: Service[Any, Nothing]): Service[Any, Nothing] = service
 
     override def andThen(factory: ServiceFactory[Any, Nothing]): ServiceFactory[Any, Nothing] = factory
 
-    def apply(request: Any, service: Service[Any, Nothing]): Future[Nothing] =
-      service(request)
+    def apply(request: Any, service: Service[Any, Nothing]): Future[Nothing] = service(request)
   }
 
   implicit def canStackFromSvc[Req, Rep]

--- a/finagle-core/src/main/scala/com/twitter/finagle/Filter.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/Filter.scala
@@ -27,6 +27,8 @@ import com.twitter.util.{NonFatal, Future, Time}
 abstract class Filter[-ReqIn, +RepOut, +ReqOut, -RepIn]
   extends ((ReqIn, Service[ReqOut, RepIn]) => Future[RepOut])
 {
+  import Filter.AndThen
+
   /**
    * This is the method to override/implement to create your own Filter.
    *
@@ -48,28 +50,9 @@ abstract class Filter[-ReqIn, +RepOut, +ReqOut, -RepIn]
    *
    * @param next another filter to follow after this one
    */
-  def andThen[Req2, Rep2](next: Filter[ReqOut, RepIn, Req2, Rep2]) =
-    new Filter[ReqIn, RepOut, Req2, Rep2] {
-      def apply(request: ReqIn, service: Service[Req2, Rep2]) = {
-        val svc: Service[ReqOut, RepIn] = new Service[ReqOut, RepIn] with Proxy {
-          // note that while `Service.rescue` could be used here it would
-          // entail an extra allocation.
-          def apply(request: ReqOut): Future[RepIn] = {
-            try {
-              next(request, service)
-            } catch {
-              case NonFatal(e) => Future.exception(e)
-            }
-          }
-          def self = service
-          override def close(deadline: Time) = service.close(deadline)
-          override def status = service.status
-          override def toString() = service.toString()
-        }
-
-        Filter.this.apply(request, svc)
-      }
-    }
+  def andThen[Req2, Rep2](next: Filter[ReqOut, RepIn, Req2, Rep2]): Filter[ReqIn, RepOut, Req2, Rep2] =
+    if (next eq Filter.identity) this.asInstanceOf[Filter[ReqIn, RepOut, Req2, Rep2]]
+    else AndThen(service => andThen(next.andThen(service)))
 
   /**
    * Terminates a filter chain in a service. For example,
@@ -126,6 +109,49 @@ abstract class Filter[-ReqIn, +RepOut, +ReqOut, -RepIn]
 abstract class SimpleFilter[Req, Rep] extends Filter[Req, Rep, Req, Rep]
 
 object Filter {
+  private case class AndThen[ReqIn, RepOut, ReqOut, RepIn](
+      build: Service[ReqOut, RepIn] => Service[ReqIn, RepOut]
+  )
+    extends Filter[ReqIn, RepOut, ReqOut, RepIn]
+  {
+    override def andThen[Req2, Rep2](
+      next: Filter[ReqOut, RepIn, Req2, Rep2]
+    ): Filter[ReqIn, RepOut, Req2, Rep2] =
+      AndThen(service => build(next.andThen(service)))
+
+    override def andThen(service: Service[ReqOut, RepIn]): Service[ReqIn, RepOut] =
+      build(service)
+
+    override def andThen(
+      factory: ServiceFactory[ReqOut, RepIn]
+    ): ServiceFactory[ReqIn, RepOut] =
+      new ServiceFactory[ReqIn, RepOut] {
+        val fn: Service[ReqOut, RepIn] => Service[ReqIn, RepOut] =
+          svc => AndThen.this.andThen(svc)
+        def apply(conn: ClientConnection): Future[Service[ReqIn, RepOut]] =
+          factory(conn).map(fn)
+        def close(deadline: Time) = factory.close(deadline)
+        override def status = factory.status
+        override def toString() = factory.toString()
+      }
+
+    def apply(request: ReqIn, service: Service[ReqOut, RepIn]): Future[RepOut] =
+      build(service)(request)
+  }
+
+  private case object Identity extends SimpleFilter[Any, Nothing] {
+    override def andThen[Req2, Rep2](
+      next: Filter[Any, Nothing, Req2, Rep2]
+    ): Filter[Any, Nothing, Req2, Rep2] = next
+
+    override def andThen(service: Service[Any, Nothing]): Service[Any, Nothing] = service
+
+    override def andThen(factory: ServiceFactory[Any, Nothing]): ServiceFactory[Any, Nothing] = factory
+
+    def apply(request: Any, service: Service[Any, Nothing]): Future[Nothing] =
+      service(request)
+  }
+
   implicit def canStackFromSvc[Req, Rep]
     : CanStackFrom[Filter[Req, Rep, Req, Rep], Service[Req, Rep]] =
     new CanStackFrom[Filter[Req, Rep, Req, Rep], Service[Req, Rep]] {
@@ -160,13 +186,8 @@ object Filter {
     }
   }
 
-  def identity[Req, Rep] = new SimpleFilter[Req, Rep] {
-    override def andThen[Req2, Rep2](next: Filter[Req, Rep, Req2, Rep2]) = next
-    override def andThen(service: Service[Req, Rep]) = service
-    override def andThen(factory: ServiceFactory[Req, Rep]) = factory
-
-    def apply(request: Req, service: Service[Req, Rep]) = service(request)
-  }
+  def identity[Req, Rep]: SimpleFilter[Req, Rep] =
+    Identity.asInstanceOf[SimpleFilter[Req, Rep]]
 
   def mk[ReqIn, RepOut, ReqOut, RepIn](
     f: (ReqIn, ReqOut => Future[RepIn]) => Future[RepOut]


### PR DESCRIPTION
Problem

The definition of `andThen` which accepts a `Filter` parameter is the
most common usage for composing filters and a service, e.g.,

    filterA andThen filterB andThen service

The resulting Service allocates an additional Service per filter for
every request. Merely associating `andThen` to the right avoids the
allocations.

    filterA andThen (filterB andThen service)

This is possible because the right-associated pattern invokes the
definition of `andThen` which accepts a Service parameter. However, it
is not possible to do this if the user wants to build a filter chain
without a service on hand.

Solution

Introduce a hidden type, `AndThen`, to wrap a continuation, which, when
ready to build the Service, we can  use to magically re-associate the
`andThen`s to the most efficient pattern: to the right. The continuation
represents the eventual Service, applied to the filter chain to build a
Service, and therefore has the same type as the `andThen` which takes a
Service parameter: `Service[ReqOut, RepIn] => Service[ReqIn, RepOut]`.

Benchmark

Old

                                       (numAndThens)  Mode  Cnt     Score     Error   Units
    andThenFilter                                  1  avgt   10    10.162 ±   0.077   ns/op
    andThenFilter:·gc.alloc.rate.norm              1  avgt   10    ≈ 10⁻⁵              B/op
    andThenFilter                                 10  avgt   10    95.834 ±   1.872   ns/op
    andThenFilter:·gc.alloc.rate.norm             10  avgt   10   240.000 ±   0.001    B/op
    andThenFilter                                 20  avgt   10   212.385 ±   3.959   ns/op
    andThenFilter:·gc.alloc.rate.norm             20  avgt   10   480.000 ±   0.001    B/op


New

                                       (numAndThens)  Mode  Cnt   Score    Error   Units
    andThenFilter                                  1  avgt   10  11.199 ±  0.181   ns/op
    andThenFilter:·gc.alloc.rate.norm              1  avgt   10  ≈ 10⁻⁵             B/op
    andThenFilter                                 10  avgt   10  47.235 ±  0.507   ns/op
    andThenFilter:·gc.alloc.rate.norm             10  avgt   10  ≈ 10⁻⁴             B/op
    andThenFilter                                 20  avgt   10  85.747 ±  1.062   ns/op
    andThenFilter:·gc.alloc.rate.norm             20  avgt   10  ≈ 10⁻⁴             B/op