### PR TITLE
Added Round Robin load balancer for comparison purposes and improved Simulation.scala

### DIFF
--- a/finagle-benchmark/src/main/scala/com/twitter/finagle/loadbalancer/Simulation.scala
+++ b/finagle-benchmark/src/main/scala/com/twitter/finagle/loadbalancer/Simulation.scala
@@ -3,6 +3,7 @@ package com.twitter.finagle.loadbalancer
 import com.twitter.conversions.time._
 import com.twitter.finagle._
 import com.twitter.finagle.stats.{StatsReceiver, SummarizingStatsReceiver, Stat}
+import com.twitter.finagle.tracing.Trace
 import com.twitter.finagle.util.{Drv, Rng, DefaultTimer}
 import com.twitter.util.{Function => _, _}
 import java.util.concurrent.atomic.AtomicInteger
@@ -139,9 +140,16 @@ private[finagle] class LatencyFactory(sr: StatsReceiver) {
 private[finagle] object Simulation extends com.twitter.app.App {
 
   val qps = flag("qps", 1250, "QPS at which to run the benchmark")
+  // TODO: add an option to always make a fixed number of requests.
   val dur = flag("dur", 45.seconds, "Benchmark duration")
   val nstable = flag("stable", 10, "Number of stable hosts")
   val bal = flag("bal", "p2c", "Load balancer")
+  val coldstart = flag("coldstart", true, "Add a cold start backend")
+  // we need a client that gets slow and then speeds up again
+  val slowmiddle = flag("slowmiddle", false, "Adds a fast-then-slow-then-fast again backend")
+  val showprogress = flag("showprogress", true, "print stats each second")
+  val showsummary = flag("showsummary", true,
+    "prints a Stats summary or else print each response time")
 
   def main() {
     val Qpms = qps()/1000
@@ -176,19 +184,45 @@ private[finagle] object Simulation extends com.twitter.app.App {
           activity,
           statsReceiver=stats.scope("aperture"),
           noBrokers)
+
+      case "rr" =>
+        Balancers.rr().newBalancer(
+          activity,
+          statsReceiver=stats.scope("rr"),
+          noBrokers)
     }
 
     val balancer = factory.toService
-
     val latstat = stats.stat("latency")
-    def call() = Stat.timeFuture(latstat, TimeUnit.MILLISECONDS) { balancer(()) }
+
+    val call: () => Unit = if (showsummary()) {
+      () => { Stat.timeFuture(latstat, TimeUnit.MILLISECONDS) { balancer(()) } }
+    } else {
+      () => {
+        val profileStopWatch = Stopwatch.start()
+        balancer().ensure {
+          Trace.recordBinary("balancer", profileStopWatch().inMilliseconds)
+        }
+      }
+    }
 
     val stopWatch = Stopwatch.start()
     val p = new LatencyProfile(stopWatch)
 
-    val coldStart = p.warmup(10.seconds)_ andThen p.slowWithin(19.seconds, 23.seconds, 10)
-    underlying() += newFactory(nstable()+1, coldStart(dist))
-    underlying() += newFactory(nstable()+2, p.slowBy(2)(dist))
+    var n = 1
+    if (coldstart()) {
+      val coldStart = p.warmup(10.seconds)_ andThen p.slowWithin(19.seconds, 23.seconds, 10)
+      underlying() += newFactory(nstable()+n, coldStart(dist))
+      n += 1
+      underlying() += newFactory(nstable()+n, p.slowBy(2)(dist))
+      n += 1
+    }
+
+    if (slowmiddle()) {
+      val slowMiddle = p.slowWithin(15.seconds, 45.seconds, 10)_
+      underlying() += newFactory(nstable() + n, slowMiddle(dist))
+      n += 1
+    }
 
     var ms = 0
     while (stopWatch() < dur()) {
@@ -204,16 +238,20 @@ private[finagle] object Simulation extends com.twitter.app.App {
 
       ms += 1
 
-      if (ms%1000==0) {
-        println("-"*100)
-        println("Requests at %s".format(stopWatch()))
+      if (showprogress()) {
+        if (ms%1000==0) {
+          println("-"*100)
+          println("Requests at %s".format(stopWatch()))
 
-        val lines = for ((name, fn) <- stats.gauges.toSeq) yield (name.mkString("/"), fn())
-        for ((name, value) <- lines.sortBy(_._1))
-          println(name+" "+value)
+          val lines = for ((name, fn) <- stats.gauges.toSeq) yield (name.mkString("/"), fn())
+          for ((name, value) <- lines.sortBy(_._1))
+            println(name+" "+value)
+        }
       }
     }
 
-    println(stats.summary(includeTails = true))
+    if (showsummary()) {
+      println(stats.summary(includeTails = true))
+    }
   }
 }

--- a/finagle-benchmark/src/main/scripts/build_graphs.R
+++ b/finagle-benchmark/src/main/scripts/build_graphs.R
@@ -1,0 +1,91 @@
+This is not really an R script, it is a literate transcript of the R
+functions I wrote to generate a graph combined with some commentary on
+the data generated. How I use this script is to copy and paste
+snippets into my R workspace.
+
+# returns a data.frame with response times from different load balancers, sampled at the given rate.
+buildData <- function(rr, p2c, ewma, samples=1000) {
+    rr <- read.table(rr)
+    p2c <- read.table(p2c)
+    ewma <- read.table(ewma)
+    data = data.frame(seq(1, samples),
+         sample(rr$V1, samples),
+         sample(p2c$V1, samples),
+         sample(ewma$V1, samples))
+
+    names(data) <- c("id", "rr", "p2c", "ewma")
+
+    return(data)
+}
+
+allGood <- buildData(rr="all_good_1000_rr.txt", p2c="all_good_1000_p2c.txt", ewma="all_good_1000_ewma.txt")
+
+slowMiddle <- buildData(rr="slow_middle_1000_rr.txt", p2c="slow_middle_1000_p2c.txt", ewma="slow_middle_1000_ewma.txt")
+
+slowStart <- buildData(rr="slow_start_1000_rr.txt", p2c="slow_start_1000_p2c.txt", ewma="slow_start_1000_ewma.txt")
+
+# Overlapping ewma vs rr histograms
+> nines = c(0.5, 0.9, 0.95, 0.96, 0.97, 0.98, 0.99, 0.999, 0.9999, 0.99999)
+> quantile(slowMiddle$p2c, nines)
+     50%      90%      95%      96%      97%      98%      99%    99.9%   99.99%  99.999%
+ 174.000  184.000  189.000  191.000  193.000  197.000  205.000 1723.004 1825.201 1907.291
+> quantile(slowMiddle$ewma, nines)
+     50%      90%      95%      96%      97%      98%      99%    99.9%   99.99%  99.999%
+ 174.000  183.000  188.000  189.000  191.000  194.000  199.000  211.000 1780.103 1819.110
+> quantile(slowMiddle$rr, nines)
+    50%     90%     95%     96%     97%     98%     99%   99.9%  99.99% 99.999%
+ 175.00  187.00  203.00 1664.00 1673.00 1683.00 1714.00 1862.00 1977.70 1994.56
+
+### How to think about the latency graphic where Round Robin jumps up
+to 2 seconds after 95%
+
+What does it mean for our service? If your timeout was 1 second, your
+success rate dropped to 95% during this period of time if you used
+round robin. Your success rate only drops to 99.9% if you used EWMA.
+99% if you used queue-depth as your metric.
+
+We setup a load balancing simulation with repsonse latencies from some
+collected ping data. The median was 167ms with a stddev of 5ms and a
+max of 200ms.
+
+10 good clients and 1 client that slows to 2 seconds in the middle of
+the test run and then recovers back to normal. This acts similar to a
+bad GC pause in a backend. No timeouts enabled and no retries.
+
+[TODO: find a way to do this automatically]
+I hand-converted those quantiles into the following file (rr_latencies.txt):
+
+Please note that the file uses tabs.
+
+percentile         queue       ewma rr
+"90"               184         183  187
+"95"               189         188  203
+"97"               193         191  1673
+"98"               197         194  1683
+"99"               205         199  1714
+"99.9"             1723        211  1862
+"99.99"            1825        1780 1977
+"99.999"           1907        1819 1994
+
+Here's how we generate the png of response times.
+
+rr_latencies <- read.table("rr_latencies.txt", header=TRUE)
+# turn this into a new dataframe for my own sanity. read.table is not being helpful
+df <- data.frame(percentile=rr_latencies$percentile, ewma=rr_latencies$ewma, queue=rr_latencies$queue, roundrobin=rr_latencies$rr)
+# builds an x-axis along the number of 9s we care about.
+# the graph looks nuts along the automatically inferred scale so we'll force a continuous scale.
+df$nines <- abs(log10(1.0 - df$percentile / 100))
+
+png("rr_latencies.png", width=960, height=960)
+theme_set(theme_bw(base_size = 27) + theme(legend.key.size=unit(35, "pt")))
+ggplot(data=df, aes(x=nines, y=roundrobin)) +
+       scale_x_continuous(breaks=df$nines,
+                     labels=c("90", "95", "97", "98", "99", "99.9", "99.99", "99.999")) +
+       geom_point(aes(y=roundrobin, col="Round Robin")) +
+       geom_line(aes(y=roundrobin, col="Round Robin")) +
+       geom_point(aes(y=ewma, col="EWMA")) +
+       geom_line(aes(y=ewma, col="EWMA")) +
+       geom_point(aes(y=queue, col="Least Loaded")) +
+       geom_line(aes(y=queue, col="Least Loaded")) +
+       labs(title="Latency by Load Balancer", x="Percentile", y="Latency (ms)", color="Balancers")
+dev.off()

--- a/finagle-benchmark/src/main/scripts/load_balancing_numbers.sh
+++ b/finagle-benchmark/src/main/scripts/load_balancing_numbers.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+./sbt 'project finagle-benchmark' \
+      'run-main com.twitter.finagle.loadbalancer.Simulation -com.twitter.finagle.tracing.debugTrace=true -dur=60.seconds -bal=rr -qps=1000 -showprogress=false -showsummary=false -coldstart=false' 2>&1 |gawk 'match($0, /BinaryAnnotation\(balancer,([0-9]+).*\)/, a){print a[1]}' > all_good_1000_rr.txt
+
+./sbt 'project finagle-benchmark' \
+      'run-main com.twitter.finagle.loadbalancer.Simulation -com.twitter.finagle.tracing.debugTrace=true -dur=60.seconds -bal=p2c -qps=1000 -showprogress=false -showsummary=false -coldstart=false' 2>&1 |gawk 'match($0, /BinaryAnnotation\(balancer,([0-9]+).*\)/, a){print a[1]}' > all_good_1000_p2c.txt
+
+./sbt 'project finagle-benchmark' \
+      'run-main com.twitter.finagle.loadbalancer.Simulation -com.twitter.finagle.tracing.debugTrace=true -dur=60.seconds -bal=ewma -qps=1000 -showprogress=false -showsummary=false -coldstart=false' 2>&1 |gawk 'match($0, /BinaryAnnotation\(balancer,([0-9]+).*\)/, a){print a[1]}' > all_good_1000_ewma.txt
+
+./sbt 'project finagle-benchmark' \
+      'run-main com.twitter.finagle.loadbalancer.Simulation -com.twitter.finagle.tracing.debugTrace=true -dur=60.seconds -bal=rr -qps=1000 -showprogress=false -showsummary=false -coldstart=true' 2>&1 |gawk 'match($0, /BinaryAnnotation\(balancer,([0-9]+).*\)/, a){print a[1]}' > slow_start_1000_rr.txt
+
+./sbt 'project finagle-benchmark' \
+      'run-main com.twitter.finagle.loadbalancer.Simulation -com.twitter.finagle.tracing.debugTrace=true -dur=60.seconds -bal=p2c -qps=1000 -showprogress=false -showsummary=false -coldstart=true' 2>&1 |gawk 'match($0, /BinaryAnnotation\(balancer,([0-9]+).*\)/, a){print a[1]}' > slow_start_1000_p2c.txt
+
+./sbt 'project finagle-benchmark' \
+'run-main com.twitter.finagle.loadbalancer.Simulation -com.twitter.finagle.tracing.debugTrace=true -bal=ewma -dur=60.seconds -qps=1000 -showprogress=false -showsummary=false -coldstart=true' 2>&1 |gawk 'match($0, /BinaryAnnotation\(balancer,([0-9]+).*\)/, a){print a[1]}' > slow_start_1000_ewma.txt
+
+./sbt 'project finagle-benchmark' \
+      'run-main com.twitter.finagle.loadbalancer.Simulation -com.twitter.finagle.tracing.debugTrace=true -dur=60.seconds -bal=rr -qps=1000 -showprogress=false -showsummary=false -coldstart=false -slowmiddle=true' 2>&1 |gawk 'match($0, /BinaryAnnotation\(balancer,([0-9]+).*\)/, a){print a[1]}' > slow_middle_1000_rr.txt
+
+./sbt 'project finagle-benchmark' \
+      'run-main com.twitter.finagle.loadbalancer.Simulation -com.twitter.finagle.tracing.debugTrace=true -dur=60.seconds -bal=p2c -qps=1000 -showprogress=false -showsummary=false -coldstart=false -slowmiddle=true' 2>&1 |gawk 'match($0, /BinaryAnnotation\(balancer,([0-9]+).*\)/, a){print a[1]}' > slow_middle_1000_p2c.txt
+
+./sbt 'project finagle-benchmark' \
+      'run-main com.twitter.finagle.loadbalancer.Simulation -com.twitter.finagle.tracing.debugTrace=true -dur=60.seconds -bal=ewma -qps=1000 -showprogress=false -showsummary=false -coldstart=false -slowmiddle=true' 2>&1 |gawk 'match($0, /BinaryAnnotation\(balancer,([0-9]+).*\)/, a){print a[1]}' > slow_middle_1000_ewma.txt

--- a/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/Aperture.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/Aperture.scala
@@ -39,7 +39,7 @@ import java.util.concurrent.atomic.AtomicInteger
  *     arranges load in a manner that ensures a higher level of per-service
  *     concurrency.
  */
-private class ApertureLoadBandBalancer[Req, Rep](
+private[loadbalancer] class ApertureLoadBandBalancer[Req, Rep](
     protected val activity: Activity[Traversable[ServiceFactory[Req, Rep]]],
     protected val smoothWin: Duration,
     protected val lowLoad: Double,
@@ -85,7 +85,7 @@ object Aperture {
  * harmless to adjust apertures frequently, since underlying nodes
  * are typically backed by pools, and will be warm on average.
  */
-private trait Aperture[Req, Rep] { self: Balancer[Req, Rep] =>
+private[loadbalancer] trait Aperture[Req, Rep] { self: Balancer[Req, Rep] =>
   import Aperture._
 
   protected def rng: Rng
@@ -211,7 +211,7 @@ private trait Aperture[Req, Rep] { self: Balancer[Req, Rep] =>
  * The upshot is that `lowLoad` and `highLoad` define an acceptable
  * band of load for each serving unit.
  */
-private trait LoadBand[Req, Rep] { self: Balancer[Req, Rep] with Aperture[Req, Rep] =>
+private[loadbalancer] trait LoadBand[Req, Rep] { self: Balancer[Req, Rep] with Aperture[Req, Rep] =>
   /**
    * The time-smoothing factor used to compute the capacity-adjusted
    * load. Exponential smoothing is used to absorb large spikes or

--- a/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/Balancer.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/Balancer.scala
@@ -15,7 +15,7 @@ import scala.annotation.tailrec
  * example, we can specify and mix in a load metric (via a Node) and
  * a balancer (a Distributor) separately.
  */
-private trait Balancer[Req, Rep] extends ServiceFactory[Req, Rep] { self =>
+private[loadbalancer] trait Balancer[Req, Rep] extends ServiceFactory[Req, Rep] { self =>
   /**
    * The maximum number of balancing tries (yielding unavailable
    * factories) until we give up.

--- a/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/Balancers.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/Balancers.scala
@@ -123,6 +123,7 @@ object Balancers {
    *  1. The concurrent load, measured over a window specified by
    *     `smoothWin`, to each service stays within the load band, delimited
    *     by `lowLoad` and `highLoad`.
+   *
    *  2. Services receive load proportional to the ratio of their
    *     weights.
    *
@@ -153,6 +154,32 @@ object Balancers {
           gauge.remove()
           super.close(when)
         }
+      }
+    }
+  }
+
+  /**
+   * A simple round robin balancer that chooses the next backend in
+   * the list for each request.
+   *
+   * WARNING: Unlike other balancers available in finagle, this does
+   * not take latency into account and will happily direct load to
+   * slow or oversubscribed services. We recommend using one of the
+   * other load balancers for typical production use.
+   *
+   * @param maxEffort the maximum amount of "effort" we're willing to
+   * expend on a load balancing decision without reweighing.
+   */
+  def rr(
+    maxEffort: Int = MaxEffort
+  ): LoadBalancerFactory = new LoadBalancerFactory {
+    def newBalancer[Req, Rep](
+      endpoints: Activity[Set[ServiceFactory[Req, Rep]]],
+      sr: StatsReceiver,
+      exc: NoBrokersAvailableException
+    ): ServiceFactory[Req, Rep] = {
+      new RoundRobinBalancer(endpoints, sr, exc) {
+        private[this] val gauge = sr.addGauge("rr")(1)
       }
     }
   }

--- a/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/DistributorT.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/DistributorT.scala
@@ -6,7 +6,7 @@ package com.twitter.finagle.loadbalancer
  * data across updates.
  */
 protected[loadbalancer] trait DistributorT[Node] {
-  type This
+  type This <: DistributorT[Node]
 
   /**
    * The vector of nodes over which we are currently balancing.

--- a/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/LeastLoaded.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/LeastLoaded.scala
@@ -11,7 +11,7 @@ import java.util.concurrent.atomic.AtomicInteger
  * Provide Nodes whose 'load' is the current number of pending
  * requests and thus will result in least-loaded load balancer.
  */
-private trait LeastLoaded[Req, Rep] { self: Balancer[Req, Rep] =>
+private[loadbalancer] trait LeastLoaded[Req, Rep] { self: Balancer[Req, Rep] =>
   protected def rng: Rng
 
   protected case class Node(

--- a/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/RoundRobin.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/RoundRobin.scala
@@ -1,0 +1,99 @@
+package com.twitter.finagle.loadbalancer
+
+import com.twitter.finagle.{ClientConnection, NoBrokersAvailableException, Service,
+  ServiceFactory, ServiceFactoryProxy, Status}
+import com.twitter.finagle.service.FailingFactory
+import com.twitter.finagle.stats.StatsReceiver
+import com.twitter.finagle.util.OnReady
+import com.twitter.util.{Activity, Future, Promise, Time}
+
+/**
+ * A simple round robin balancer that chooses the next backend in
+ * the list for each request.
+ */
+class RoundRobinBalancer[Req, Rep](
+  val activity: Activity[Traversable[ServiceFactory[Req, Rep]]],
+  val statsReceiver: StatsReceiver,
+  val emptyException: NoBrokersAvailableException,
+  val maxEffort: Int = 5
+) extends ServiceFactory[Req, Rep]
+    with Balancer[Req, Rep]
+    with Updating[Req, Rep] {
+
+  // For the OnReady mixin
+  private[this] val ready = new Promise[Unit]
+  override def onReady: Future[Unit] = ready
+
+  protected[this] val maxEffortExhausted = statsReceiver.counter("max_effort_exhausted")
+
+  override def apply(conn: ClientConnection): Future[Service[Req,Rep]] = {
+    dist.pick()(conn)
+  }
+
+  protected class Node(val factory: ServiceFactory[Req, Rep])
+      extends ServiceFactoryProxy[Req,Rep](factory)
+      with NodeT[Req,Rep] { self =>
+    type This = Node
+    // Note: These stats are never updated.
+    override def load = 0.0
+    override def pending = 0
+    override def token = 0
+
+    override def close(deadline: Time): Future[Unit] = factory.close(deadline)
+    override def apply(conn: ClientConnection): Future[Service[Req,Rep]] = factory(conn)
+  }
+
+  /**
+    * A simple round robin distributor.
+    */
+  protected class Distributor(val vector: Vector[Node])
+      extends DistributorT[Node] {
+    type This = Distributor
+
+    @volatile private[this] var sawDown = false
+    private[this] var currentNode = 0
+
+    private[this] val nodeUp: Node => Boolean = {_.isAvailable}
+    private[this] val nodeDown: Node => Boolean = {!_.isAvailable}
+
+    private[this] val (up, down) = vector.partition(nodeUp) match {
+      case (Vector(), down) => (down, Vector.empty)
+      case updown => updown
+    }
+
+    // For each node that's requested, we move the currentNode index
+    // around the wheel using mod arithmetic. This is the round robin
+    // of our balancer.
+    private def chooseNext(): Int = {
+      synchronized {
+        currentNode = (currentNode + 1) % up.size
+        currentNode
+      }
+    }
+
+    /**
+      * Will only return Nodes that have Status.Open
+      */
+    override def pick(): Node = {
+      if (up.isEmpty) failingNode(emptyException)
+      else {
+        val node = up(chooseNext())
+        node.status match {
+          case Status.Open => node
+          case _ => up.find(_.isAvailable).getOrElse(failingNode(emptyException))
+        }
+      }
+    }
+
+    override def needsRebuild: Boolean = {
+      sawDown || down.exists(nodeUp) || up.exists(nodeDown)
+    }
+
+    override def rebuild(): This = new Distributor(vector)
+    override def rebuild(vector: Vector[Node]): This = new Distributor(vector)
+  }
+
+  protected def initDistributor(): Distributor = new Distributor(Vector.empty)
+  protected def newNode(factory: ServiceFactory[Req,Rep], statsReceiver: StatsReceiver): Node = new Node(factory)
+  protected def failingNode(cause: Throwable): Node = new Node(new FailingFactory(cause))
+}

--- a/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/Updating.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/Updating.scala
@@ -8,7 +8,7 @@ import com.twitter.util.{Time, Activity, Future, Promise}
  * A Balancer mix-in which provides the collection over which to load balance
  * by observing `activity`.
  */
-private trait Updating[Req, Rep] extends Balancer[Req, Rep] with OnReady {
+private[loadbalancer] trait Updating[Req, Rep] extends Balancer[Req, Rep] with OnReady {
   private[this] val ready = new Promise[Unit]
   def onReady: Future[Unit] = ready
 

--- a/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/ApertureTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/ApertureTest.scala
@@ -9,12 +9,12 @@ import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
 import scala.collection.mutable
 
-private trait ApertureTesting {
+trait ApertureTesting {
   val N = 100000
 
   class Empty extends Exception
 
-  protected trait TestBal extends Balancer[Unit, Unit] with Aperture[Unit, Unit] {
+  trait TestBal extends Balancer[Unit, Unit] with Aperture[Unit, Unit] {
     protected val rng = Rng(12345L)
     protected val emptyException = new Empty
     protected val maxEffort = 10
@@ -85,9 +85,9 @@ private trait ApertureTesting {
 }
 
 @RunWith(classOf[JUnitRunner])
-private class ApertureTest extends FunSuite with ApertureTesting {
+class ApertureTest extends FunSuite with ApertureTesting {
 
-  protected class Bal extends TestBal with LeastLoaded[Unit, Unit]
+  class Bal extends TestBal with LeastLoaded[Unit, Unit]
 
   test("Balance only within the aperture") {
     val counts = new Counts
@@ -180,7 +180,7 @@ private class ApertureTest extends FunSuite with ApertureTesting {
 
 
 @RunWith(classOf[JUnitRunner])
-private class LoadBandTest extends FunSuite with ApertureTesting {
+class LoadBandTest extends FunSuite with ApertureTesting {
 
   val rng = Rng()
 

--- a/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/BalancerTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/BalancerTest.scala
@@ -12,7 +12,7 @@ import org.scalatest.concurrent.{IntegrationPatience, Conductors}
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
 @RunWith(classOf[JUnitRunner])
-private class BalancerTest extends FunSuite
+class BalancerTest extends FunSuite
   with Conductors
   with IntegrationPatience
   with GeneratorDrivenPropertyChecks {

--- a/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/RoundRobinBalancerTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/RoundRobinBalancerTest.scala
@@ -1,0 +1,159 @@
+package com.twitter.finagle.loadbalancer
+
+import com.twitter.app.App
+import com.twitter.conversions.time._
+import com.twitter.finagle._
+import com.twitter.finagle.stats.{StatsReceiver, NullStatsReceiver, InMemoryStatsReceiver}
+import com.twitter.util.{Function => _, _}
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+import scala.collection.mutable
+
+private[loadbalancer] trait RoundRobinSuite {
+  // number of servers
+  val N: Int = 100
+  // number of reqs
+  val R: Int = 100000
+  // tolerated variance
+  val ε: Double = 0.0001*R
+
+  trait RRServiceFactory extends ServiceFactory[Unit, Int] {
+    def meanLoad: Double
+  }
+
+  val noBrokers = new NoBrokersAvailableException
+
+  def newBal(
+    fs: Var[Traversable[RRServiceFactory]],
+    sr: StatsReceiver = NullStatsReceiver
+  ): ServiceFactory[Unit, Int] = new RoundRobinBalancer(
+    Activity(fs.map(Activity.Ok(_))),
+    statsReceiver = sr,
+    emptyException = noBrokers,
+    maxEffort = 1
+  )
+
+  def assertEven(fs: Traversable[RRServiceFactory]) {
+    val ml = fs.head.meanLoad
+    for (f <- fs) {
+      assert(math.abs(f.meanLoad - ml) < ε,
+        "ml=%f; f.ml=%f; ε=%f".format(ml, f.meanLoad, ε))
+    }
+  }
+}
+
+@RunWith(classOf[JUnitRunner])
+class RoundRobinBalancerTest extends FunSuite with RoundRobinSuite {
+  case class LoadedFactory(id: Int) extends RRServiceFactory {
+    @volatile var stat: Status = Status.Open
+    var load = 0
+    var sum = 0
+    var count = 0
+
+    def meanLoad: Double = if (count == 0) 0 else sum.toDouble/count.toDouble
+
+    def apply(conn: ClientConnection) = {
+      load += 1
+      sum += load
+      count += 1
+
+      Future.value(new Service[Unit, Int] {
+        def apply(req: Unit) = Future.value(id)
+        override def close(deadline: Time) = {
+          load -= 1
+          sum += load
+          count += 1
+          Future.Done
+        }
+      })
+    }
+
+    def close(deadline: Time) = Future.Done
+    override def toString = "LoadedFactory(%d, %d, %s)".format(id, load, stat)
+    override def status = stat
+  }
+
+  test("Balances evenly") {
+    val init = Vector.tabulate(N) { i => new LoadedFactory(i) }
+    val bal = newBal(Var(init))
+    for (_ <- 0 until R) bal()
+    assertEven(init)
+  }
+
+  test("Empty load balancer throws") {
+    val vec = Var(Vector.empty[LoadedFactory])
+    val bal = newBal(vec)
+    val exc = intercept[NoBrokersAvailableException] { Await.result(bal()) }
+    assert(exc eq noBrokers)
+
+    vec() :+= new LoadedFactory(0)
+    for (_ <- 0 until R) Await.result(bal())
+    assert(vec().head.load == R)
+
+    vec() = Vector.empty
+    intercept[NoBrokersAvailableException] { Await.result(bal()) }
+  }
+
+  test("Closing a node removes it from load balancing") {
+    val init = Vector.tabulate(N) { i => new LoadedFactory(i) }
+    val bal = newBal(Var.value(init))
+
+    for (_ <- 0 until R) {
+      assert(Await.result(bal()).status == Status.Open)
+    }
+    assert(init(0).count > 0)
+
+    assert(init(0).status == Status.Open)
+    init(0).stat = Status.Closed
+    assert(init(0).status == Status.Closed)
+
+    val init0count = init(0).count
+
+    // There are no closed nodes returned from bal()
+    for (_ <- 0 until R) {
+      assert(Await.result(bal()).status == Status.Open)
+    }
+
+    // no new traffic has been sent to init(0) which is closed.
+    assert(init0count == init(0).count)
+  }
+
+  test("Changing a node from Closed to Open re-adds it to load balancing") {
+    val init = Vector.tabulate(N) { i => new LoadedFactory(i) }
+    val bal = newBal(Var(init))
+
+    // checkpoint for seeing how much traffic init(0) has seen
+    var init0count = init(0).count
+
+    assert(init(0).status == Status.Open)
+    for (_ <- 0 until R) { bal() }
+    assert(init(0).count > init0count)
+    init0count = init(0).count
+
+    init(0).stat = Status.Closed
+    assert(init(0).status == Status.Closed)
+
+    // There are no closed nodes
+    for (_ <- 0 until R) {
+      assert(Await.result(bal()).status == Status.Open)
+    }
+
+    for (_ <- 0 until R) { bal() }
+    assert(init(0).count == init0count)
+
+    init(0).stat = Status.Open
+    init0count = init(0).count
+    // And init(0) is now returned by the balancer
+    for (_ <- 0 until R) { bal() }
+    assert(init(0).count > init0count)
+  }
+
+  test("Closes") {
+    val init = Vector.tabulate(N) { i => new LoadedFactory(i) }
+    val bal = newBal(Var.value(init))
+    // Give it some traffic.
+    for (_ <- 0 until R) bal()
+    Await.result(bal.close(), 5.seconds)
+  }
+}


### PR DESCRIPTION
Problem

We wanted to compare Round Robin load balancing with the choices available in Finagle.

Solution

We added a simple round robin loadbalancer to the finagle-core package along with a unit test suite.

We also added improvements to Simulation.scala such as printing individual latency numbers, adding a slow client in the middle of a simulation run.

We added a .rr() function to Balancers.scala as well as a newline to .aperture()'s comment to improve the scaladoc output.

We added a type constraint to DistributorT#This to enforce by the compiler what was being done by convention.

We changed protection modifiers to several member classes and traits of loadbalancer package to allow running their tests from sbt.

Result
  * Added Round Robin load balancer and unit tests
  * Added .rr() to Balancers
  * Changed protection modifiers to several member classes and traits of loadbalancer package
  * Modified Simulation to allow a slow client in the middle.
  * Modified Simulation to allow tracing latency per request.
  * Added a shell script for running Simulation.scala from a shell.
  * Added some R code in a literate file to help me build nice graphs.
  * Added a newline for improved scaladoc in Balancers.scala