### PR TITLE
Support wildcards in Dtab prefixes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -26,6 +26,8 @@ Breaking API Changes
   * finagle-core: When a client is created, its server set resolution is started eagerly.
   ``RB_ID=806940``
 
+  * finagle-core: Dentry now takes a Dentry.Prefix instead of a Path.
+
 New Features
 ~~~~~~~~~~~~
 

--- a/CHANGES
+++ b/CHANGES
@@ -32,12 +32,7 @@ New Features
   * finagle-http: new stack params MaxChunkSize, MaxHeaderSize, and MaxInitialLineLength
     are available to configure the http codec. ``RB_ID=811129``
 
-Breaking API Changes
-~~~~~~~~~~~~~~~~~~~~
-
-  * finagle-cache-resolver: `c.t.f.cacheresolver.ZookeeperCacheNodeGroup` has been removed from the
-    API since we no longer check for the zookeeper data for the cache pool size to refresh for the
-    changes in the serverset. ``RB_ID=811190``
+  * finagle-core: Dtabs allow wildcard path elements in prefixes.
 
 6.34.0
 ------

--- a/doc/src/sphinx/Names.rst
+++ b/doc/src/sphinx/Names.rst
@@ -112,6 +112,31 @@ to
 Note that prefixes match on path `components`, not characters; e.g.
 `/s` is a prefix of `/s/crawler`, but not of `/s#/foo/bar/crawler`.
 
+Furthermore, prefixes may contain the wildcard character `*` to match
+any component. For example
+
+::
+
+	/s#/*/bar	=>	/t/bah
+
+rewrites the paths 
+
+::
+
+	/s#/foo/bar/baz
+
+or
+
+::
+
+	/s#/boo/bar/baz
+        
+to
+
+::
+
+	/t/bah/baz
+
 Paths beginning with ``/$/`` are called "system paths." They are interpreted
 specially by Finagle, similarly to resolver schemes. Paths of the form
 

--- a/finagle-core/src/main/scala/com/twitter/finagle/Dtab.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/Dtab.scala
@@ -145,7 +145,7 @@ object Dentry {
    * dentry     ::= prefix '=>' tree
    * }}}
    *
-   * where the production `prefix` is from the grammer documented in
+   * where the production `prefix` is from the grammar documented in
    * [[Prefix.read]] and the production `tree` is from the grammar
    * documented in [[com.twitter.finagle.NameTree.read
    * NameTree.read]].

--- a/finagle-core/src/main/scala/com/twitter/finagle/Dtab.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/Dtab.scala
@@ -1,6 +1,7 @@
 package com.twitter.finagle
 
 import com.twitter.app.Flaggable
+import com.twitter.io.Buf
 import com.twitter.util.Local
 import java.io.PrintWriter
 import scala.collection.generic.CanBuildFrom
@@ -32,7 +33,7 @@ case class Dtab(dentries0: IndexedSeq[Dentry])
    */
   def lookup(path: Path): NameTree[Name.Path] = {
     val matches = dentries.collect {
-      case Dentry(prefix, dst) if path.startsWith(prefix) =>
+      case Dentry(prefix, dst) if prefix.matches(path) =>
         val suff = path.drop(prefix.size)
         dst.map { pfx => Name.Path(pfx ++ suff) }
     }
@@ -127,32 +128,139 @@ case class Dtab(dentries0: IndexedSeq[Dentry])
  * the paths that the entry applies to. `dst` describes the resulting
  * tree for this prefix on lookup.
  */
-case class Dentry(prefix: Path, dst: NameTree[Path]) {
+case class Dentry(prefix: Dentry.Prefix, dst: NameTree[Path]) {
   def show = "%s=>%s".format(prefix.show, dst.show)
   override def toString = "Dentry("+show+")"
 }
 
 object Dentry {
+
+  /** Build a Dentry with a Path prefix. */
+  def apply(path: Path, dst: NameTree[Path]): Dentry =
+    Dentry(Prefix(path.elems.map(Prefix.Label(_)):_*), dst)
+
   /**
    * Parse a Dentry from the string `s` with concrete syntax:
    * {{{
-   * dentry     ::= path '=>' tree
+   * dentry     ::= prefix '=>' tree
    * }}}
    *
-   * where the productions `path` and `tree` are from the grammar
-   * documented in [[com.twitter.finagle.NameTree.read NameTree.read]].
+   * where the production `prefix` is from the grammer documented in
+   * [[Prefix.read]] and the production `tree` is from the grammar
+   * documented in [[com.twitter.finagle.NameTree.read
+   * NameTree.read]].
    */
   def read(s: String): Dentry = NameTreeParsers.parseDentry(s)
 
   // The prefix to this is an illegal path in the sense that the
   // concrete syntax will not admit it. It will do for a no-op.
-  val nop: Dentry = Dentry(Path.Utf8("/"), NameTree.Neg)
+  val nop: Dentry = Dentry(Prefix(Prefix.Label("/")), NameTree.Neg)
 
   implicit val equiv: Equiv[Dentry] = new Equiv[Dentry] {
     def equiv(d1: Dentry, d2: Dentry): Boolean = (
       d1.prefix == d2.prefix &&
       d1.dst.simplified == d2.dst.simplified
     )
+  }
+
+  /**
+   * A Prefix comprises a [[Path]]-matching expression.
+   *
+   * Each element in a prefix may be either a [[Label]] or [[AnyElem]].
+   * When matching a [[Path]], Label-elements must match exactly,
+   * while Any-elements are ignored.
+   */
+  case class Prefix(elems: Prefix.Elem*) {
+
+    def matches(path: Path): Boolean = {
+      if (this.size > path.size)
+        return false
+      var i = 0
+      while (i != this.size)
+        elems(i) match {
+          case Prefix.Label(buf) if buf != path.elems(i) =>
+            return false
+          case _ => // matches
+            i += 1
+        }
+      true
+    }
+
+    // A prefix acts somewhat like a Seq[Elem]
+    def take(n: Int) = Prefix(elems.take(n):_*)
+    def drop(n: Int) = Prefix(elems.drop(n):_*)
+    def ++(that: Prefix): Prefix =
+      if (that.isEmpty) this
+      else Prefix((elems ++ that.elems):_*)
+    def size: Int = elems.size
+    def isEmpty: Boolean = elems.isEmpty
+
+    def ++(path: Path): Prefix =
+      if (path.isEmpty) this
+      else this ++ Prefix(path)
+
+    lazy val showElems = elems.map(_.show)
+    lazy val show = showElems.mkString("/", "/", "")
+    override def toString = s"""Prefix(${showElems.mkString(",")})"""
+  }
+
+  object Prefix {
+
+    def apply(path: Path): Prefix =
+      Prefix(path.elems.map(Label(_)):_*)
+
+    /**
+     * Parse `s` as a prefix matching expression with concrete syntax
+     *
+     * {{{
+     * path       ::= '/' elems | '/'
+     *
+     * elems      ::= elem '/' elem | elem
+     *
+     * elem       ::= '*' | label
+     *
+     * label      ::= (\\x[a-f0-9][a-f0-9]|[0-9A-Za-z:.#$%-_])+
+     *
+     * }}}
+     *
+     * for example
+     *
+     * {{{
+     * /foo/bar/baz
+     * /foo&#47;*&#47;bar/baz
+     * /
+     * }}}
+     *
+     * parses into the path
+     *
+     * {{{
+     * Prefix(Label(foo),Label(bar),Label(baz))
+     * Prefix(Label(foo),AnyElem,Label(bar),Label(baz))
+     * Prefix()
+     * }}}
+     *
+     * @throws IllegalArgumentException when `s` is not a syntactically valid path.
+     */
+    def read(s: String): Prefix = NameTreeParsers.parseDentryPrefix(s)
+
+    val empty = new Prefix()
+
+    sealed trait Elem {
+      def show: String
+    }
+
+    object AnyElem extends Elem {
+      val show = "*"
+    }
+
+    case class Label(buf: Buf) extends Elem {
+      require(!buf.isEmpty)
+      lazy val show = Path.showElem(buf)
+    }
+
+    object Label {
+      def apply(s: String): Label = Label(Buf.Utf8(s))
+    }
   }
 }
 
@@ -168,8 +276,8 @@ object Dtab {
   }
 
   /**
-    * A failing delegation table.
-    */
+   * A failing delegation table.
+   */
   val fail: Dtab = Dtab.read("/=>!")
 
   /**

--- a/finagle-core/src/main/scala/com/twitter/finagle/NameTreeParsers.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/NameTreeParsers.scala
@@ -7,6 +7,7 @@ private[finagle] object NameTreeParsers {
   def parsePath(str: String): Path = new NameTreeParsers(str).parseAllPath()
   def parseNameTree(str: String): NameTree[Path] = new NameTreeParsers(str).parseAllNameTree()
   def parseDentry(str: String): Dentry = new NameTreeParsers(str).parseAllDentry()
+  def parseDentryPrefix(str: String): Dentry.Prefix = new NameTreeParsers(str).parseAllDentryPrefix()
   def parseDtab(str: String): Dtab = new NameTreeParsers(str).parseAllDtab()
 }
 
@@ -105,6 +106,14 @@ private class NameTreeParsers private (str: String) {
     Buf.ByteArray.Owned(baos.getBuf, 0, baos.size)
   }
 
+  private[this] def isDentryPrefixElemChar(c: Char) = isLabelChar(c) || c == '*'
+
+  private[this] def parseDentryPrefixElem(): Dentry.Prefix.Elem =
+    if (peek == '*') {
+      next()
+      Dentry.Prefix.AnyElem
+    } else Dentry.Prefix.Label(parseLabel())
+
   private[this] def isNumberChar(c: Char) = c.isDigit || c == '.'
 
   private[this] def parseNumber(): Double = {
@@ -123,6 +132,24 @@ private class NameTreeParsers private (str: String) {
       illegal("weight", '.')
     }
     sb.toString.toDouble // can fail if string is too long
+  }
+
+  private[this] def parseDentryPrefix(): Dentry.Prefix = {
+    eatWhitespace()
+    eat('/')
+
+    if (!isDentryPrefixElemChar(peek))
+      Dentry.Prefix.empty
+
+    else {
+      val elems = Buffer[Dentry.Prefix.Elem]()
+
+      do {
+        elems += parseDentryPrefixElem()
+      } while (maybeEat('/'))
+
+      Dentry.Prefix(elems:_*)
+    }
   }
 
   private[this] def parsePath(): Path = {
@@ -217,12 +244,12 @@ private class NameTreeParsers private (str: String) {
   }
 
   private[this] def parseDentry(): Dentry = {
-    val path = parsePath()
+    val prefix = parseDentryPrefix()
     eatWhitespace()
     eat('=')
     eat('>')
     val tree = parseTree()
-    Dentry(path, tree)
+    Dentry(prefix, tree)
   }
 
   private[this] def parseDtab(): Dtab = {
@@ -258,6 +285,13 @@ private class NameTreeParsers private (str: String) {
     eatWhitespace()
     ensureEnd()
     dentry
+  }
+
+  def parseAllDentryPrefix(): Dentry.Prefix = {
+    val pfx = parseDentryPrefix()
+    eatWhitespace()
+    ensureEnd()
+    pfx
   }
 
   def parseAllDtab(): Dtab = {

--- a/finagle-core/src/main/scala/com/twitter/finagle/Path.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/Path.scala
@@ -16,40 +16,21 @@ import java.util.BitSet
 case class Path(elems: Buf*) {
   require(elems.forall(Path.nonemptyBuf))
 
-  def startsWith(other: Path) = elems startsWith other.elems
+  def startsWith(other: Path) = elems.startsWith(other.elems)
 
-  def take(n: Int) = Path((elems take n):_*)
-  def drop(n: Int) = Path((elems drop n):_*)
+  def take(n: Int) = Path(elems.take(n):_*)
+  def drop(n: Int) = Path(elems.drop(n):_*)
   def ++(that: Path) =
     if (that.isEmpty) this
     else Path((elems ++ that.elems):_*)
   def size = elems.size
   def isEmpty = elems.isEmpty
 
-  lazy val showElems = elems map { buf =>
-    // We're extra careful with allocation here because any time
-    // there are nonbase delegations, we need to serialize the paths
-    // to strings
-    val nbuf = buf.length
-    val bytes = Buf.ByteArray.Owned.extract(buf)
-    if (Path.showableAsString(bytes, nbuf))
-      new String(bytes, 0, nbuf, Path.Utf8Charset)
-    else {
-      val str = new StringBuilder(nbuf * 4)
-      var i = 0
-      while (i < nbuf) {
-        str.append("\\x")
-        str.append(Integer.toString((bytes(i) >> 4) & 0xf, 16))
-        str.append(Integer.toString(bytes(i) & 0xf, 16))
-        i += 1
-      }
-      str.toString
-    }
-  }
+  lazy val showElems = elems.map(Path.showElem(_))
 
-  lazy val show = "/"+(showElems mkString "/")
+  lazy val show = showElems.mkString("/", "/", "")
 
-  override def toString = "Path("+(showElems mkString ",")+")"
+  override def toString = s"""Path(${showElems.mkString(",")})"""
 }
 
 object Path {
@@ -93,7 +74,7 @@ object Path {
    */
   def isShowable(ch: Char): Boolean = charSet.get(ch.toInt)
 
-  private def showableAsString(bytes: Array[Byte], size: Int): Boolean = {
+  private[finagle] def showableAsString(bytes: Array[Byte], size: Int): Boolean = {
     var i = 0
     while (i < size) {
       if (!isShowable(bytes(i).toChar))
@@ -101,6 +82,27 @@ object Path {
       i += 1
     }
     true
+  }
+
+  // We're extra careful with allocation here because any time
+  // there are nonbase delegations, we need to serialize the paths
+  // to strings
+  private[finagle] val showElem: Buf => String = { buf =>
+    val nbuf = buf.length
+    val bytes = Buf.ByteArray.Owned.extract(buf)
+    if (Path.showableAsString(bytes, nbuf))
+      new String(bytes, 0, nbuf, Path.Utf8Charset)
+    else {
+      val str = new StringBuilder(nbuf * 4)
+      var i = 0
+      while (i < nbuf) {
+        str.append("\\x")
+        str.append(Integer.toString((bytes(i) >> 4) & 0xf, 16))
+        str.append(Integer.toString(bytes(i) & 0xf, 16))
+        i += 1
+      }
+      str.toString
+    }
   }
 
   /**

--- a/finagle-core/src/test/scala/com/twitter/finagle/DtabTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/DtabTest.scala
@@ -61,7 +61,7 @@ class DtabTest extends FunSuite with AssertionsForJUnit {
     assert(dtab1.size == 2)
     dtab1(0) match {
       case Dentry(a, b) =>
-        assert(a == Path.Utf8("A"))
+        assert(a == Dentry.Prefix(Dentry.Prefix.Label("A")))
         assert(b == NameTree.Leaf(Path.Utf8("B")))
     }
   }
@@ -74,5 +74,10 @@ class DtabTest extends FunSuite with AssertionsForJUnit {
           """)
       } catch { case _: IllegalArgumentException => Dtab.empty }
     assert(dtab.length == 2)
+  }
+
+  test("dtab rewrites with wildcards") {
+    val dtab = Dtab.read("/a/*/c => /d")
+    assert(dtab.lookup(Path.read("/a/b/c/e/f")) == NameTree.Leaf(Name.Path(Path.read("/d/e/f"))))
   }
 }

--- a/finagle-core/src/test/scala/com/twitter/finagle/NameTreeParsersTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/NameTreeParsersTest.scala
@@ -67,14 +67,28 @@ class NameTreeParsersTest extends FunSuite with AssertionsForJUnit {
   test("parseDentry") {
     assert(NameTreeParsers.parseDentry("/=>!") == Dentry(Path.empty, NameTree.Fail))
     assert(NameTreeParsers.parseDentry("/ => !") == Dentry(Path.empty, NameTree.Fail))
-
+    assert(NameTreeParsers.parseDentry("/foo/*/bar => !") == Dentry(
+      Dentry.Prefix(
+        Dentry.Prefix.Label("foo"),
+        Dentry.Prefix.AnyElem,
+        Dentry.Prefix.Label("bar")),
+      NameTree.Fail))
+    assert(NameTreeParsers.parseDentry("/foo/bar/baz => !") == Dentry(
+      Dentry.Prefix(
+        Dentry.Prefix.Label("foo"),
+        Dentry.Prefix.Label("bar"),
+        Dentry.Prefix.Label("baz")),
+      NameTree.Fail))
+    intercept[IllegalArgumentException] { NameTreeParsers.parseDentry("/foo/*bar/baz => !") }
     intercept[IllegalArgumentException] { NameTreeParsers.parseDentry("/&!") }
   }
 
   test("parseDtab") {
     assert(NameTreeParsers.parseDtab("") == Dtab.empty)
-    assert(NameTreeParsers.parseDtab("  /=>!  ") == Dtab(IndexedSeq(Dentry(Path.empty, NameTree.Fail))))
-    assert(NameTreeParsers.parseDtab("/=>!;") == Dtab(IndexedSeq(Dentry(Path.empty, NameTree.Fail))))
+    assert(NameTreeParsers.parseDtab("  /=>!  ") ==
+      Dtab(IndexedSeq(Dentry(Path.empty, NameTree.Fail))))
+    assert(NameTreeParsers.parseDtab("/=>!;") ==
+      Dtab(IndexedSeq(Dentry(Path.empty, NameTree.Fail))))
     assert(NameTreeParsers.parseDtab("/=>!;/foo=>/bar") ==
       Dtab(IndexedSeq(
         Dentry(Path.empty, NameTree.Fail),

--- a/finagle-http/src/main/scala/com/twitter/finagle/http/codec/HttpDtab.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/http/codec/HttpDtab.scala
@@ -41,20 +41,20 @@ object HttpDtab {
   private def decodingFailure(value: String) =
     Failure("Value not b64-encoded: "+value)
 
-  private def pathFailure(path: String, cause: IllegalArgumentException) =
-    Failure("Invalid path: "+path, cause)
+  private def prefixFailure(prefix: String, cause: IllegalArgumentException) =
+    Failure("Invalid prefix: "+prefix, cause)
 
   private def nameFailure(name: String, cause: IllegalArgumentException) =
     Failure("Invalid name: "+name, cause)
 
-  private def decodePath(b64path: String): Try[Path] =
-      b64Decode(b64path) match {
-        case Throw(e: IllegalArgumentException) => Throw(decodingFailure(b64path))
-        case Throw(e) => Throw(e)
-        case Return(pathStr) =>
-          Try(Path.read(pathStr)).rescue {
-            case iae: IllegalArgumentException => Throw(pathFailure(pathStr, iae))
-          }
+  private def decodePrefix(b64pfx: String): Try[Dentry.Prefix] =
+    b64Decode(b64pfx) match {
+      case Throw(e: IllegalArgumentException) => Throw(decodingFailure(b64pfx))
+      case Throw(e) => Throw(e)
+      case Return(pfxStr) =>
+        Try(Dentry.Prefix.read(pfxStr)).rescue {
+          case iae: IllegalArgumentException => Throw(prefixFailure(pfxStr, iae))
+        }
     }
 
   private def decodeName(b64name: String): Try[NameTree[Path]] =
@@ -193,9 +193,9 @@ object HttpDtab {
 
       val tryDentry =
         for {
-          path <- decodePath(msg.headerMap(prefix))
+          pfx <- decodePrefix(msg.headerMap(prefix))
           name <- decodeName(msg.headerMap(dest))
-        } yield Dentry(path,  name)
+        } yield Dentry(pfx,  name)
 
       dentries(i) =
         tryDentry match {

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/codec/HttpDtabTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/codec/HttpDtabTest.scala
@@ -12,11 +12,11 @@ import java.nio.charset.Charset
 @RunWith(classOf[JUnitRunner])
 class HttpDtabTest extends FunSuite with AssertionsForJUnit {
   val okDests = Vector("/$/inet/10.0.0.1/9000", "/foo/bar", "/")
-  val okPrefixes = Vector("/foo", "/")
+  val okPrefixes = Vector("/foo", "/", "/foo/*/bar")
   val okDentries = for {
     prefix <- okPrefixes
     dest <- okDests
-  } yield Dentry(Path.read(prefix), NameTree.read(dest))
+  } yield Dentry(Dentry.Prefix.read(prefix), NameTree.read(dest))
 
   val Utf8 = Charset.forName("UTF-8")
   val Base64 = BaseEncoding.base64()
@@ -95,7 +95,7 @@ class HttpDtabTest extends FunSuite with AssertionsForJUnit {
     m.headers.set("X-Dtab-01-B", "L2Zhcg==") // /far
     val result = HttpDtab.read(m)
     val failure = intercept[Failure] { result.get() }
-    assert(failure.why == "Invalid path: /foo => /far")
+    assert(failure.why == "Invalid prefix: /foo => /far")
   }
 
   test("X-Dtab: Invalid name") {

--- a/finagle-thrift/src/main/scala/com/twitter/finagle/thrift/RichRequestHeader.scala
+++ b/finagle-thrift/src/main/scala/com/twitter/finagle/thrift/RichRequestHeader.scala
@@ -24,7 +24,7 @@ private[finagle] class RichRequestHeader(val header: RequestHeader) extends AnyV
       while (ds.hasNext()) {
         val d = ds.next()
         if (d.isSetSrc && d.isSetDst) {
-          val src = Path.read(d.getSrc)
+          val src = Dentry.Prefix.read(d.getSrc)
           val dst = NameTree.read(d.getDst)
           dtab += Dentry(src, dst)
         }


### PR DESCRIPTION
Problem

In some cases, it is convenient to simply ignore parts of a path when
processing dtabs.  This is currently quite awkward to accomplish with custom
namers.

Consider the case when a name like the following is processed:

    /http/1.1/GET/host/resource

Solution

Alter the Dtab syntax to support wildcards in prefix paths.  This enables dtabs in the form:

    /http/1.1/* => /h

This would allow the above name to easily be processed to /h/host/resource.