### PR TITLE
finagle-core: implementing RequestMeterFilter based on new AsyncMeter…

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/filter/RequestMeterFilter.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/filter/RequestMeterFilter.scala
@@ -1,15 +1,15 @@
 package com.twitter.finagle.filter
 
-import java.util.concurrent.RejectedExecutionException
-
 import com.twitter.concurrent.AsyncMeter
 import com.twitter.finagle.{Failure, Service, SimpleFilter}
 import com.twitter.util.{Future, Throw}
 
+import java.util.concurrent.RejectedExecutionException
+
 /**
   * A [[com.twitter.finagle.Filter]] that rate limits requests to a fixed rate over time by
   * using the [[com.twitter.concurrent.AsyncMeter]] implementation. It can be used for slowing
-  * down access to throttled resources. Requests that are unable to acquire a permit are failed
+  * down access to throttled resources. Requests that cannot be enqueued to await a permit are failed
   * immediately with a [[com.twitter.finagle.Failure]] that signals that the work was never done,
   * so it's safe to reenqueue.
   *

--- a/finagle-core/src/main/scala/com/twitter/finagle/filter/RequestMeterFilter.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/filter/RequestMeterFilter.scala
@@ -1,5 +1,7 @@
 package com.twitter.finagle.filter
 
+import java.util.concurrent.RejectedExecutionException
+
 import com.twitter.concurrent.AsyncMeter
 import com.twitter.finagle.{Failure, Service, SimpleFilter}
 import com.twitter.util.{Future, Throw}
@@ -8,13 +10,23 @@ import com.twitter.util.{Future, Throw}
   * A [[com.twitter.finagle.Filter]] that rate limits requests to a fixed rate over time by
   * using the [[com.twitter.concurrent.AsyncMeter]] implementation. It can be used for slowing
   * down access to throttled resources. Requests that are unable to acquire a permit are failed
-  * immediately with a [[com.twitter.finagle.Failure]] that signals a restartable or
-  * idempotent process.
+  * immediately with a [[com.twitter.finagle.Failure]] that signals that the work was never done,
+  * so it's safe to reenqueue.
+  *
+  * NOTE: If you're just trying not to be overwhelmed, you almost certainly want to use
+  * [[com.twitter.finagle.filter.RequestSemaphoreFilter]] instead, because RequestMeterFilter
+  * doesn't work well with "real" resources that are sometimes faster or slower (like a service
+  * that you're depending on that sometimes slows when it takes bursty traffic). This is better for
+  * resources that are artificially bounded, like a rate-limited API.
   */
-class RequestMeterFilter[Req, Rep](meter: AsyncMeter, permits: Int = 1) extends SimpleFilter[Req, Rep] {
+class RequestMeterFilter[Req, Rep](meter: AsyncMeter) extends SimpleFilter[Req, Rep] {
   def apply(request: Req, service: Service[Req, Rep]) = {
-    meter.await(permits).transform {
-      case Throw(noPermit) => Future.exception(Failure.rejected(noPermit))
+    meter.await(1).transform {
+      case Throw(noPermit) => noPermit match {
+        case e: RejectedExecutionException =>
+          Future.exception(Failure.rejected(noPermit))
+        case e => Future.exception(e)
+      }
       case _ => service(request)
     }
   }

--- a/finagle-core/src/main/scala/com/twitter/finagle/filter/RequestMeterFilter.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/filter/RequestMeterFilter.scala
@@ -1,0 +1,21 @@
+package com.twitter.finagle.filter
+
+import com.twitter.concurrent.AsyncMeter
+import com.twitter.finagle.{Failure, Service, SimpleFilter}
+import com.twitter.util.{Future, Throw}
+
+/**
+  * A [[com.twitter.finagle.Filter]] that rate limits requests to a fixed rate over time by
+  * using the [[com.twitter.concurrent.AsyncMeter]] implementation. It can be used for slowing
+  * down access to throttled resources. Requests that are unable to acquire a permit are failed
+  * immediately with a [[com.twitter.finagle.Failure]] that signals a restartable or
+  * idempotent process.
+  */
+class RequestMeterFilter[Req, Rep](meter: AsyncMeter, permits: Int = 1) extends SimpleFilter[Req, Rep] {
+  def apply(request: Req, service: Service[Req, Rep]) = {
+    meter.await(permits).transform {
+      case Throw(noPermit) => Future.exception(Failure.rejected(noPermit))
+      case _ => service(request)
+    }
+  }
+}

--- a/finagle-core/src/test/scala/com/twitter/finagle/filter/RequestMeterFilterTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/filter/RequestMeterFilterTest.scala
@@ -1,0 +1,44 @@
+package com.twitter.finagle.filter
+
+import com.twitter.concurrent.AsyncMeter
+import com.twitter.conversions.time._
+import com.twitter.finagle.util.DefaultTimer
+import com.twitter.finagle.{Failure, Service}
+import com.twitter.util.{Await, Future}
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class RequestMeterFilterTest extends FunSuite {
+
+  val timer = DefaultTimer.twitter
+  val meter = AsyncMeter.newMeter(1, 1 second, 1)(timer)
+
+  test("return service execution after getting a permit") {
+    val echoSvc = new Service[Int, Int] {
+      def apply(req: Int) = Future(req)
+    }
+    val svc = new RequestMeterFilter(meter) andThen echoSvc
+    assert(Await.result(svc(2)) == 2)
+  }
+
+  test("mark dropped requests as rejected") {
+    val neverSvc = new Service[Int, Int] {
+      def apply(req: Int) = Future.never
+    }
+    val svc = new RequestMeterFilter(meter, 2) andThen neverSvc
+    val f = intercept[Failure] { Await.result(svc(1)) }
+    assert(f.isFlagged(Failure.Restartable))
+  }
+
+  test("service failures are not wrapped as rejected") {
+    val exc = new Exception("app exc")
+    val excSvc = new Service[Int, Int] {
+      def apply(req: Int) = Future.exception(exc)
+    }
+    val svc = new RequestMeterFilter(meter) andThen excSvc
+    val e = intercept[Exception] { Await.result(svc(1)) }
+    assert(e == exc)
+  }
+}


### PR DESCRIPTION
Problem

We wanted to be able to control access to rate limited resources, by slowing down requests to fit on the request rate accepted by these resources.

Solution

We ended up implementing a filter named `RequestMeterFilter` using Twitter util's `AsyncMeter` to achieve that. Feedback on naming are really welcomed.

Result

As a result, I've added this `Filter` so other users with the same needs can use this solution.