### PR TITLE
P2CBalancer: Reduce the magnitude of the Penalty

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/P2CBalancer.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/P2CBalancer.scala
@@ -96,7 +96,7 @@ private trait PeakEwma[Req, Rep] { self: Balancer[Req, Rep] =>
 
   protected class Metric(sr: StatsReceiver, name: String) {
     private[this] val epoch = nanoTime()
-    private[this] val Penalty: Double = Double.MaxValue/2
+    private[this] val Penalty: Double = Int.MaxValue/2
     // The mean lifetime of `cost`, it reaches its half-life after Tau*ln(2).
     private[this] val Tau: Double = decayTime.inNanoseconds.toDouble
     require(Tau > 0)

--- a/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/P2CBalancer.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/P2CBalancer.scala
@@ -96,7 +96,7 @@ private trait PeakEwma[Req, Rep] { self: Balancer[Req, Rep] =>
 
   protected class Metric(sr: StatsReceiver, name: String) {
     private[this] val epoch = nanoTime()
-    private[this] val Penalty: Double = Int.MaxValue/2
+    private[this] val Penalty: Double = Long.MaxValue >> 16
     // The mean lifetime of `cost`, it reaches its half-life after Tau*ln(2).
     private[this] val Tau: Double = decayTime.inNanoseconds.toDouble
     require(Tau > 0)


### PR DESCRIPTION
**Problem**
The PeakEWMA load balancer applies a penalty to the load of a server when it 
doesn't have any historical latency. That penalty is initialized at 
`Double.MaxValue/2`, and we add the number of outstanding messages to compute 
the load of a server. The idea behind that, is that the load balancer behaves 
like `LeastLoaded` at start-up before having any historical data.

The problem is that the Penalty is a very big double, and adding a small 
integer will not change its value because of the lack of double precision in 
that range.
e.g.:
```
scala> val Penalty: Double = Double.MaxValue/2
Penalty: Double = 8.988465674311579E307

scala> val b = Penalty + 1
b: Double = 8.988465674311579E307

scala> Penalty < b
res4: Boolean = false

scala> Penalty == b
res5: Boolean = true
```

Actually, the number of outstanding requests needed to increase the load 
properly is humongous (bigger than Int.MaxValue).
```
scala> Math.nextUp(Penalty) - Penalty
res0: Double = 9.979201547673599E291

scala> res0 > Int.MaxValue
res1: Boolean = true
```


**Solution**
Reduce the Penalty to a value (`Long.MaxValue >> 16`) where the double precision 
is good enough to add small integers. This penalty is about equal to 140737 seconds or 39 hours, which is enough to deal with extremely latent systems (meaning that a host without historical latencies will not be chosen over one with history unless its ewma latency is above 39 hours).