### PR TITLE
Add homepage and source reference to gemspec

### DIFF
--- a/finagle-thrift/src/main/ruby/finagle-thrift.gemspec
+++ b/finagle-thrift/src/main/ruby/finagle-thrift.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |s|
   s.summary     = ""
   s.description = "A Ruby client library for integrating into finagle's thrift tracing protocol"
   s.license     = 'Apache License Version 2.0'
+  s.homepage    = "http://twitter.github.io/finagle/"
+  s.metadata    = { "source_code" => "https://github.com/twitter/finagle/tree/develop/finagle-thrift/src/main/ruby" }
 
   s.required_rubygems_version = ">= 1.3.5"
 


### PR DESCRIPTION
Why you made the change:

I did this so that people would easily be able to find the source. I
spent ~10 mins searching and failing to find the ruby source for
finagle-thrift before eventually doing the following:

1. `bundle open finagle-thrift`
2. cd ../../../specifications
3. inspecting the finagle-thrift gemspec to find the author
4. then search internet for author
5. check author's github repositories to only fail to find it
6. then guess that maybe the twitter/finagle repository housed multiple
   languages being a monolith of a repository
7. dig through the repository to find this source finally

How the change addresses the need:

This change will make the homepage and source_code reference urls
available as links on rubygems.org when someone searches for the
finagle-thrift gem. This will make it trivial for them to find the
source and the homepage.

In terms of testing this pull request, I included no automated test because it is really just metadata. I did however run `gem build finagle-thrift.gemspec` to make sure that I didn't break the gem building process in any way.