### PR TITLE
Add thrift dependency

### DIFF
--- a/finagle-thrift/src/main/ruby/finagle-thrift.gemspec
+++ b/finagle-thrift/src/main/ruby/finagle-thrift.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = ">= 1.3.5"
 
-  # s.add_runtime_dependency 'thrift', '~> 0.6.0'
+  s.add_runtime_dependency 'thrift', '~> 0.9.3'
 
   s.files        = Dir.glob("{bin,lib}/**/*")
   s.require_path = 'lib'


### PR DESCRIPTION
Why you made the change:

I did this because the gemspec currently did NOT reference thrift as a
dependency and was causing problems when I was using the zipkin-tracer
gem. Therefore, I dug through the backtrace and discovered that this gem
was the one that neglected to specify it's dependency on thrift.

How the change addresses the need:

This should make it so that thrift is installed as a dependency when
this gem is installed as a dependency.