### PR TITLE
Removes package protection for RawZipkinTracer

### DIFF
--- a/finagle-zipkin-core/src/main/scala/com/twitter/finagle/zipkin/core/RawZipkinTracer.scala
+++ b/finagle-zipkin-core/src/main/scala/com/twitter/finagle/zipkin/core/RawZipkinTracer.scala
@@ -15,7 +15,9 @@ import java.nio.ByteBuffer
  * @param statsReceiver We generate stats to keep track of traces sent, failures and so on
  * @param timer A Timer used for timing out spans in the [[DeadlineSpanMap]]
  */
-abstract private[twitter] class RawZipkinTracer(
+// Not private, so that this can be extended to support other transports, such as Kafka.
+// See https://github.com/openzipkin/zipkin-finagle
+abstract class RawZipkinTracer(
     statsReceiver: StatsReceiver,
     timer: Timer = DefaultTimer.twitter)
   extends Tracer


### PR DESCRIPTION
Problem

RawZipkinTracer is a base class that is extended to support other
transports like http or kafka. The current implementation requires subtypes to be in the `com.twitter` package. This isn't likely intentional. See #465

Solution

This removes the constraint that
requires such subtypes to be in the `com.twitter` package.

Result

RawZipkinTracer can be extended from other packages, such as `zipkin.finagle`