### PR TITLE
Fix histogram snapshotting after a lapse in snapshotting     

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -58,6 +58,9 @@ Bug Fixes
   * finagle-http: Ensure that service closure is delayed until chunked response bodies
     have been processed. ``RB_ID=813110``
 
+  * finagle-stats: Ensure that histogram snapshotting does not fall behind if snapshot()
+    is not called at least once per interval.
+
 6.34.0
 ------
 

--- a/finagle-stats/src/main/scala/com/twitter/finagle/stats/MetricsBucketedHistogram.scala
+++ b/finagle-stats/src/main/scala/com/twitter/finagle/stats/MetricsBucketedHistogram.scala
@@ -79,8 +79,12 @@ private[stats] class MetricsBucketedHistogram(
       // we give 1 second of wiggle room so that a slightly early request
       // will still trigger a roll.
       if (Time.now >= nextSnapAfter.get - 1.second) {
-        // time to recompute the snapshot, clearing it out before allowing usage.
-        nextSnapAfter.set(nextSnapAfter.get + latchPeriod)
+        // if nextSnapAfter have a datetime older than (latchPeriod*2) ago, update it next minutes.
+        if (nextSnapAfter.get + latchPeriod*2 > Time.now) {
+          nextSnapAfter.set(nextSnapAfter.get + latchPeriod)
+        } else {
+          nextSnapAfter.set(JsonExporter.startOfNextMinute)
+        }
         if (isHistogramRequested) histogramCountsSnap.recomputeFrom(current)
         snap.recomputeFrom(current)
         current.clear()


### PR DESCRIPTION
Problem

When snapshotting does not occur for serveral minutes, the 60-second snapshotting is not honored. If snapshotting does not occur for two minutes, histogram windowin will not be properly honored until snapshot has been called twice.

Solution

Change snapshot windowing to be based on the current time.
 
Fixes twitter/twitter-server#33