### PR TITLE
Add transition to ProbeClosed in onServiceAcquisitionFailure

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/service/FailureAccrualFactory.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/service/FailureAccrualFactory.scala
@@ -1,6 +1,5 @@
 package com.twitter.finagle.service
 
-import java.net.InetSocketAddress
 import com.twitter.conversions.time._
 import com.twitter.finagle.Stack.{Params, Role}
 import com.twitter.finagle._
@@ -311,8 +310,8 @@ class FailureAccrualFactory[Req, Rep](
   /**
     * Exit 'Probing' state (if necessary)
     *
-    * The follow-on operation (i.e. the result of first request while probing) will determine
-    * whether the factory transitions to Alive (successful) or Dead (unsuccessful).
+    * The result of the subsequent request will determine whether the factory transitions to
+    * Alive (successful) or Dead (unsuccessful).
     */
   private[this] def stopProbing() = self.synchronized {
     state match {
@@ -337,7 +336,6 @@ class FailureAccrualFactory[Req, Rep](
           // (unsuccessful).
           stopProbing()
 
-          // Invoke service
           service(request).respond { rep =>
             if (isSuccess(ReqRep(request, rep))) didSucceed()
             else didFail()

--- a/finagle-core/src/test/scala/com/twitter/finagle/service/FailureAccrualFactoryTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/service/FailureAccrualFactoryTest.scala
@@ -51,19 +51,15 @@ class FailureAccrualFactoryTest extends FunSuite with MockitoSugar {
     import h._
 
     Time.withCurrentTimeFrozen { timeControl =>
-      intercept[Exception] {
-        Await.result(service(123))
+      for (i <- 0 until 3) {
+        assert(factory.isAvailable)
+        assert(service.isAvailable)
+        intercept[Exception] {
+          Await.result(service(123))
+        }
       }
-      intercept[Exception] {
-        Await.result(service(123))
-      }
-      assert(factory.isAvailable)
-      assert(service.isAvailable)
+      // Now failed
 
-      // Now fail:
-      intercept[Exception] {
-        Await.result(service(123))
-      }
       assert(statsReceiver.counters.get(List("removals")) == Some(1))
       assert(!factory.isAvailable)
       assert(!service.isAvailable)
@@ -106,14 +102,10 @@ class FailureAccrualFactoryTest extends FunSuite with MockitoSugar {
     import h._
 
     Time.withCurrentTimeFrozen { timeControl =>
-      intercept[Exception] {
-        Await.result(service(123))
-      }
-      intercept[Exception] {
-        Await.result(service(123))
-      }
-      intercept[Exception] {
-        Await.result(service(123))
+      for (i <- 0 until 3) {
+        intercept[Exception] {
+          Await.result(service(123))
+        }
       }
       assert(statsReceiver.counters.get(List("removals")) == Some(1))
       assert(!factory.isAvailable)
@@ -133,11 +125,10 @@ class FailureAccrualFactoryTest extends FunSuite with MockitoSugar {
       intercept[Exception] {
         Await.result(service(123))
       }
-
+      assert(statsReceiver.counters.get(List("probes")) == Some(1))
       assert(statsReceiver.counters.get(List("removals")) == Some(1))
       assert(!factory.isAvailable)
       assert(!service.isAvailable)
-
     }
   }
 
@@ -157,13 +148,12 @@ class FailureAccrualFactoryTest extends FunSuite with MockitoSugar {
       intercept[Exception] {
         Await.result(service(123))
       }
+      // After another failure, the service should be unavailable
+      intercept[Exception] {
+        Await.result(service(123))
+      }
 
       for (i <- 0 until markDeadForList.length) {
-        // After another failure, the service should be unavailable
-        intercept[Exception] {
-          Await.result(service(123))
-        }
-
         assert(statsReceiver.counters.get(List("removals")) == Some(1))
         assert(!factory.isAvailable)
         assert(!service.isAvailable)
@@ -187,6 +177,12 @@ class FailureAccrualFactoryTest extends FunSuite with MockitoSugar {
         assert(statsReceiver.counters.get(List("revivals")) == None)
         assert(factory.isAvailable)
         assert(service.isAvailable)
+
+        // After another failure, the service should be unavailable
+        intercept[Exception] {
+          Await.result(service(123))
+        }
+        assert(statsReceiver.counters.get(List("probes")).getOrElse(0) >= 1)
       }
     }
   }
@@ -592,11 +588,12 @@ class FailureAccrualFactoryTest extends FunSuite with MockitoSugar {
     when(underlying.status) thenReturn Status.Open
     val exc = new Exception("i broked :-(")
     when(underlying()) thenReturn Future.exception(exc)
+    val timer = new MockTimer
     val factory = new FailureAccrualFactory[Int, Int](
       underlying,
       FailureAccrualPolicy.consecutiveFailures(3, FailureAccrualFactory.jitteredBackoff),
       ResponseClassifier.Default,
-      new MockTimer,
+      timer,
       statsReceiver)
   }
 
@@ -605,19 +602,26 @@ class FailureAccrualFactoryTest extends FunSuite with MockitoSugar {
     import h._
 
     Time.withCurrentTimeFrozen { timeControl =>
-      assert(factory.isAvailable)
-      intercept[Exception] {
-        Await.result(factory())
-      }
-      assert(factory.isAvailable)
-      intercept[Exception] {
-        Await.result(factory())
-      }
-      assert(factory.isAvailable)
-      intercept[Exception] {
-        Await.result(factory())
+      for (i <- 1 to 3) {
+        assert(factory.isAvailable)
+        intercept[Exception] {
+          Await.result(factory())
+        }
       }
       assert(!factory.isAvailable)
+
+      // Advance past period
+      timeControl.advance(10.seconds)
+      timer.tick()
+
+      // Probing should fail due to factory exception. It should stop the probing and mark it dead again
+      intercept[Exception] {
+        Await.result(factory())
+      }
+      assert(statsReceiver.counters.get(List("probes")) == Some(1))
+      assert(statsReceiver.counters.get(List("removals")) == Some(1))
+      assert(!factory.isAvailable)
+      assert(factory.status == Status.Busy)
     }
   }
 

--- a/finagle-core/src/test/scala/com/twitter/finagle/service/FailureAccrualFactoryTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/service/FailureAccrualFactoryTest.scala
@@ -182,7 +182,8 @@ class FailureAccrualFactoryTest extends FunSuite with MockitoSugar {
         intercept[Exception] {
           Await.result(service(123))
         }
-        assert(statsReceiver.counters.get(List("probes")).getOrElse(0) >= 1)
+        val probeStat = statsReceiver.counters.get(List("probes"))
+        assert(probeStat.isDefined && probeStat.get >= 1)
       }
     }
   }


### PR DESCRIPTION
Problem

- If a memcached node is inactive, FAF pointing to the node enters DEAD state
- After markDeadFor timeout, the FAF enters the startProbing state
- When next probing (i.e. attempt to execute the request) fails, because node
  is still down, and factory (underlying(conn)) throws an exception
- Currently, onServiceAcquisitionFailure function fails to close the probe
- The FAF remains stuck in the ProbeOpen state and thus causing continuous
  failure

Solution

- Inside onServiceAcquisitionFailure, put transition the state into
  ProbeClosed state

Describe the modifications you've done.
- Added stopProbing method
- The onServiceAcquisitionFailure calls stopProbing before calling didFail

Result

Fixes #524 