### PR TITLE
Add Sticky Load Balancer which connects to one host and sticks to it.

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/Balancers.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/Balancers.scala
@@ -188,4 +188,25 @@ object Balancers {
       }
     }
   }
+
+  /**
+   * A simple sticky load balancer which selects the first backend it
+   * can connect to and sticks to it unless that backend is not functioning
+   * properly, in which case it will change to another functioning backend.
+   *
+   * WARNING: This load balancer does not take load or latency into account
+   * when selecting backends.
+   */
+  def sticky(): LoadBalancerFactory = new LoadBalancerFactory {
+    override def toString: String = "StickyLoadBalancerFactory"
+    def newBalancer[Req, Rep](
+      endpoints: Activity[Set[ServiceFactory[Req, Rep]]],
+      sr: StatsReceiver,
+      exc: NoBrokersAvailableException
+    ): ServiceFactory[Req, Rep] = {
+      new StickyBalancer(endpoints, sr, exc) {
+        private[this] val gauge = sr.addGauge("sticky")(1)
+      }
+    }
+  }
 }

--- a/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/Sticky.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/Sticky.scala
@@ -1,0 +1,95 @@
+package com.twitter.finagle.loadbalancer
+
+import com.twitter.finagle.{ClientConnection, NoBrokersAvailableException, Service,
+  ServiceFactory, ServiceFactoryProxy, Status}
+import com.twitter.finagle.service.FailingFactory
+import com.twitter.finagle.stats.StatsReceiver
+import com.twitter.util.{Activity, Future, Promise, Time}
+
+/**
+ * A simple sticky load balancer which selects the first backend it
+ * can connect to and sticks to it unless that backend is not functioning
+ * properly, in which case it will change to another functioning backend.
+ */
+class StickyBalancer[Req, Rep](
+    val activity: Activity[Traversable[ServiceFactory[Req, Rep]]],
+    val statsReceiver: StatsReceiver,
+    val emptyException: NoBrokersAvailableException,
+    val maxEffort: Int = 5)
+  extends ServiceFactory[Req, Rep]
+  with Balancer[Req, Rep]
+  with Updating[Req, Rep] {
+
+  // For the OnReady mixin
+  private[this] val ready = new Promise[Unit]
+  override def onReady: Future[Unit] = ready
+
+  protected[this] val maxEffortExhausted = statsReceiver.counter("max_effort_exhausted")
+
+  override def apply(conn: ClientConnection): Future[Service[Req,Rep]] = {
+    dist.pick()(conn)
+  }
+
+  protected class Node(val factory: ServiceFactory[Req, Rep])
+      extends ServiceFactoryProxy[Req,Rep](factory)
+      with NodeT[Req,Rep] { self =>
+    type This = Node
+    // Note: These stats are never updated.
+    def load = 0.0
+    def pending = 0
+    def token = 0
+
+    override def close(deadline: Time): Future[Unit] = factory.close(deadline)
+    override def apply(conn: ClientConnection): Future[Service[Req,Rep]] = factory(conn)
+  }
+
+  /**
+    * A simple sticky distributor.
+    */
+  protected class Distributor(val vector: Vector[Node])
+      extends DistributorT[Node] {
+    type This = Distributor
+
+    private[this] var currentNode = 0
+
+    private[this] val nodeUp: Node => Boolean = {_.isAvailable}
+
+    private[this] val nodes = vector
+
+    /**
+      * Will only return Nodes that have Status.Open
+      */
+    def pick(): Node = {
+      if (nodes.isEmpty) failingNode(emptyException)
+      else {
+        val node = nodes(currentNode)
+        node.status match {
+          case Status.Open => node
+          case _ => synchronized {
+            var idx = 0
+            var res = -1
+
+            while (idx < nodes.size && res == -1) {
+              if (nodes(idx).isAvailable) res = idx
+              else idx += 1
+            }
+
+            if (res != -1) {
+              currentNode = res
+              nodes(res)
+            } else failingNode(emptyException)
+          }
+        }
+      }
+    }
+
+    def needsRebuild: Boolean = false
+
+    def rebuild(): This = new Distributor(vector)
+    def rebuild(vector: Vector[Node]): This = new Distributor(vector)
+  }
+
+  protected def initDistributor(): Distributor = new Distributor(Vector.empty)
+  protected def newNode(factory: ServiceFactory[Req,Rep], statsReceiver: StatsReceiver): Node = new Node(factory)
+  protected def failingNode(cause: Throwable): Node = new Node(new FailingFactory(cause))
+}

--- a/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/StickyBalancerTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/StickyBalancerTest.scala
@@ -1,0 +1,150 @@
+package com.twitter.finagle.loadbalancer
+
+import com.twitter.app.App
+import com.twitter.conversions.time._
+import com.twitter.finagle._
+import com.twitter.finagle.stats.{StatsReceiver, NullStatsReceiver, InMemoryStatsReceiver}
+import com.twitter.util.{Function => _, _}
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+import scala.collection.mutable
+
+private[loadbalancer] trait StickySuite {
+  // number of servers
+  val N: Int = 100
+  // number of reqs
+  val R: Int = 100000
+
+  trait SServiceFactory extends ServiceFactory[Unit, Int]
+
+  val noBrokers = new NoBrokersAvailableException
+
+  def newBal(
+    fs: Var[Traversable[SServiceFactory]],
+    sr: StatsReceiver = NullStatsReceiver
+  ): ServiceFactory[Unit, Int] = new StickyBalancer(
+    Activity(fs.map(Activity.Ok(_))),
+    statsReceiver = sr,
+    emptyException = noBrokers,
+    maxEffort = 1
+  )
+}
+
+@RunWith(classOf[JUnitRunner])
+class StickyBalancerTest extends FunSuite with StickySuite {
+  case class LoadedFactory(id: Int) extends SServiceFactory {
+    @volatile var stat: Status = Status.Open
+    var load = 0
+    var sum = 0
+    var count = 0
+
+    def apply(conn: ClientConnection) = {
+      load += 1
+      sum += load
+      count += 1
+
+      Future.value(new Service[Unit, Int] {
+        def apply(req: Unit) = Future.value(id)
+        override def close(deadline: Time) = {
+          load -= 1
+          sum += load
+          count += 1
+          Future.Done
+        }
+      })
+    }
+
+    def close(deadline: Time) = Future.Done
+    override def toString = "LoadedFactory(%d, %d, %s)".format(id, load, stat)
+    override def status = stat
+  }
+
+  test("Sticks to one backend") {
+    val init = Vector.tabulate(N) { i => new LoadedFactory(i) }
+    val bal = newBal(Var(init))
+    for (_ <- 0 until R) bal()
+
+    assert(init.filter(_.count == R).size == 1)
+    assert(init.filter(_.count == 0).size == N - 1)
+  }
+
+  test("Empty load balancer throws") {
+    val vec = Var(Vector.empty[LoadedFactory])
+    val bal = newBal(vec)
+    val exc = intercept[NoBrokersAvailableException] { Await.result(bal()) }
+    assert(exc eq noBrokers)
+
+    vec() :+= new LoadedFactory(0)
+    for (_ <- 0 until R) Await.result(bal())
+    assert(vec().head.load == R)
+
+    vec() = Vector.empty
+    intercept[NoBrokersAvailableException] { Await.result(bal()) }
+  }
+
+  test("Closing a node removes it from load balancing") {
+    val init = Vector.tabulate(N) { i => new LoadedFactory(i) }
+    val bal = newBal(Var.value(init))
+
+    for (_ <- 0 until R) {
+      assert(Await.result(bal()).status == Status.Open)
+    }
+    assert(init(0).count > 0)
+
+    assert(init(0).status == Status.Open)
+    init(0).stat = Status.Closed
+    assert(init(0).status == Status.Closed)
+
+    val init0count = init(0).count
+
+    // There are no closed nodes returned from bal()
+    for (_ <- 0 until R) {
+      assert(Await.result(bal()).status == Status.Open)
+    }
+
+    // no new traffic has been sent to init(0) which is closed.
+    assert(init0count == init(0).count)
+  }
+
+  test("Changing a node from Closed to Open re-adds it to load balancing") {
+    val init = Vector.tabulate(2) { i => new LoadedFactory(i) }
+    val bal = newBal(Var(init))
+
+    // checkpoint for seeing how much traffic init(0) has seen
+    var init0count = init(0).count
+
+    assert(init(0).status == Status.Open)
+    for (_ <- 0 until R) { bal() }
+    assert(init(0).count > init0count)
+    init0count = init(0).count
+
+    init(0).stat = Status.Closed
+    assert(init(0).status == Status.Closed)
+
+    // There are no closed nodes
+    for (_ <- 0 until R) {
+      assert(Await.result(bal()).status == Status.Open)
+    }
+
+    for (_ <- 0 until R) { bal() }
+    assert(init(0).count == init0count)
+
+    // closing init(1) to swap back to re-opened node
+    init(1).stat = Status.Closed
+
+    init(0).stat = Status.Open
+    init0count = init(0).count
+    // And init(0) is now returned by the balancer
+    for (_ <- 0 until R) { bal() }
+    assert(init(0).count > init0count)
+  }
+
+  test("Closes") {
+    val init = Vector.tabulate(N) { i => new LoadedFactory(i) }
+    val bal = newBal(Var.value(init))
+    // Give it some traffic.
+    for (_ <- 0 until R) bal()
+    Await.result(bal.close(), 5.seconds)
+  }
+}


### PR DESCRIPTION
Problem

If you use Finagle for services which aren't identical replicas such as
systems using strong eventual consistency, you can't currently use any provided
load balancers since they treat all hosts as replicas.

Solution

This PR adds a new load balancer sticking to the first backend it can connect
to. It only changes backend if the initial backend is not reachable. This allows
Finagle clients to be used in systems using (strong) eventual consistency.