### PR TITLE
Control Thrift transport framing with a Stack.Param

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -37,6 +37,13 @@ Runtime Behavior Changes
     for clients that spend significant time deserializing and do not have higher level
     metrics this may come as a surprise. ``RB_ID=772931``
 
+Breaking API Changes
+~~~~~~~~~~~~~~~~~~~~
+
+  * finagle-thrift: Remove the `framed` attributes from `c.t.f.Thrift.Client` and
+    `c.t.f.Thrift.Server`.  This behavior may now be controlled with `c.t.f.Thrift.param.Framed`.
+
+
 6.31.0
 ------
 

--- a/finagle-thrift/src/main/scala/com/twitter/finagle/Thrift.scala
+++ b/finagle-thrift/src/main/scala/com/twitter/finagle/Thrift.scala
@@ -73,6 +73,12 @@ object Thrift extends Client[ThriftClientRequest, Array[Byte]] with ThriftRichCl
       val default = ProtocolFactory(Protocols.binaryFactory())
     }
 
+    /**
+     * A `Param` to control whether a framed transport should be used.
+     * If this is set to false, a buffered transport is used.  Framed
+     * transports are enabled by default.
+     * @param enabled Whether a framed transport should be used.
+     */
     case class Framed(enabled: Boolean)
     implicit object Framed extends Stack.Param[Framed] {
       val default = Framed(true)


### PR DESCRIPTION
Problem:

It is cumbersome to control whether Thrift clients and servers are framed
because there is no Stack.Param that influences this behavior.

Solution:

Introduce a Stack.Param, Thrift.param.Framed, and remove the Client/Server
boolean attribute.