### PR TITLE
Fix typo in FailureAccrualFactory example

### DIFF
--- a/doc/src/sphinx/Clients.rst
+++ b/doc/src/sphinx/Clients.rst
@@ -585,7 +585,7 @@ success rate [#example]_.
   import com.twitter.finagle.service.exp.FailureAccrualPolicy
 
   val twitter = Http.client
-    .configured(FailureAccrual.Param(() => FailureAccrualPolicy.successRate(
+    .configured(FailureAccrualFactory.Param(() => FailureAccrualPolicy.successRate(
       requiredSuccessRate = 0.95,
       window = 100,
       markDeadFor = Backoff.const(10.seconds)


### PR DESCRIPTION
Problem

The documentation refers to `FailureAccrual.Param`, which does not exist.

Solution

Correct the reference so that it is `FailureAccrualFactory.Param`.