### PR TITLE
finagle-http: Encode local dtabs in the Dtab-Local header

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,8 +7,15 @@ Note that ``RB_ID=#`` correspond to associated messages in commits.
 6.x
 -----
 
+Runtime Behavior Changes
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+  * finagle-http: Local Dtabs are now encoded into the `Dtab-Local` header.  `X-Dtab` headers
+    may still be read but should be considered deprecated.
+
 New Features
 ~~~~~~~~~~~~
+
   * finagle-http: new stack params MaxChunkSize, MaxHeaderSize, and MaxInitialLineLength
     are available to configure the http codec. ``RB_ID=811129``
 

--- a/finagle-http/src/main/scala/com/twitter/finagle/http/codec/HttpDtab.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/http/codec/HttpDtab.scala
@@ -114,7 +114,7 @@ object HttpDtab {
   }
 
   /**
-   * Write X-Dtab header pairs into the given message.
+   * Write a Dtab-local header into the given message.
    */
   def write(dtab: Dtab, msg: Message): Unit = {
     if (dtab.isEmpty)
@@ -125,12 +125,7 @@ object HttpDtab {
         "Dtabs with length greater than 100 are not serializable with HTTP")
     }
 
-    for ((Dentry(prefix, dst), i) <- dtab.zipWithIndex) {
-      // TODO: now that we have a proper Dtab grammar,
-      // should just embed this directly instead.
-      msg.headerMap.set(Prefix+indexstr(i)+"-A", b64Encode(prefix.show))
-      msg.headerMap.set(Prefix+indexstr(i)+"-B", b64Encode(dst.show))
-    }
+    msg.headerMap.set(Header, dtab.show)
   }
 
   /**


### PR DESCRIPTION
Problem

Finagle's HTTP server may read Dtabs in two forms: the `Dtab-local` header and `X-Dtab-NN-[A|B]` header pairs.  The latter was designed before the Dtab syntax stabilized; and `Dtab-local` was introduced some to simplify this in 88ede12847c996547381a2b990b3aaf4f8f99759.  The old `X-Dtab` is more complicated and is no longer necessary, since the `Dtab-local` header has been supported since August 2014.

Solution

Change Finagle's HTTP client to encode `Dtab-local` headers.  The old `X-Dtab` syntax may still be read by servers, but clients will set only the `Dtab-local` header.

Fixes #485