### PR TITLE
finagle-memcached: Bugfix memcached Zipkin integration

### DIFF
--- a/finagle-memcached/src/main/scala/com/twitter/finagle/Memcached.scala
+++ b/finagle-memcached/src/main/scala/com/twitter/finagle/Memcached.scala
@@ -11,7 +11,7 @@ import com.twitter.finagle.memcached._
 import com.twitter.finagle.memcached.exp.LocalMemcached
 import com.twitter.finagle.memcached.protocol.text.{MemcachedClientPipelineFactory, MemcachedServerPipelineFactory}
 import com.twitter.finagle.memcached.protocol.{Command, Response, RetrievalCommand, Values}
-import com.twitter.finagle.netty3.{BufChannelBuffer, Netty3Listener, Netty3Transporter}
+import com.twitter.finagle.netty3.{Netty3Listener, Netty3Transporter}
 import com.twitter.finagle.param.{Monitor => _, ResponseClassifier => _, ExceptionStatsHandler => _, Tracer => _, _}
 import com.twitter.finagle.pool.SingletonPool
 import com.twitter.finagle.server.{Listener, StackServer, StdStackServer}
@@ -22,49 +22,54 @@ import com.twitter.finagle.tracing._
 import com.twitter.finagle.transport.Transport
 import com.twitter.hashing
 import com.twitter.io.Buf
-import com.twitter.util.{Closable, Duration, Future, Monitor}
+import com.twitter.util.{Closable, Duration, Monitor}
 import com.twitter.util.registry.GlobalRegistry
 import scala.collection.mutable
 
-/**
- * Defines a [[Tracer]] that understands the finagle-memcached request type.
- * This is installed as the `ClientTracingFilter` in the default stack.
- */
-private[finagle] object MemcachedTraceInitializer {
-  object Module extends Stack.Module1[param.Tracer, ServiceFactory[Command, Response]] {
-    val role = TraceInitializerFilter.role
-    val description = "Initialize traces for the client and record hits/misses"
-    def make(_tracer: param.Tracer, next: ServiceFactory[Command, Response]) = {
-      val param.Tracer(tracer) = _tracer
-      val filter = new Filter(tracer)
-      filter andThen next
+private[finagle] object MemcachedTracingFilter {
+
+  object Module extends Stack.Module1[param.Label, ServiceFactory[Command, Response]] {
+    val role = ClientTracingFilter.role
+    val description = "Add Memcached client specific annotations to the trace"
+
+    def make(_label: param.Label, next: ServiceFactory[Command, Response]) = {
+      val param.Label(label) = _label
+      val annotations = new AnnotatingTracingFilter[Command, Response](
+        label, Annotation.ClientSend(), Annotation.ClientRecv())
+      annotations andThen TracingFilter andThen next
     }
   }
 
-  class Filter(tracer: Tracer) extends SimpleFilter[Command, Response] {
-    def apply(command: Command, service: Service[Command, Response]): Future[Response] =
-      Trace.letTracerAndNextId(tracer) {
-        val response = service(command)
+  object TracingFilter extends SimpleFilter[Command, Response] {
+    def apply(command: Command, service: Service[Command, Response]) = {
+      val response = service(command)
+      if (Trace.isActivelyTracing) {
+        // Submitting rpc name here assumes there is no further tracing lower in the stack
         Trace.recordRpc(command.name)
         command match {
-          case command: RetrievalCommand if Trace.isActivelyTracing =>
-            response onSuccess {
+          case command: RetrievalCommand =>
+            response.onSuccess {
               case Values(vals) =>
                 val cmd = command.asInstanceOf[RetrievalCommand]
                 val misses = mutable.Set.empty[String]
-                cmd.keys foreach { case Buf.Utf8(key) => misses += key }
-                vals foreach { value =>
+                cmd.keys.foreach { case Buf.Utf8(key) => misses += key }
+                vals.foreach { value =>
                   val Buf.Utf8(key) = value.key
                   Trace.recordBinary(key, "Hit")
                   misses.remove(key)
                 }
-                misses foreach { Trace.recordBinary(_, "Miss") }
+                misses.foreach {
+                  Trace.recordBinary(_, "Miss")
+                }
               case _ =>
             }
           case _ =>
+            response
         }
+      } else {
         response
       }
+    }
   }
 }
 
@@ -187,7 +192,7 @@ object Memcached extends finagle.Client[Command, Response]
     def newStack: Stack[ServiceFactory[Command, Response]] = StackClient.newStack
       .replace(LoadBalancerFactory.role, ConcurrentLoadBalancerFactory.module[Command, Response])
       .replace(DefaultPool.Role, SingletonPool.module[Command, Response])
-      .replace(ClientTracingFilter.role, MemcachedTraceInitializer.Module)
+      .replace(ClientTracingFilter.role, MemcachedTracingFilter.Module)
 
     /**
      * The memcached client should be using fixed hosts that do not change

--- a/finagle-memcached/src/main/scala/com/twitter/finagle/memcached/protocol/text/Memcached.scala
+++ b/finagle-memcached/src/main/scala/com/twitter/finagle/memcached/protocol/text/Memcached.scala
@@ -70,8 +70,6 @@ class Memcached extends CodecFactory[Command, Response] {
       override def prepareConnFactory(underlying: ServiceFactory[Command, Response], params: Stack.Params) =
         new MemcachedLoggingFilter(params[param.Stats].statsReceiver).andThen(underlying)
 
-      override def newTraceInitializer = MemcachedTraceInitializer.Module
-
       override def protocolLibraryName: String = Memcached.this.protocolLibraryName
     }
   }


### PR DESCRIPTION
Problem

When getting a value from memcached the cache hit/miss annotation
was submitted after the cr annotation was submitted.

Submitting the cache hit/miss annotation after the cr annotation resulted
in the span being recreated and ending up in the DeadlineSpanMap.
When the deadline exceeded the span was submitted a 2nd time overwriting
the correct duration of the original span.  Once that happened
the span was also annotated with 'finagle.flush'.

Solution

Update the memcached specific tracing filter so memcached specific
annotations are submitted in between cs and cr annotations.

Result

The memcached span is not re-submitted a 2nd time and does not end
up in DeadlineSpanMap. The duration is correct when viewed in zipkin-web
and there is no 'finagle.flush' annotation anymore.