### PR TITLE
Add extractors for Status of HTTP Response

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,7 +9,7 @@ Note that ``RB_ID=#`` correspond to associated messages in commits.
 
 New Features
 ~~~~~~~~~~~~
-  * finagle-http: Introduce convience extractors to pattern match `c.t.f.http.Response.status`
+  * finagle-http: Introduce convenience extractors to pattern match `c.t.f.http.Response.status`
     against the different categories.
 
 6.33.0

--- a/CHANGES
+++ b/CHANGES
@@ -7,8 +7,16 @@ Note that ``RB_ID=#`` correspond to associated messages in commits.
 6.x
 -----
 
+6.34.0
+~~~~~~
+
+New Features
+~~~~~~~~~~~~
+  * finagle-http: Introduce convience extractors to pattern match `c.t.f.http.Response.status`
+    against the different categories.
+
 6.33.0
-~~~~~~~
+~~~~~~
 
 New Features
 ~~~~~~~~~~~~

--- a/CHANGES
+++ b/CHANGES
@@ -7,9 +7,6 @@ Note that ``RB_ID=#`` correspond to associated messages in commits.
 6.x
 -----
 
-6.34.0
-~~~~~~
-
 New Features
 ~~~~~~~~~~~~
   * finagle-http: Introduce convience extractors to pattern match `c.t.f.http.Response.status`

--- a/finagle-http/src/main/scala/com/twitter/finagle/http/Status.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/http/Status.scala
@@ -33,50 +33,39 @@ case class Status(code: Int) {
 object Status {
 
   /**
-   * Matches when the status code isn't in range of any of the
-   * categories: {{Informational}}, {{Successful}}, {{Redirection}},
-   * {{ClientError}}, {{ServerError}}.
+   * Matches when the status code isn't in range of any of the  categories: {{Informational}},
+   * {{Successful}}, {{Redirection}}, {{ClientError}}, {{ServerError}}.
    */
   object UnknownStatus {
     def unapply(status: Status): Option[Status] =
       Option(status).filter(s => s.code < 100 || s.code >= 600)
   }
 
-  /**
-   * Matches when the status code is between 100 and 200.
-   */
+  /** Matches when the status code is between 100 and 200. */
   object Informational {
     def unapply(status: Status): Option[Status] =
       inRange(100, 200, status)
   }
 
-  /**
-   * Matches when the status code is between 200 and 300.
-   */
+  /** Matches when the status code is between 200 and 300. */
   object Successful {
     def unapply(status: Status): Option[Status] =
       inRange(200, 300, status)
   }
 
-  /**
-   * Matches when the status code is between 300 and 400.
-   */
+  /** Matches when the status code is between 300 and 400. */
   object Redirection {
     def unapply(status: Status): Option[Status] =
       inRange(300, 400, status)
   }
 
-  /**
-   * Matches when the status code is between 400 and 500.
-   */
+  /** Matches when the status code is between 400 and 500. */
   object ClientError {
     def unapply(status: Status): Option[Status] =
       inRange(400, 500, status)
   }
 
-  /**
-   * Matches when the status code is between 500 and 600.
-   */
+  /** Matches when the status code is between 500 and 600. */
   object ServerError {
     def unapply(status: Status): Option[Status] =
       inRange(500, 600, status)

--- a/finagle-http/src/main/scala/com/twitter/finagle/http/Status.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/http/Status.scala
@@ -74,7 +74,7 @@ object Status {
   @inline
   private[finagle] def inRange(lower: Int, upper: Int,
                                status: Status): Option[Status] =
-    Option(status).filter(s => s.code >= lower && s.code < upper)
+    Some(status).filter(s => s.code >= lower && s.code < upper)
 
 
   val Continue = Status(100)

--- a/finagle-http/src/main/scala/com/twitter/finagle/http/Status.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/http/Status.scala
@@ -36,9 +36,9 @@ object Status {
    * Matches when the status code isn't in range of any of the  categories: {{Informational}},
    * {{Successful}}, {{Redirection}}, {{ClientError}}, {{ServerError}}.
    */
-  object UnknownStatus {
+  object Unknown {
     def unapply(status: Status): Option[Status] =
-      Option(status).filter(s => s.code < 100 || s.code >= 600)
+      Some(status).filter(s => s.code < 100 || s.code >= 600)
   }
 
   /** Matches when the status code is between 100 and 200. */

--- a/finagle-http/src/main/scala/com/twitter/finagle/http/Status.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/http/Status.scala
@@ -29,7 +29,47 @@ case class Status(code: Int) {
     }
 }
 
+
+
+
+
 object Status {
+
+  @inline
+  private[finagle] def inRange(lower: Int, upper: Int)
+                              (status: Status): Option[Status] =
+    Some(status).filter(s => s.code >= lower && s.code < upper)
+
+  object UnknownStatus {
+    def unapply(status: Status): Option[Status] =
+      Some(status).filter(s => s.code < 100 || s.code >= 600)
+  }
+
+  object Informational {
+    def unapply(status: Status): Option[Status] =
+      inRange(100, 200)(status)
+  }
+
+  object Successful{
+    def unapply(status: Status): Option[Status] =
+      inRange(200, 300)(status)
+  }
+
+  object Redirection {
+    def unapply(status: Status): Option[Status] =
+      inRange(300, 400)(status)
+  }
+
+  object ClientError {
+    def unapply(status: Status): Option[Status] =
+      inRange(400, 500)(status)
+  }
+
+  object ServerError {
+    def unapply(status: Status): Option[Status] =
+      inRange(500, 600)(status)
+  }
+
   val Continue = Status(100)
   val SwitchingProtocols = Status(101)
   val Processing = Status(102)

--- a/finagle-http/src/main/scala/com/twitter/finagle/http/Status.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/http/Status.scala
@@ -1,20 +1,20 @@
 package com.twitter.finagle.http
 
 /**
- * Represents an HTTP status code.
- *
- * The set of commonly known HTTP status codes have an associated reason phrase
- * (see `reasons`). We don't provide a way to set the reason phrase because:
- *
- * - it simplifies construction (users only supply the code)
- * - it avoids the need to validate user-defined reason phrases
- * - it omits the possibility of statuses with duplicate reason phrases
- *
- * The only downside is that we lose the ability to create custom statuses with
- * "vanity" reason phrases, but this should be tolerable.
- *
- * For Java-friendly enums, see [[com.twitter.finagle.http.Statuses]].
- */
+  * Represents an HTTP status code.
+  *
+  * The set of commonly known HTTP status codes have an associated reason phrase
+  * (see `reasons`). We don't provide a way to set the reason phrase because:
+  *
+  * - it simplifies construction (users only supply the code)
+  * - it avoids the need to validate user-defined reason phrases
+  * - it omits the possibility of statuses with duplicate reason phrases
+  *
+  * The only downside is that we lose the ability to create custom statuses with
+  * "vanity" reason phrases, but this should be tolerable.
+  *
+  * For Java-friendly enums, see [[com.twitter.finagle.http.Statuses]].
+  */
 case class Status(code: Int) {
   def reason: String =
     Status.reasons.get(this) match {
@@ -30,45 +30,63 @@ case class Status(code: Int) {
 }
 
 
-
-
-
 object Status {
 
-  @inline
-  private[finagle] def inRange(lower: Int, upper: Int)
-                              (status: Status): Option[Status] =
-    Some(status).filter(s => s.code >= lower && s.code < upper)
-
+  /**
+    * Matches when the status code isn't in range of any of the
+    * categories: {{Informational}}, {{Successful}}, {{Redirection}},
+    * {{ClientError}}, {{ServerError}}.
+    */
   object UnknownStatus {
     def unapply(status: Status): Option[Status] =
-      Some(status).filter(s => s.code < 100 || s.code >= 600)
+      Option(status).filter(s => s.code < 100 || s.code >= 600)
   }
 
+  /**
+    * Matches when the status code is between 100 and 200.
+    */
   object Informational {
     def unapply(status: Status): Option[Status] =
-      inRange(100, 200)(status)
+      inRange(100, 200, status)
   }
 
-  object Successful{
+  /**
+    * Matches when the status code is between 200 and 300.
+    */
+  object Successful {
     def unapply(status: Status): Option[Status] =
-      inRange(200, 300)(status)
+      inRange(200, 300, status)
   }
 
+  /**
+    * Matches when the status code is between 300 and 400.
+    */
   object Redirection {
     def unapply(status: Status): Option[Status] =
-      inRange(300, 400)(status)
+      inRange(300, 400, status)
   }
 
+  /**
+    * Matches when the status code is between 400 and 500.
+    */
   object ClientError {
     def unapply(status: Status): Option[Status] =
-      inRange(400, 500)(status)
+      inRange(400, 500, status)
   }
 
+  /**
+    * Matches when the status code is between 500 and 600.
+    */
   object ServerError {
     def unapply(status: Status): Option[Status] =
-      inRange(500, 600)(status)
+      inRange(500, 600, status)
   }
+
+  @inline
+  private[finagle] def inRange(lower: Int, upper: Int,
+                               status: Status): Option[Status] =
+    Option(status).filter(s => s.code >= lower && s.code < upper)
+
 
   val Continue = Status(100)
   val SwitchingProtocols = Status(101)

--- a/finagle-http/src/main/scala/com/twitter/finagle/http/Status.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/http/Status.scala
@@ -1,20 +1,20 @@
 package com.twitter.finagle.http
 
 /**
-  * Represents an HTTP status code.
-  *
-  * The set of commonly known HTTP status codes have an associated reason phrase
-  * (see `reasons`). We don't provide a way to set the reason phrase because:
-  *
-  * - it simplifies construction (users only supply the code)
-  * - it avoids the need to validate user-defined reason phrases
-  * - it omits the possibility of statuses with duplicate reason phrases
-  *
-  * The only downside is that we lose the ability to create custom statuses with
-  * "vanity" reason phrases, but this should be tolerable.
-  *
-  * For Java-friendly enums, see [[com.twitter.finagle.http.Statuses]].
-  */
+ * Represents an HTTP status code.
+ *
+ * The set of commonly known HTTP status codes have an associated reason phrase
+ * (see `reasons`). We don't provide a way to set the reason phrase because:
+ *
+ * - it simplifies construction (users only supply the code)
+ * - it avoids the need to validate user-defined reason phrases
+ * - it omits the possibility of statuses with duplicate reason phrases
+ *
+ * The only downside is that we lose the ability to create custom statuses with
+ * "vanity" reason phrases, but this should be tolerable.
+ *
+ * For Java-friendly enums, see [[com.twitter.finagle.http.Statuses]].
+ */
 case class Status(code: Int) {
   def reason: String =
     Status.reasons.get(this) match {
@@ -33,50 +33,50 @@ case class Status(code: Int) {
 object Status {
 
   /**
-    * Matches when the status code isn't in range of any of the
-    * categories: {{Informational}}, {{Successful}}, {{Redirection}},
-    * {{ClientError}}, {{ServerError}}.
-    */
+   * Matches when the status code isn't in range of any of the
+   * categories: {{Informational}}, {{Successful}}, {{Redirection}},
+   * {{ClientError}}, {{ServerError}}.
+   */
   object UnknownStatus {
     def unapply(status: Status): Option[Status] =
       Option(status).filter(s => s.code < 100 || s.code >= 600)
   }
 
   /**
-    * Matches when the status code is between 100 and 200.
-    */
+   * Matches when the status code is between 100 and 200.
+   */
   object Informational {
     def unapply(status: Status): Option[Status] =
       inRange(100, 200, status)
   }
 
   /**
-    * Matches when the status code is between 200 and 300.
-    */
+   * Matches when the status code is between 200 and 300.
+   */
   object Successful {
     def unapply(status: Status): Option[Status] =
       inRange(200, 300, status)
   }
 
   /**
-    * Matches when the status code is between 300 and 400.
-    */
+   * Matches when the status code is between 300 and 400.
+   */
   object Redirection {
     def unapply(status: Status): Option[Status] =
       inRange(300, 400, status)
   }
 
   /**
-    * Matches when the status code is between 400 and 500.
-    */
+   * Matches when the status code is between 400 and 500.
+   */
   object ClientError {
     def unapply(status: Status): Option[Status] =
       inRange(400, 500, status)
   }
 
   /**
-    * Matches when the status code is between 500 and 600.
-    */
+   * Matches when the status code is between 500 and 600.
+   */
   object ServerError {
     def unapply(status: Status): Option[Status] =
       inRange(500, 600, status)

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/StatusTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/StatusTest.scala
@@ -17,13 +17,6 @@ class StatusTest extends FunSuite {
     assert(Status(601).reason == "Unknown Status")
   }
 
-  test("null isn't a status") {
-    null match {
-      case UnknownStatus(_) | Informational(_) | Successful(_) |
-           Redirection(_) | ClientError(_) | ServerError(_) => fail("null shouldn't match any status.")
-      case _ =>
-    }
-  }
   test("matches unknown status") {
     Status(99) match {
       case UnknownStatus(_) =>

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/StatusTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/StatusTest.scala
@@ -17,44 +17,71 @@ class StatusTest extends FunSuite {
     assert(Status(601).reason == "Unknown Status")
   }
 
-  test("Pattern match usability check") {
+  test("null isn't a status") {
     null match {
       case UnknownStatus(_) | Informational(_) | Successful(_) |
            Redirection(_) | ClientError(_) | ServerError(_) => fail("null shouldn't match any status.")
       case _ =>
     }
-
+  }
+  test("matches unknown status") {
     Status(99) match {
       case UnknownStatus(_) =>
       case status => fail(s"$status should be UnknownStatus")
     }
-    Status(100) match {
-      case Informational(_) =>
-      case status => fail(s"$status should be Informational")
+  }
+
+  test("matches informational status") {
+    100 until 200 foreach { code =>
+      Status(code) match {
+        case Informational(_) =>
+        case status => fail(s"$status should be Informational")
+      }
     }
-    Status(199) match {
-      case Informational(_) =>
-      case status => fail(s"$status should be Informational")
+  }
+
+  test("matches successful status") {
+    200 until 300 foreach { code =>
+      Status(code) match {
+        case Successful(_) =>
+        case status => fail(s"$status should be Successful")
+      }
     }
-    Status(299) match {
-      case Successful(_) =>
-      case status => fail(s"$status should be Successful")
+  }
+
+  test("matches redirection status") {
+    300 until 400 foreach { code =>
+      Status(code) match {
+        case Redirection(_) =>
+        case status => fail(s"$status should be Redirection")
+      }
     }
-    Status(399) match {
-      case Redirection(_) =>
-      case status => fail(s"$status should be Redirection")
+  }
+
+  test("match client error status") {
+    400 until 500 foreach { code =>
+      Status(code) match {
+        case ClientError(_) =>
+        case status => fail(s"$status should be ClientError")
+      }
     }
-    Status(489) match {
-      case ClientError(_) =>
-      case status => fail(s"$status should be ClientError")
+  }
+
+  test("match server error status") {
+    500 until 600 foreach { code =>
+      Status(code) match {
+        case ServerError(_) =>
+        case status => fail(s"$status should be ServerError")
+      }
     }
-    Status(599) match {
-      case ServerError(_) =>
-      case status => fail(s"$status should be ServerError")
-    }
-    Status(601) match {
-      case UnknownStatus(_) =>
-      case status => fail(s"$status should be UnknownStatus")
+  }
+
+  test("match unknown status") {
+    600 until 700 foreach { code =>
+      Status(601) match {
+        case UnknownStatus(_) =>
+        case status => fail(s"$status should be UnknownStatus")
+      }
     }
   }
 }

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/StatusTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/StatusTest.scala
@@ -19,7 +19,7 @@ class StatusTest extends FunSuite {
 
   test("matches unknown status") {
     Status(99) match {
-      case UnknownStatus(_) =>
+      case Unknown(_) =>
       case status => fail(s"$status should be UnknownStatus")
     }
   }
@@ -72,7 +72,7 @@ class StatusTest extends FunSuite {
   test("match unknown status") {
     600 until 700 foreach { code =>
       Status(601) match {
-        case UnknownStatus(_) =>
+        case Unknown(_) =>
         case status => fail(s"$status should be UnknownStatus")
       }
     }

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/StatusTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/StatusTest.scala
@@ -18,6 +18,12 @@ class StatusTest extends FunSuite {
   }
 
   test("Pattern match usability check") {
+    null match {
+      case UnknownStatus(_) | Informational(_) | Successful(_) |
+           Redirection(_) | ClientError(_) | ServerError(_) => fail("null shouldn't match any status.")
+      case _ =>
+    }
+
     Status(99) match {
       case UnknownStatus(_) =>
       case status => fail(s"$status should be UnknownStatus")

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/StatusTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/StatusTest.scala
@@ -1,5 +1,6 @@
 package com.twitter.finagle.http
 
+import com.twitter.finagle.http.Status._
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
@@ -14,5 +15,40 @@ class StatusTest extends FunSuite {
     assert(Status(498).reason == "Client Error")
     assert(Status(599).reason == "Server Error")
     assert(Status(601).reason == "Unknown Status")
+  }
+
+  test("Pattern match usability check") {
+    Status(99) match {
+      case UnknownStatus(_) =>
+      case status => fail(s"$status should be UnknownStatus")
+    }
+    Status(100) match {
+      case Informational(_) =>
+      case status => fail(s"$status should be Informational")
+    }
+    Status(199) match {
+      case Informational(_) =>
+      case status => fail(s"$status should be Informational")
+    }
+    Status(299) match {
+      case Successful(_) =>
+      case status => fail(s"$status should be Successful")
+    }
+    Status(399) match {
+      case Redirection(_) =>
+      case status => fail(s"$status should be Redirection")
+    }
+    Status(489) match {
+      case ClientError(_) =>
+      case status => fail(s"$status should be ClientError")
+    }
+    Status(599) match {
+      case ServerError(_) =>
+      case status => fail(s"$status should be ServerError")
+    }
+    Status(601) match {
+      case UnknownStatus(_) =>
+      case status => fail(s"$status should be UnknownStatus")
+    }
   }
 }


### PR DESCRIPTION
> When writing response classifiers, and other code that deals with responses,
> in a generic manner, it is currently inconvenient to match against specific
> ranges of errors such as Server Errors or Client errors.
> 
> Solution
> 
> By adding extractors for the different categories (Unknown, Informational,
> Successful, Redirection, Client Error, and Server Error) it becomes possible
> to easily determine in which category a response falls.
> 
> Result
> 
> Determining whether a response was succesful is as easy as matching
> on Successful(_).

It can be debated whether we should also provide an extractor that works on the `Response` directly, and if so, where the code should be placed.