### PR TITLE
Implement server-side request entity decoding (#476 & #469).

### DIFF
--- a/finagle-http/src/main/scala/com/twitter/finagle/http/Codec.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/http/Codec.scala
@@ -205,6 +205,9 @@ case class Http(
             pipeline.addLast("httpCompressor", new TextualContentCompressor)
           }
 
+          if (_decompressionEnabled)
+            pipeline.addLast("httpDecompressor", new HttpContentDecompressor)
+
           // The payload size handler should come before the RespondToExpectContinue handler so that we don't
           // send a 100 CONTINUE for oversize requests we have no intention of handling.
           pipeline.addLast("payloadSizeHandler", new PayloadSizeHandler(maxRequestSizeInBytes))

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/ServerSideDecodingTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/ServerSideDecodingTest.scala
@@ -3,7 +3,7 @@ package com.twitter.finagle.http
 import java.io.{ByteArrayOutputStream, OutputStream, PrintStream}
 import java.net.InetSocketAddress
 import java.util.zip.{DeflaterOutputStream, GZIPOutputStream}
-
+import com.twitter.conversions.time._
 import com.twitter.finagle
 import com.twitter.finagle.Service
 import com.twitter.finagle.builder.ClientBuilder
@@ -88,7 +88,7 @@ class ServerSideDecodingTest extends FunSuite with GeneratorDrivenPropertyChecks
         .setHeader("Content-Type", "text/plain;charset=utf-8")
         .url(url)
 
-      assert(content == Await.result(client(req.buildPost(encoder.encode(content)))).contentString)
+      assert(content == Await.result(client(req.buildPost(encoder.encode(content))), 1.second).contentString)
     }
   }
 }

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/ServerSideDecodingTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/ServerSideDecodingTest.scala
@@ -16,12 +16,13 @@ import org.scalatest.junit.JUnitRunner
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 
-/** Provides tests for server side content decoding.
-  *
-  * If and when client side compression is implemented, this test should probably be removed in favour of a complete
-  * entry in [[EndToEndTest]]. Client side compression is currently made problematic by netty
-  * (see https://github.com/netty/netty/issues/4970).
-  */
+/**
+ *  Provides tests for server side content decoding.
+ *
+ * If and when client side compression is implemented, this test should probably be removed in favour of a complete
+ * entry in [[EndToEndTest]]. Client side compression is currently made problematic by netty
+ * (see https://github.com/netty/netty/issues/4970).
+ */
 @RunWith(classOf[JUnitRunner])
 class ServerSideDecodingTest extends FunSuite with GeneratorDrivenPropertyChecks with BeforeAndAfterAll {
   // Echo server (with decoding)

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/ServerSideDecodingTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/ServerSideDecodingTest.scala
@@ -46,8 +46,8 @@ class ServerSideDecodingTest extends FunSuite with GeneratorDrivenPropertyChecks
 
   // URL at which all requests should be made
   val url: String = {
-    val adr = server.boundAddress.asInstanceOf[InetSocketAddress]
-    s"http://${adr.getHostName}:${adr.getPort}/"
+    val addr = server.boundAddress.asInstanceOf[InetSocketAddress]
+    s"http://${addr.getHostName}:${addr.getPort}/"
   }
 
   // Makes sure everything is cleaned up

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/ServerSideDecodingTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/ServerSideDecodingTest.scala
@@ -1,14 +1,14 @@
 package com.twitter.finagle.http
 
-import java.io.{ByteArrayOutputStream, OutputStream, PrintStream}
-import java.net.InetSocketAddress
-import java.util.zip.{DeflaterOutputStream, GZIPOutputStream}
 import com.twitter.conversions.time._
 import com.twitter.finagle
 import com.twitter.finagle.Service
 import com.twitter.finagle.builder.ClientBuilder
 import com.twitter.io.Buf
 import com.twitter.util.{Await, Closable, Future}
+import java.io.{ByteArrayOutputStream, OutputStream, PrintStream}
+import java.net.InetSocketAddress
+import java.util.zip.{DeflaterOutputStream, GZIPOutputStream}
 import org.jboss.netty.handler.codec.http.HttpHeaders
 import org.junit.runner.RunWith
 import org.scalacheck.{Arbitrary, Gen}

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/ServerSideDecodingTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/ServerSideDecodingTest.scala
@@ -1,0 +1,94 @@
+package com.twitter.finagle.http
+
+import java.io.{ByteArrayOutputStream, OutputStream, PrintStream}
+import java.net.InetSocketAddress
+import java.util.zip.{DeflaterOutputStream, GZIPOutputStream}
+
+import com.twitter.finagle
+import com.twitter.finagle.Service
+import com.twitter.finagle.builder.ClientBuilder
+import com.twitter.io.Buf
+import com.twitter.util.{Await, Closable, Future}
+import org.jboss.netty.handler.codec.http.HttpHeaders
+import org.junit.runner.RunWith
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
+
+/** Provides tests for server side content decoding.
+  *
+  * If and when client side compression is implemented, this test should probably be removed in favour of a complete
+  * entry in [[EndToEndTest]]. Client side compression is currently made problematic by netty
+  * (see https://github.com/netty/netty/issues/4970).
+  */
+@RunWith(classOf[JUnitRunner])
+class ServerSideDecodingTest extends FunSuite with GeneratorDrivenPropertyChecks with BeforeAndAfterAll {
+  // Echo server (with decoding)
+  val server = finagle.Http.server
+    .withLabel("server")
+    .withDecompression(true)
+    .serve("localhost:*", new Service[Request, Response] {
+      def apply(request: Request) = {
+        val response = Response()
+        response.contentString = request.contentString
+        Future.value(response)
+      }
+    })
+
+  // Standard client
+  val client = ClientBuilder()
+    .codec(Http())
+    .hosts(Seq(server.boundAddress.asInstanceOf[InetSocketAddress]))
+    .hostConnectionLimit(1)
+    .build()
+
+  // URL at which all requests should be made
+  val url: String = {
+    val adr = server.boundAddress.asInstanceOf[InetSocketAddress]
+    s"http://${adr.getHostName}:${adr.getPort}/"
+  }
+
+  // Makes sure everything is cleaned up
+  override def afterAll(): Unit = {
+    Closable.all(client, server)
+  }
+
+  // Helper class - might be overkill to have a sum type for just one test, but it makes it simple to provide an
+  // Arbitrary instance for encoders and to make the actual test that much more readable.
+  sealed abstract class Encoder(val name: String) {
+    def encodeWith(out: OutputStream): OutputStream
+    def encode(string: String): Buf = {
+      val bytes = new ByteArrayOutputStream()
+      val out = new PrintStream(encodeWith(bytes), true, "UTF-8")
+      out.print(string)
+      out.close() // Do not remove, filter streams absolutely need this to generate legal content.
+      Buf.ByteArray.Shared(bytes.toByteArray)
+    }
+  }
+
+  case object Gzip extends Encoder(HttpHeaders.Values.GZIP) {
+    override def encodeWith(out: OutputStream) = new GZIPOutputStream(out)
+  }
+
+  case object Deflate extends Encoder(HttpHeaders.Values.DEFLATE) {
+    override def encodeWith(out: OutputStream) = new DeflaterOutputStream(out)
+  }
+
+  case object Identity extends Encoder(HttpHeaders.Values.IDENTITY) {
+    override def encodeWith(out: OutputStream) = out
+  }
+
+  implicit val arbEncoder: Arbitrary[Encoder] = Arbitrary(Gen.oneOf(Gzip, Deflate, Identity))
+
+  test("decode client-side encoded entity bodies") {
+    forAll { (content: String, encoder: Encoder) ⇒
+      val req = RequestBuilder()
+        .setHeader("Content-Encoding", encoder.name)
+        .setHeader("Content-Type", "text/plain;charset=utf-8")
+        .url(url)
+
+      assert(content == Await.result(client(req.buildPost(encoder.encode(content)))).contentString)
+    }
+  }
+}


### PR DESCRIPTION
Problem

Finagle currently fails to decode legal client-submitted encoded request entities (typically, gzipped or deflated).

See #476 and #469 for more details.

Solution

Hook `HttpContentDecompressor` into server pipelines whenever configured to support it.