### PR TITLE
FIX: Race condition in IdleConnectionFilter

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -38,6 +38,13 @@ Breaking API Changes
   * finagle-core: `BackupRequestLost` is no longer itself an `Exception`. Use
     `BackupRequestLost.Exeption` in its place. ``RB_ID=758056``
 
+Bug Fixes
+~~~~~~~~~
+
+  * finagle-core: Fix race condition in `c.t.f.netty3.channel.IdleConnectionFilter` when
+    a connection is closed by the client.
+
+
 6.30.0
 ~~~~~~~
 

--- a/finagle-core/src/main/scala/com/twitter/finagle/netty3/channel/IdleConnectionFilter.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/netty3/channel/IdleConnectionFilter.scala
@@ -108,7 +108,13 @@ class IdleConnectionFilter[Req, Rep](
     def apply(request: Req, service: Service[Req, Rep]) = {
       queue.remove(c)
       service(request) ensure {
-        queue.touch(c)
+        // The connection might have been closed by the client during the request
+        if (c.onClose.isDefined) {
+          queue.touch(c)
+          if (c.onClose.isDefined) {
+            queue.remove(c)
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
If a connection is closed by the client during a request, `onClose`
could be filled (and the connection "removed" from the queue), before
the connection is added back to queue.