### PR TITLE
Lazily instantiate StackServer's JvmFilter

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/server/StackServer.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/server/StackServer.scala
@@ -20,7 +20,7 @@ import scala.collection.JavaConverters._
 
 object StackServer {
 
-  private[this] val newJvmFilter = new MkJvmFilter(Jvm())
+  private[this] lazy val newJvmFilter = new MkJvmFilter(Jvm())
 
   private[this] class JvmTracing[Req, Rep] extends Stack.Module1[param.Tracer, ServiceFactory[Req, Rep]] {
     override def role: Role = Role.jvmTracing


### PR DESCRIPTION
Problem

StackServer statically instantiates a `MkJvmFilter` with a `c.t.jvm.Jvm`. This creates a timer thread that samples JVM stats. We'd like to disable the JvmFilter stack module during profiling, but JVM stats polling is initiated regardless of whether the module is used.

Solution

Lazily instantiate StackServer's JvmFilter.

Result

The stats polling timer is only initiated when the JvmFilter server module is
enabled.

Also-by: Steve Jenson <stevej@buoyant.io>