### PR TITLE
Admit comments in Dtabs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -35,6 +35,9 @@ Breaking API Changes
 New Features
 ~~~~~~~~~~~~
 
+  * finagle-core: Multi-line Dtabs may now contain line-oriented comments beginning with '#'.
+    Comments are omitted from parsed Dtabs.
+
   * finagle-http: new stack params MaxChunkSize, MaxHeaderSize, and MaxInitialLineLength
     are available to configure the http codec. ``RB_ID=811129``
 

--- a/doc/src/sphinx/Names.rst
+++ b/doc/src/sphinx/Names.rst
@@ -161,8 +161,9 @@ is bound by Finagle to the Internet address ``localhost:8080``. Similarly,
 is the path describing the serverset_ ``/foo/bar`` on the ZooKeeper
 ensemble ``zk.local.twitter.com:2181``.
 
-Dtabs may contain line-oriented comments beginning with ``#``.  For
-example, this Dtab with commentary:
+Dtabs may contain line-oriented comments beginning with ``#``. ``#``
+must be preceded by a whitespace character or delimeter such as ``;``,
+``|``, or ``&``.  For example, this Dtab with commentary:
 
 ::
 
@@ -176,7 +177,7 @@ is equivalent to this Dtab without commentary:
 
 ::
 
-       /s => /t | (/u & /v);
+       /s => /a | (/b & /c);
 
 We use dtabs to define how logical names (e.g. ``/s/crawler``)
 translate into addresses. Because rewriting is abstracted away, we can

--- a/doc/src/sphinx/Names.rst
+++ b/doc/src/sphinx/Names.rst
@@ -161,6 +161,23 @@ is bound by Finagle to the Internet address ``localhost:8080``. Similarly,
 is the path describing the serverset_ ``/foo/bar`` on the ZooKeeper
 ensemble ``zk.local.twitter.com:2181``.
 
+Dtabs may contain line-oriented comments beginning with ``#``.  For
+example, this Dtab with commentary:
+
+::
+
+        # delegation for /s
+        /s => /a      # prefer /b
+            | ( /b    # or share traffic between /b and /c
+              & /c
+              );
+
+is equivalent to this Dtab without commentary:
+
+::
+
+       /s => /t | (/u & /v);
+
 We use dtabs to define how logical names (e.g. ``/s/crawler``)
 translate into addresses. Because rewriting is abstracted away, we can
 adapt a Finagle process to its environment by manipulating its dtab.

--- a/finagle-core/src/main/scala/com/twitter/finagle/NameTreeParsers.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/NameTreeParsers.scala
@@ -55,8 +55,17 @@ private class NameTreeParsers private (str: String) {
   }
 
   private[this] def eatWhitespace() {
-    while (!atEnd && str(idx).isWhitespace)
+    while (!atEnd && (str(idx).isWhitespace || str(idx) == '#')) {
+      if (str(idx) == '#') eatLine()
+      else next()
+    }
+  }
+
+  private[this] def eatLine() {
+    while (!atEnd && str(idx) != '\n')
       next()
+    if (!atEnd)
+      eat('\n')
   }
 
   private[this] def atEnd() = idx >= size

--- a/finagle-core/src/test/scala/com/twitter/finagle/DtabTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/DtabTest.scala
@@ -27,6 +27,26 @@ class DtabTest extends FunSuite with AssertionsForJUnit {
     """))
   }
 
+  test("Dtab.read ignores comment lines with #") {
+    val withComments = Dtab.read("""
+# a comment
+      /#foo => /biz  # another comment
+             | ( /bliz & # yet another comment
+                 /bluth ) # duh bluths
+             ; #finalmente
+      #/ignore=>/me;
+    """)
+    assert(withComments == Dtab(IndexedSeq(
+      Dentry(Path.Utf8("#foo"), NameTree.Alt(
+        NameTree.Leaf(Path.Utf8("biz")),
+        NameTree.Union(
+          NameTree.Weighted(NameTree.Weighted.defaultWeight, NameTree.Leaf(Path.Utf8("bliz"))),
+          NameTree.Weighted(NameTree.Weighted.defaultWeight, NameTree.Leaf(Path.Utf8("bluth")))
+        )
+      ))
+    )))
+  }
+
   test("d1 ++ Dtab.empty") {
     val d1 = Dtab.read("/foo=>/bar;/biz=>/baz")
 


### PR DESCRIPTION
Problem

There is no way to annotate Dtabs with commentary.

Solution

Support line-oriented comments beginning with '#'.

NameTreeParser's `eatWhitespace` method has been modified to consume lines or
line-endings once the '#' character is encountered.