### PR TITLE
Add channel stats to Netty4 clients

### DIFF
--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/channel/ChannelRequestStatsHandler.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/channel/ChannelRequestStatsHandler.scala
@@ -26,9 +26,9 @@ private[finagle] class ChannelRequestStatsHandler(statsReceiver: StatsReceiver)
 
   private[this] val requestCount = statsReceiver.stat("connection_requests")
 
-  override def channelActive(ctx: ChannelHandlerContext): Unit = {
+  override def handlerAdded(ctx: ChannelHandlerContext): Unit = {
     ctx.attr(ConnectionRequestsKey).set(new AtomicInteger(0))
-    super.channelActive(ctx)
+    super.handlerAdded(ctx)
   }
 
   override def channelInactive(ctx: ChannelHandlerContext): Unit = {

--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/channel/Netty4ClientChannelInitializer.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/channel/Netty4ClientChannelInitializer.scala
@@ -19,6 +19,7 @@ private[netty4] object Netty4ClientChannelInitializer {
   val ReadTimeoutHandlerKey = "read timeout"
   val ConnectionHandlerKey = "connection handler"
   val ChannelStatsHandlerKey = "channel stats"
+  val ChannelRequestStatsHandlerKey = "channel request stats"
 }
 
 /**
@@ -76,9 +77,11 @@ private[netty4] abstract class AbstractNetty4ClientChannelInitializer[In, Out](
   private[this] val Stats(stats) = params[Stats]
   private[this] val Transporter.HttpProxyTo(hostAndCredentials) = params[Transporter.HttpProxyTo]
 
-  private[this] val channelStatsHandler =
-    if (!stats.isNull) Some(new ChannelStatsHandler(stats))
-    else None
+  private[this] val (channelRequestStatsHandler, channelStatsHandler) =
+    if (!stats.isNull)
+      (Some(new ChannelRequestStatsHandler(stats)), Some(new ChannelStatsHandler(stats)))
+    else
+      (None, None)
 
   private[this] val exceptionHandler = new ChannelExceptionHandler(stats, logger)
 
@@ -88,11 +91,13 @@ private[netty4] abstract class AbstractNetty4ClientChannelInitializer[In, Out](
     // - a request flies from last to first
     // - a response flies from first to last
     //
-    // http proxy => ssl => read timeout => write timeout => channel stats => exceptions
+    // http proxy => ssl => read timeout => write timeout => ...
+    // ... => channel stats => req stats => exceptions
 
     val pipe = ch.pipeline
 
     channelStatsHandler.foreach(pipe.addFirst(ChannelStatsHandlerKey, _))
+    channelRequestStatsHandler.foreach(pipe.addLast(ChannelRequestStatsHandlerKey, _))
 
     if (readTimeout.isFinite && readTimeout > Duration.Zero) {
       val (timeoutValue, timeoutUnit) = readTimeout.inTimeUnit

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/channel/ChannelStatsHandlerTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/channel/ChannelStatsHandlerTest.scala
@@ -9,7 +9,8 @@ import io.netty.util.{AttributeKey, Attribute}
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicLong
 import org.junit.runner.RunWith
-import org.mockito.Mockito.when
+import org.mockito.Matchers.any
+import org.mockito.Mockito.{when, verify}
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.mock.MockitoSugar
@@ -168,8 +169,10 @@ class ChannelStatsHandlerTest extends FunSuite with MockitoSugar {
     val tc = new TestContext { }
     import tc._
 
-    handler.channelActive(ctx)
+    handler.handlerAdded(ctx)
+    verify(statsAttr).set(any[ChannelStats])
     handler.write(ctx, wrappedBuffer(Array.fill(42)(0.toByte)), mock[ChannelPromise])
+    handler.channelActive(ctx)
     handler.channelInactive(ctx)
 
     assert(sr.counter("sent_bytes")() == 42)


### PR DESCRIPTION
Problem

Netty3 includes channel stats (connects, closes, etc) for clients, but the
Netty4 client pipeline does not include channel stats.

Solution

Add ChannelStatsHandler to the Netty4 client pipeline.

Fixes #506