### PR TITLE
Netty 4 server fixes

### DIFF
--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/Netty4Listener.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/Netty4Listener.scala
@@ -13,7 +13,7 @@ import io.netty.channel._
 import io.netty.channel.nio.NioEventLoopGroup
 import io.netty.channel.socket.SocketChannel
 import io.netty.channel.socket.nio.NioServerSocketChannel
-import io.netty.util.concurrent.GenericFutureListener
+import io.netty.util.concurrent.{Future => NettyFuture, FutureListener}
 import java.lang.{Boolean => JBool, Integer => JInt}
 import java.net.SocketAddress
 import java.util.concurrent.TimeUnit
@@ -130,8 +130,8 @@ private[finagle] case class Netty4Listener[In, Out](
         // Existing tasks have ``deadline`` time to finish executing.
         bossLoop
           .shutdownGracefully(0 /* quietPeriod */ , deadline.inMillis /* timeout */ , TimeUnit.MILLISECONDS)
-          .addListener(new GenericFutureListener[Nothing] {
-            def operationComplete(future: Nothing): Unit = p.setDone()
+          .addListener(new FutureListener[Any] {
+            def operationComplete(future: NettyFuture[Any]) = p.setDone()
           })
         p
       }

--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/transport/ChannelTransport.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/transport/ChannelTransport.scala
@@ -130,7 +130,7 @@ private[netty4] class ChannelTransport[In, Out](ch: Channel) extends Transport[I
 
   override def toString = s"Transport<channel=$ch, onClose=$closed>"
 
-  ch.pipeline().addLast("finagleChannelTransport", new SimpleChannelInboundHandler[Out]() {
+  ch.pipeline().addLast("finagleChannelTransport", new SimpleChannelInboundHandler[Out](false) {
 
     override def channelReadComplete(ctx: ChannelHandlerContext): Unit = {
       if (!ch.config.isAutoRead && msgsNeeded.get > 0) ch.read()

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/Netty4ListenerTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/Netty4ListenerTest.scala
@@ -152,7 +152,7 @@ class Netty4ListenerTest extends FunSuite with Eventually with IntegrationPatien
     eventually { counterEquals("connects")(3) }
 
     // listening socket is closed
-    Await.ready(server.close(), Duration.fromSeconds(15))
+    Await.ready(server.close(Time.Top), Duration.fromSeconds(15))
 
     // new connection attempts fail
     intercept[java.net.ConnectException] { new Socket().connect(server.boundAddress) }


### PR DESCRIPTION
- Fix casting bug at shutdown. 

- Call retain() on ByteBuf before offering to an AsyncQueue