### PR TITLE
Adding link to configuring fault tolerant finagle clients

### DIFF
--- a/doc/src/sphinx/index.rst
+++ b/doc/src/sphinx/index.rst
@@ -33,6 +33,7 @@ Other useful resources include:
 - `Twitter engineering blog entry introducing Finagle <https://blog.twitter.com/2011/finagle-a-protocol-agnostic-rpc-system>`_
 - `ScalaDays 2011 presentation on Finagle <http://days2011.scala-lang.org/node/138/286>`_
 - Twitter's `Scala School <http://twitter.github.com/scala_school/>`_ has a section `introducing Finagle <http://twitter.github.com/scala_school/finagle.html>`_ and another `constructing a distributed search engine using Finagle <http://twitter.github.com/scala_school/searchbird.html>`_
+- Alex Martins’ `post <http://alexmartins.me/2015/12/30/building-fault-tolerant-clients-with-finagle-part-1.html>`_ on configuring fault tolerant Finagle clients (Part 1)
 
 .. _Dapper: http://research.google.com/pubs/pub36356.html
 .. _Zipkin: http://twitter.github.com/zipkin/


### PR DESCRIPTION
I've had lots of positive feedbacks on this post and I would like to make it available on the website so new devs can have access to another resource.