### PR TITLE
Make MapHeaderMap completely case insensitive

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -104,6 +104,14 @@ Breaking API Changes
   * finagle-redis: `c.t.f.redis.Redis` no longer takes a `StatsReceiver`, pass it to a
     `(Client/Server)Builder` instead. ``RB_ID=797821``
 
+
+Bug Fixes
+~~~~~~~~~
+
+  * finagle-core: Fixed `getAll` method on `c.t.f.http.MapHeaderMap`, now it is case insensitive.
+    `apply` method was altering the provided header names. This is fixed it is now possible to
+    iterate on the original header names.
+
 6.33.0
 ------
 

--- a/CHANGES
+++ b/CHANGES
@@ -104,6 +104,8 @@ Breaking API Changes
   * finagle-redis: `c.t.f.redis.Redis` no longer takes a `StatsReceiver`, pass it to a
     `(Client/Server)Builder` instead. ``RB_ID=797821``
 
+  * finagle-core: `c.t.f.http.MapHeaderMap` no longer takes a `mutable.Map[String, Seq[String]]` as
+    a constructor parameter. `apply` method provides a similar functionality.
 
 Bug Fixes
 ~~~~~~~~~

--- a/finagle-http/src/main/scala/com/twitter/finagle/http/HeaderMap.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/http/HeaderMap.scala
@@ -1,12 +1,14 @@
 package com.twitter.finagle.http
 
-import com.twitter.finagle.http.netty.HttpMessageProxy
-import com.twitter.util.TwitterDateFormat
 import java.text.SimpleDateFormat
 import java.util.{Date, Locale, TimeZone}
+
+import com.twitter.finagle.http.netty.HttpMessageProxy
+import com.twitter.util.TwitterDateFormat
+
 import scala.annotation.varargs
-import scala.collection.mutable
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 
 /**
  * Mutable message headers map.
@@ -52,67 +54,84 @@ abstract class HeaderMap
   def += (kv: (String, Date)): HeaderMap =
     += ((kv._1, HeaderMap.format(kv._2)))
 
-  override def empty: HeaderMap = new MapHeaderMap(mutable.Map.empty)
+  override def empty: HeaderMap = MapHeaderMap()
 }
 
+private[finagle] case class HeaderValuePair(header: String, value: String) {
+  val canonicalName = HeaderValuePair.canonicalName(header)
+}
+
+private[finagle] object HeaderValuePair {
+  def canonicalName(header: String) = header.toLowerCase(Locale.US)
+}
 
 /** Mutable-Map-backed [[HeaderMap]] */
-class MapHeaderMap(underlying: mutable.Map[String, Seq[String]]) extends HeaderMap {
+class MapHeaderMap extends HeaderMap {
+
+  private[this] val underlying = mutable.Map.empty[String, List[HeaderValuePair]]
+
+  // This is here to provide backward compatibility
+  def this(underlying: mutable.Map[String, Seq[String]]) {
+    this
+    for ((k, vs) <- underlying; v <- vs) yield {
+      add(k, v)
+    }
+  }
 
   def getAll(key: String): Iterable[String] =
-    underlying.getOrElse(key, Nil)
+    underlying.getOrElse(HeaderValuePair.canonicalName(key), Nil).map(_.value)
 
   def add(k: String, v: String): MapHeaderMap = {
-    underlying(k) = underlying.getOrElse(k, Nil) :+ v
+    val t = HeaderValuePair(k, v)
+    underlying(t.canonicalName) = underlying.getOrElse(t.canonicalName, Nil) :+ t
     this
   }
 
   def set(key: String, value: String): MapHeaderMap = {
-    underlying.retain { case (a, _) => !a.equalsIgnoreCase(key) }
-    underlying(key) = Seq(value)
+    val t = HeaderValuePair(key, value)
+    underlying(t.canonicalName) = List(t)
     this
   }
 
   // For Map/MapLike
   def get(key: String): Option[String] = {
-    underlying.find { case (k, v) => k.equalsIgnoreCase(key) }.flatMap { _._2.headOption }
+    getAll(key).headOption
   }
 
   // For Map/MapLike
   def iterator: Iterator[(String, String)] = {
-    for ((k, vs) <- underlying.iterator; v <- vs) yield
-      (k, v)
+    for ((_, vs) <- underlying.iterator; v <- vs) yield
+      (v.header, v.value)
   }
 
   // For Map/MapLike
   def += (kv: (String, String)): MapHeaderMap.this.type = {
-    underlying(kv._1) = Seq(kv._2)
+    val t = HeaderValuePair(kv._1, kv._2)
+    underlying(t.canonicalName) = List(t)
     this
   }
 
   // For Map/MapLike
   def -= (key: String): MapHeaderMap.this.type = {
-    underlying.retain { case (a, b) => !a.equalsIgnoreCase(key) }
+    underlying.remove(HeaderValuePair.canonicalName(key))
     this
   }
 
   override def keys: Iterable[String] =
-    underlying.keys
+    keySet
 
   override def keySet: Set[String] =
-    underlying.keySet.toSet
+    underlying.values.flatten.map(_.header).toSet
 
   override def keysIterator: Iterator[String] =
-    underlying.keysIterator
+    keySet.iterator
 }
-
 
 object MapHeaderMap {
   def apply(headers: Tuple2[String, String]*): MapHeaderMap = {
-    val map = headers
-      .groupBy { case (k, v) => k.toLowerCase }
-      .mapValues { case values => values.map { _._2 } } // remove keys
-    new MapHeaderMap(mutable.Map() ++ map)
+    val tmp = new MapHeaderMap
+    headers.foreach(t => tmp.add(t._1, t._2))
+    tmp
   }
 }
 

--- a/finagle-http/src/main/scala/com/twitter/finagle/http/HeaderMap.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/http/HeaderMap.scala
@@ -70,14 +70,6 @@ class MapHeaderMap extends HeaderMap {
 
   private[this] val underlying = mutable.Map.empty[String, List[HeaderValuePair]]
 
-  // This is here to provide backward compatibility
-  def this(underlying: mutable.Map[String, Seq[String]]) {
-    this
-    for ((k, vs) <- underlying; v <- vs) yield {
-      add(k, v)
-    }
-  }
-
   def getAll(key: String): Iterable[String] =
     underlying.getOrElse(HeaderValuePair.canonicalName(key), Nil).map(_.value)
 

--- a/finagle-http/src/main/scala/com/twitter/finagle/http/HeaderMap.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/http/HeaderMap.scala
@@ -105,9 +105,13 @@ class MapHeaderMap extends HeaderMap {
   }
 
   // For Map/MapLike
-  def += (kv: (String, String)): MapHeaderMap.this.type = {
+  def +=(kv: (String, String)): MapHeaderMap.this.type = {
     val t = HeaderValuePair(kv._1, kv._2)
-    underlying(t.canonicalName) = List(t)
+
+    // this slightly complicated logic is here to be backward compatible
+    underlying(t.canonicalName) =
+      underlying.getOrElse(t.canonicalName, Nil)
+        .filterNot(_.header == t.header) :+ t
     this
   }
 

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/MapHeaderMapTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/MapHeaderMapTest.scala
@@ -130,4 +130,11 @@ class MapHeaderMapTest extends FunSuite {
     val map2 = new MapHeaderMap(mutable.Map("a" -> Seq("1", "3"), "A" -> Seq("2")))
     assert(map2.iterator.toSet == Set("a" -> "1", "a" -> "3", "A" -> "2"))
   }
+
+  test("preserves the legacy behavior of +=") {
+    val map = MapHeaderMap("a" -> "1", "a" -> "3", "A" -> "2")
+    map += ("a" -> "4")
+
+    assert(map.iterator.toSet == Set("a" -> "4", "A" -> "2"))
+  }
 }

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/MapHeaderMapTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/MapHeaderMapTest.scala
@@ -123,14 +123,6 @@ class MapHeaderMapTest extends FunSuite {
     assert(map.keySet == Set("a", "A", "b", "B"))
   }
 
-  test("supports constructing from a map for legacy reasons") {
-    val map1 = new MapHeaderMap(mutable.Map.empty)
-    assert(map1.iterator.isEmpty == true)
-
-    val map2 = new MapHeaderMap(mutable.Map("a" -> Seq("1", "3"), "A" -> Seq("2")))
-    assert(map2.iterator.toSet == Set("a" -> "1", "a" -> "3", "A" -> "2"))
-  }
-
   test("preserves the legacy behavior of +=") {
     val map = MapHeaderMap("a" -> "1", "a" -> "3", "A" -> "2")
     map += ("a" -> "4")

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/MapHeaderMapTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/MapHeaderMapTest.scala
@@ -4,6 +4,8 @@ import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
 
+import scala.collection.mutable
+
 @RunWith(classOf[JUnitRunner])
 class MapHeaderMapTest extends FunSuite {
 
@@ -18,12 +20,12 @@ class MapHeaderMapTest extends FunSuite {
     val map = MapHeaderMap("a" -> "1", "b" -> "2", "a" -> "3")
 
     assert(map.get("a") == Some("1"))
-    assert(map.getAll("a").toList == List("1", "3"))
-    assert(map.iterator.toList.sorted == List(("a" -> "1"), ("a" -> "3"), ("b" -> "2")))
+    assert(map.getAll("a").toSet == Set("1", "3"))
+    assert(map.iterator.toSet == Set(("a" -> "1"), ("a" -> "3"), ("b" -> "2")))
 
-    assert(map.keys.toList.sorted == List("a", "b"))
-    assert(map.keySet.toList.sorted == List("a", "b"))
-    assert(map.keysIterator.toList.sorted == List("a", "b"))
+    assert(map.keys.toSet == Set("a", "b"))
+    assert(map.keySet == Set("a", "b"))
+    assert(map.keysIterator.toSet == Set("a", "b"))
   }
 
   test("+=") {
@@ -33,8 +35,8 @@ class MapHeaderMapTest extends FunSuite {
     map += "a" -> "3"
 
     assert(map.get("a") == Some("3"))
-    assert(map.getAll("a").toList == List("3"))
-    assert(map.iterator.toList.sorted == List(("a" -> "3"), ("b" -> "2")))
+    assert(map.getAll("a").toSet == Set("3"))
+    assert(map.iterator.toSet == Set(("a" -> "3"), ("b" -> "2")))
   }
 
   test("add") {
@@ -44,8 +46,8 @@ class MapHeaderMapTest extends FunSuite {
     map.add("a", "3")
 
     assert(map.get("a") == Some("1"))
-    assert(map.getAll("a").toList == List("1", "3"))
-    assert(map.iterator.toList.sorted == List(("a" -> "1"), ("a" -> "3"), ("b" -> "2")))
+    assert(map.getAll("a").toSet == Set("1", "3"))
+    assert(map.iterator.toSet == Set(("a" -> "1"), ("a" -> "3"), ("b" -> "2")))
   }
 
   test("set") {
@@ -56,8 +58,8 @@ class MapHeaderMapTest extends FunSuite {
     map.set("a", "3")
 
     assert(map.get("a") == Some("3"))
-    assert(map.getAll("a").toList == List("3"))
-    assert(map.iterator.toList.sorted == List(("a" -> "3"), ("b" -> "2")))
+    assert(map.getAll("a").toSet == Set("3"))
+    assert(map.iterator.toSet == Set(("a" -> "3"), ("b" -> "2")))
   }
 
   test("-=") {
@@ -69,5 +71,63 @@ class MapHeaderMapTest extends FunSuite {
     assert(map.getAll("a").isEmpty == true)
     assert(map.iterator.isEmpty == true)
     map -= "a" // this is legal
+  }
+
+  test("get is case insensitive and returns the first inserted header") {
+    val map1 = MapHeaderMap()
+    map1.set("a", "1")
+    map1.add("A", "2")
+    assert(map1.get("a") == Some("1"))
+    assert(map1.get("A") == Some("1"))
+
+    val map2 = MapHeaderMap()
+    map2.set("A", "5")
+    map2.add("a", "6")
+    map2.add("a", "7")
+    assert(map2.get("a") == Some("5"))
+    assert(map2.get("A") == Some("5"))
+  }
+
+  test("getAll is case insensitive") {
+    val map = MapHeaderMap()
+
+    map.set("a", "1")
+    map.add("a", "3")
+    map.add("A", "4")
+    assert(map.getAll("a").toSet == Set("1", "3", "4"))
+    assert(map.getAll("A").toSet == Set("1", "3", "4"))
+  }
+
+  test("-= is case insensitive") {
+    val map = MapHeaderMap()
+
+    map += ("a" -> "5")
+    map -= "A"
+    assert(map.keySet.isEmpty == true)
+
+    map += ("A" -> "5")
+    map -= "a"
+    assert(map.keySet.isEmpty == true)
+  }
+
+  test("iterator and keySet exposes original header names") {
+    val map = MapHeaderMap("a" -> "1", "A" -> "2", "a" -> "3")
+
+    assert(map.iterator.toSet == Set("a" -> "1", "A" -> "2", "a" -> "3"))
+    assert(map.keySet == Set("a", "A"))
+
+    map.set("B", "1")
+    map.add("b", "2")
+
+    assert(map.iterator.toSet == Set("a" -> "1", "A" -> "2", "a" -> "3", "B" -> "1", "b" -> "2"))
+    assert(map.keySet == Set("a", "A", "b", "B"))
+  }
+
+  test("supports constructing from a map for legacy reasons") {
+    val map1 = new MapHeaderMap(mutable.Map.empty)
+    assert(map1.iterator.isEmpty == true)
+
+    val map2 = new MapHeaderMap(mutable.Map("a" -> Seq("1", "3"), "A" -> Seq("2")))
+    assert(map2.iterator.toSet == Set("a" -> "1", "a" -> "3", "A" -> "2"))
   }
 }


### PR DESCRIPTION
Http header field names are case-insensitive ([rfc2616#4.2](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2)). Therefore [MapHeaderMap](https://github.com/twitter/finagle/blob/develop/finagle-http/src/main/scala/com/twitter/finagle/http/HeaderMap.scala#L60) is designed to be case-insensitive. However only a subset of methods are obeying to this contract.

For example with the current implementation the tests below fail;

```scala
  test("test set and getAll") {
    val map = MapHeaderMap()
    map.set("KEY", "1")
    assert(map.getAll("key") == List("1"))
  }

  test("test +=") {
    val map = MapHeaderMap()
    map += ("KEY" -> "1")
    assert(map.getAll("key") == List("1"))
  }
```
```bash
[info] - test set and getAll *** FAILED ***
[info]   List() did not equal List("1") (MapHeaderMapTest.scala:13)
[info] - test += *** FAILED ***
[info]   List() did not equal List("1") (MapHeaderMapTest.scala:19)

```

There are easier solutions for this problem (details are below), however in order to be backward compatible (to a sufficient degree) this pr introduces a slightly more complicated logic.

In this pr, all the headers are stored with their original header names, but they are grouped by the [canonical name of the header](https://github.com/grandbora/finagle/blob/make-headermap-case-insensitive/finagle-http/src/main/scala/com/twitter/finagle/http/HeaderMap.scala#L65) on write (see `set`, `add` and `+=` methods). 

In order to keep things sane, I created the [HeaderValuePair](https://github.com/grandbora/finagle/blob/make-headermap-case-insensitive/finagle-http/src/main/scala/com/twitter/finagle/http/HeaderMap.scala#L60) abstraction, which is an implementation detail and is not visible to library users.

---- 

For the curious, other possible solutions;

* **Modify on write**
On write, lowercase every header field name (set, add, +=, apply). In [MapHeaderMap#apply](https://github.com/twitter/finagle/blob/develop/finagle-http/src/main/scala/com/twitter/finagle/http/HeaderMap.scala#L113) method this approach has been taken but it is not propagated to other write methods.

* **Merge on read**
 On write, use given header field names as they are. On read, find every entry that matches the given header field name an a case-insensitive manner and merge their values.

* **Use a case-insensitive data structure as underlying storage object**
Delegate the responsibility of handling case-insensitivity to the underlying object. Use something like `new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);`


The disadvantage of first approach is that it relies on `.toLowerCase`. In theory [header field names can contain any ISO-8859-1 character](https://tools.ietf.org/html/rfc5987#section-1). I am not sure if there would be some edge cases in the behavior of `.toLowerCase` if a non ASCII character appears in the header field name (not even sure if this is a valid concern).

Second approach doesn't have the disadvantage mentioned above, as long as it uses `String#equalsIgnoreCase` method. However keeping various representations in the underlying storage, for a single header seems like an unnecessary complication.

Third approach can actually be the cleanest implementation, however I don't know if using case-insensitive TreeMap has performance impacts or if it is feasible.

@fwbrasil care to take a look :)