### PR TITLE
Allow control over thrift protocol upgrade.

### DIFF
--- a/finagle-thrift/src/test/scala/com/twitter/finagle/thrift/EndToEndTest.scala
+++ b/finagle-thrift/src/test/scala/com/twitter/finagle/thrift/EndToEndTest.scala
@@ -64,6 +64,7 @@ class EndToEndTest extends FunSuite with ThriftTest with BeforeAndAfter {
   val serviceToIface = new B.ServiceToClient(_, _)
 
   val missingClientIdEx = new IllegalStateException("uh no client id")
+  val presentClientIdEx = new IllegalStateException("unexpected client id")
 
   def servers(pf: TProtocolFactory): Seq[(String, Closable, Int)] = {
     val iface = new BServiceImpl {
@@ -518,6 +519,32 @@ class EndToEndTest extends FunSuite with ThriftTest with BeforeAndAfter {
     assert(sr.stat("server", "response_payload_bytes")() == Seq(40.0f, 45.0f))
 
     Await.ready(ss.close())
+  }
+
+  test("clientId is not sent and prep stats are not recorded when TTwitter upgrading is disabled") {
+    val pf = Protocols.binaryFactory()
+    val iface = new BServiceImpl {
+      override def someway(): Future[Void] = {
+        ClientId.current.map(_.name) match {
+          case Some(name) => Future.exception(presentClientIdEx)
+          case _ => Future.Void
+        }
+      }
+    }
+    val server = Thrift.server
+      .withProtocolFactory(pf)
+      .serveIface(new InetSocketAddress(InetAddress.getLoopbackAddress, 0), iface)
+
+    val sr = new InMemoryStatsReceiver()
+    val client = Thrift.client
+      .configured(Stats(sr))
+      .withProtocolFactory(pf)
+      .withClientId(ClientId("aClient"))
+      .withNoAttemptTTwitterUpgrade
+      .newIface[B.ServiceIface](server)
+
+    assert(Await.result(client.someway()) == null, 5.seconds)
+    assert(sr.stats.get(Seq("codec_connection_preparation_latency_ms")) == None)
   }
 }
 

--- a/finagle-thrift/src/test/scala/com/twitter/finagle/thrift/EndToEndTest.scala
+++ b/finagle-thrift/src/test/scala/com/twitter/finagle/thrift/EndToEndTest.scala
@@ -543,7 +543,7 @@ class EndToEndTest extends FunSuite with ThriftTest with BeforeAndAfter {
       .withNoAttemptTTwitterUpgrade
       .newIface[B.ServiceIface](server)
 
-    assert(Await.result(client.someway()) == null, 5.seconds)
+    assert(Await.result(client.someway(), 5.seconds) == null)
     assert(sr.stats.get(Seq("codec_connection_preparation_latency_ms")) == None)
   }
 }


### PR DESCRIPTION
Problem

Some thrift server implementations react badly to unknown methods. In
particular, the go implementation throws up its hands and closes the
connection. This makes finagle thrift clients unusable with go servers
as finagle's attempt to upgrade the protocol results in a closed
connection.

Solution

Introduce the ability to control protocol upgrading. This is done
through a new Param (for Stack clients) and a new parameter to
ThriftClient(Buffered|Framed)Codec(Factory)? (for older clients). In
both cases, the preparer simply returns the underlying ServiceFactory
when the parameter is set to false. The parameter default is true to
by default to retain backwards compatibility.

Result

Existing code will continue to run as-is - protocol upgrading will be
attempted. New code gains the ability to turn off upgrading. When
upgrading is off, the upgrade message will not be sent and clients will
work with funky servers.

Also-by: Alex Leong <alex@buoyant.io>