### PR TITLE
Make RegistryEntryLifecycle.role static

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/client/ClientRegistry.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/client/ClientRegistry.scala
@@ -59,8 +59,9 @@ private[twitter] object ClientRegistry extends StackRegistry {
 }
 
 private[finagle] object RegistryEntryLifecycle {
+  val role = Stack.Role("RegistryEntryLifecycle")
   def module[Req, Rep]: Stackable[ServiceFactory[Req, Rep]] = new Stack.Module[ServiceFactory[Req, Rep]] {
-    val role = Stack.Role("RegistryEntryLifecycle")
+    val role = RegistryEntryLifecycle.role
 
     val description: String = "Maintains the ClientRegistry for the stack"
     def parameters: Seq[Stack.Param[_]] = Seq(


### PR DESCRIPTION
Problem

RegistryEntryLifecycle's role may not be accessed without instantiating a new
module.  This is cumbersome when referencing this module via e.g.
Stack.insertAfter.

Solution

Make RegistryEntryLifecycle.role static.