### PR TITLE
Allow control over thrift protocol upgrade.

### DIFF
--- a/finagle-thrift/src/main/scala/com/twitter/finagle/Thrift.scala
+++ b/finagle-thrift/src/main/scala/com/twitter/finagle/Thrift.scala
@@ -124,8 +124,7 @@ object Thrift extends Client[ThriftClientRequest, Array[Byte]] with ThriftRichCl
           val Label(label) = params[Label]
           val param.ClientId(clientId) = params[param.ClientId]
           val param.ProtocolFactory(pf) = params[param.ProtocolFactory]
-          val param.AttemptProtocolUpgrade(upgrade) = params[param.AttemptProtocolUpgrade]
-          val preparer = new ThriftClientPreparer(pf, label, clientId, false, upgrade)
+          val preparer = new ThriftClientPreparer(pf, label, clientId, false)
           preparer.prepare(next, params)
         }
       }
@@ -178,8 +177,11 @@ object Thrift extends Client[ThriftClientRequest, Array[Byte]] with ThriftRichCl
     def withClientId(clientId: thrift.ClientId): Client =
       configured(param.ClientId(Some(clientId)))
 
-    def withAttemptProtocolUpgrade(attemptUpgrade: Boolean): Client =
-      configured(param.AttemptProtocolUpgrade(attemptUpgrade))
+    def withProtocolUpgrade: Client =
+      configured(param.AttemptProtocolUpgrade(true))
+
+    def withNoProtocolUpgrade: Client =
+      configured(param.AttemptProtocolUpgrade(false))
 
     def clientId: Option[thrift.ClientId] = params[param.ClientId].clientId
 

--- a/finagle-thrift/src/main/scala/com/twitter/finagle/Thrift.scala
+++ b/finagle-thrift/src/main/scala/com/twitter/finagle/Thrift.scala
@@ -124,7 +124,7 @@ object Thrift extends Client[ThriftClientRequest, Array[Byte]] with ThriftRichCl
           val Label(label) = params[Label]
           val param.ClientId(clientId) = params[param.ClientId]
           val param.ProtocolFactory(pf) = params[param.ProtocolFactory]
-          val preparer = new ThriftClientPreparer(pf, label, clientId, false)
+          val preparer = new ThriftClientPreparer(pf, label, clientId)
           preparer.prepare(next, params)
         }
       }
@@ -177,10 +177,10 @@ object Thrift extends Client[ThriftClientRequest, Array[Byte]] with ThriftRichCl
     def withClientId(clientId: thrift.ClientId): Client =
       configured(param.ClientId(Some(clientId)))
 
-    def withProtocolUpgrade: Client =
+    def withAttemptProtocolUpgrade: Client =
       configured(param.AttemptProtocolUpgrade(true))
 
-    def withNoProtocolUpgrade: Client =
+    def withNoAttemptProtocolUpgrade: Client =
       configured(param.AttemptProtocolUpgrade(false))
 
     def clientId: Option[thrift.ClientId] = params[param.ClientId].clientId

--- a/finagle-thrift/src/main/scala/com/twitter/finagle/thrift/ThriftClientBufferedCodec.scala
+++ b/finagle-thrift/src/main/scala/com/twitter/finagle/thrift/ThriftClientBufferedCodec.scala
@@ -26,11 +26,7 @@ object ThriftClientBufferedCodec {
   /**
    * Create a [[com.twitter.finagle.thrift.ThriftClientBufferedCodecFactory]]
    */
-  def apply(): ThriftClientBufferedCodecFactory =
-    apply(Protocols.binaryFactory())
-
-  def apply(protocolFactory: TProtocolFactory): ThriftClientBufferedCodecFactory =
-    apply(protocolFactory)
+  def apply() = new ThriftClientBufferedCodecFactory
 
   /**
    * Helpful from Java.
@@ -43,14 +39,16 @@ object ThriftClientBufferedCodec {
     // be quite a surprise and the wrong type. Ick.
     apply()
   }
+
+  def apply(protocolFactory: TProtocolFactory) =
+    new ThriftClientBufferedCodecFactory(protocolFactory)
+
 }
 
-class ThriftClientBufferedCodecFactory(
-    protocolFactory: TProtocolFactory)
-  extends CodecFactory[ThriftClientRequest, Array[Byte]]#Client
+class ThriftClientBufferedCodecFactory(protocolFactory: TProtocolFactory) extends
+  CodecFactory[ThriftClientRequest, Array[Byte]]#Client
 {
   def this() = this(Protocols.binaryFactory())
-
   /**
    * Create a [[com.twitter.finagle.thrift.ThriftClientBufferedCodec]]
    * with a default TBinaryProtocol.
@@ -60,10 +58,7 @@ class ThriftClientBufferedCodecFactory(
   }
 }
 
-class ThriftClientBufferedCodec(
-    protocolFactory: TProtocolFactory,
-    config: ClientCodecConfig)
-  extends ThriftClientFramedCodec(protocolFactory, config) {
-
+class ThriftClientBufferedCodec(protocolFactory: TProtocolFactory, config: ClientCodecConfig)
+    extends ThriftClientFramedCodec(protocolFactory, config) {
   override def pipelineFactory = ThriftClientBufferedPipelineFactory(protocolFactory)
 }

--- a/finagle-thrift/src/main/scala/com/twitter/finagle/thrift/ThriftClientBufferedCodec.scala
+++ b/finagle-thrift/src/main/scala/com/twitter/finagle/thrift/ThriftClientBufferedCodec.scala
@@ -27,14 +27,10 @@ object ThriftClientBufferedCodec {
    * Create a [[com.twitter.finagle.thrift.ThriftClientBufferedCodecFactory]]
    */
   def apply(): ThriftClientBufferedCodecFactory =
-    apply(Protocols.binaryFactory(), true)
+    apply(Protocols.binaryFactory())
 
   def apply(protocolFactory: TProtocolFactory): ThriftClientBufferedCodecFactory =
-    apply(protocolFactory, true)
-
-  def apply(protocolFactory: TProtocolFactory,
-            _attemptProtocolUpgrade: Boolean): ThriftClientBufferedCodecFactory =
-    new ThriftClientBufferedCodecFactory(protocolFactory, _attemptProtocolUpgrade)
+    apply(protocolFactory)
 
   /**
    * Helpful from Java.
@@ -50,31 +46,24 @@ object ThriftClientBufferedCodec {
 }
 
 class ThriftClientBufferedCodecFactory(
-    protocolFactory: TProtocolFactory,
-    _attemptProtocolUpgrade: Boolean)
+    protocolFactory: TProtocolFactory)
   extends CodecFactory[ThriftClientRequest, Array[Byte]]#Client
 {
-  def this() = this(Protocols.binaryFactory(), true)
-
-  def this(protocolFactory: TProtocolFactory) = this(protocolFactory, true)
+  def this() = this(Protocols.binaryFactory())
 
   /**
    * Create a [[com.twitter.finagle.thrift.ThriftClientBufferedCodec]]
    * with a default TBinaryProtocol.
    */
   def apply(config: ClientCodecConfig) = {
-    new ThriftClientBufferedCodec(protocolFactory, config, _attemptProtocolUpgrade)
+    new ThriftClientBufferedCodec(protocolFactory, config)
   }
 }
 
 class ThriftClientBufferedCodec(
     protocolFactory: TProtocolFactory,
-    config: ClientCodecConfig,
-    attemptProtocolUpgrade: Boolean)
-  extends ThriftClientFramedCodec(protocolFactory, config, attemptProtocolUpgrade = attemptProtocolUpgrade) {
-
-  def this(protocolFactory: TProtocolFactory, config: ClientCodecConfig) =
-    this(protocolFactory, config, true)
+    config: ClientCodecConfig)
+  extends ThriftClientFramedCodec(protocolFactory, config) {
 
   override def pipelineFactory = ThriftClientBufferedPipelineFactory(protocolFactory)
 }

--- a/finagle-thrift/src/main/scala/com/twitter/finagle/thrift/ThriftClientFramedCodec.scala
+++ b/finagle-thrift/src/main/scala/com/twitter/finagle/thrift/ThriftClientFramedCodec.scala
@@ -31,8 +31,7 @@ class ThriftClientFramedCodecFactory(
     _protocolFactory: TProtocolFactory)
   extends CodecFactory[ThriftClientRequest, Array[Byte]]#Client {
 
-  def this(clientId: Option[ClientId]) =
-    this(clientId, false, Protocols.binaryFactory())
+  def this(clientId: Option[ClientId]) = this(clientId, false, Protocols.binaryFactory())
 
   def this(clientId: ClientId) = this(Some(clientId))
 
@@ -41,7 +40,7 @@ class ThriftClientFramedCodecFactory(
     new ThriftClientFramedCodecFactory(clientId, x, _protocolFactory)
 
   /**
-   * Use the given protocolFactory instead of the default `TBinaryProtocol.Factory`
+   * Use the given protocolFactory in stead of the default `TBinaryProtocol.Factory`
    */
   def protocolFactory(pf: TProtocolFactory) =
     new ThriftClientFramedCodecFactory(clientId, _useCallerSeqIds, pf)
@@ -62,7 +61,8 @@ class ThriftClientFramedCodec(
 ) extends Codec[ThriftClientRequest, Array[Byte]] {
 
   private[this] val preparer = ThriftClientPreparer(
-    protocolFactory, config.serviceName, clientId, useCallerSeqIds)
+    protocolFactory, config.serviceName,
+    clientId, useCallerSeqIds)
 
   def pipelineFactory: ChannelPipelineFactory =
     ThriftClientFramedPipelineFactory

--- a/finagle-thrift/src/test/scala/com/twitter/finagle/thrift/EndToEndTest.scala
+++ b/finagle-thrift/src/test/scala/com/twitter/finagle/thrift/EndToEndTest.scala
@@ -540,7 +540,7 @@ class EndToEndTest extends FunSuite with ThriftTest with BeforeAndAfter {
       .configured(Stats(sr))
       .withProtocolFactory(pf)
       .withClientId(ClientId("aClient"))
-      .withAttemptProtocolUpgrade(false)
+      .withNoProtocolUpgrade
       .newIface[B.ServiceIface](server)
 
     assert(Await.result(client.someway()) == null)

--- a/finagle-thrift/src/test/scala/com/twitter/finagle/thrift/EndToEndTest.scala
+++ b/finagle-thrift/src/test/scala/com/twitter/finagle/thrift/EndToEndTest.scala
@@ -540,7 +540,7 @@ class EndToEndTest extends FunSuite with ThriftTest with BeforeAndAfter {
       .configured(Stats(sr))
       .withProtocolFactory(pf)
       .withClientId(ClientId("aClient"))
-      .withNoProtocolUpgrade
+      .withNoAttemptProtocolUpgrade
       .newIface[B.ServiceIface](server)
 
     assert(Await.result(client.someway()) == null)

--- a/finagle-thrift/src/test/scala/com/twitter/finagle/thrift/EndToEndTest.scala
+++ b/finagle-thrift/src/test/scala/com/twitter/finagle/thrift/EndToEndTest.scala
@@ -64,6 +64,7 @@ class EndToEndTest extends FunSuite with ThriftTest with BeforeAndAfter {
   val serviceToIface = new B.ServiceToClient(_, _)
 
   val missingClientIdEx = new IllegalStateException("uh no client id")
+  val presentClientIdEx = new IllegalStateException("unexpected client id")
 
   def servers(pf: TProtocolFactory): Seq[(String, Closable, Int)] = {
     val iface = new BServiceImpl {
@@ -518,6 +519,32 @@ class EndToEndTest extends FunSuite with ThriftTest with BeforeAndAfter {
     assert(sr.stat("server", "response_payload_bytes")() == Seq(40.0f, 45.0f))
 
     Await.ready(ss.close())
+  }
+
+  test("clientId is not sent and prep stats are not recorded when TTwitter upgrading is disabled") {
+    val pf = Protocols.binaryFactory()
+    val iface = new BServiceImpl {
+      override def someway(): Future[Void] = {
+        ClientId.current.map(_.name) match {
+          case Some(name) => Future.exception(presentClientIdEx)
+          case _ => Future.Void
+        }
+      }
+    }
+    val server = Thrift.server
+      .withProtocolFactory(pf)
+      .serveIface(new InetSocketAddress(InetAddress.getLoopbackAddress, 0), iface)
+
+    val sr = new InMemoryStatsReceiver()
+    val client = Thrift.client
+      .configured(Stats(sr))
+      .withProtocolFactory(pf)
+      .withClientId(ClientId("aClient"))
+      .withAttemptProtocolUpgrade(false)
+      .newIface[B.ServiceIface](server)
+
+    assert(Await.result(client.someway()) == null)
+    assert(sr.stats.get(Seq("codec_connection_preparation_latency_ms")) == None)
   }
 }
 


### PR DESCRIPTION
Problem

Some thrift server implementations react badly to unknown methods. In
particular, the go implementation throws up its hands and closes the
connection. This makes finagle thrift clients unusable with go servers
as finagle's attempt to upgrade the protocol results in a closed
connection.

Solution

Introduce the ability to control protocol upgrading. This is done
through a new Param (for Stack clients) and a new parameter to
ThriftClient(Buffered|Framed)Codec(Factory)? (for older clients). In
both cases, the preparer simply returns the underlying ServiceFactory
when the parameter is set to false. The parameter default is true to
by default to retain backwards compatibility.

Result

Existing code will continue to run as-is - protocol upgrading will be
attempted. New code gains the ability to turn off upgrading. When
upgrading is off, the upgrade message will not be sent and clients will
work with funky servers.

---

We have an internal hack workaround using a custom codec factory with an `apply` method that returns a new framed codec but with `prepareConnFactory` overridden to simply return `underlying`. This doesn't work with Stack clients so pushing a broader fix back.

I am looking for guidance on two things:

1. Testing. Where / how would be the right way to test this inside finagle?
2. Implementation of avoiding the protocol upgrade in the `Thrift.Client` object. Right now, I switch in the `preparer` method - stats on prepare latency disappear (which I think is right). It seems like it would be nice to have the `stack` method just not do any replacement, but it doesn't have access to params.