### PR TITLE
finagle-http: Close server transport when request is not keepalive.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -25,6 +25,13 @@ Breaking API Changes
     "dark_traffic_filter/forwarded", "dark_traffic_filter/skipped", and
     "dark_traffic_filter/failed". ``RB_ID=852548``
 
+Runtime Behavior Changes
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+  * finagle-http: HttpTransport now eagerly closes client connection after
+    processing non-keepalive requests.
+
+
 6.36.0
 ------
 

--- a/finagle-http/src/main/scala/com/twitter/finagle/http/HttpTransport.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/http/HttpTransport.scala
@@ -20,7 +20,7 @@ private[finagle] class HttpTransport[A <: Message, B <: Message](
   def this(self: StreamTransport[A, B]) =
     this(self, new ConnectionManager)
 
-  // Servers are don't use `status` to determine when they should
+  // Servers don't use `status` to determine when they should
   // close a transport, so we close the transport when the connection
   // is ready to be closed.
   manager.onClose.before(self.close())

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/HttpTransportTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/HttpTransportTest.scala
@@ -1,16 +1,19 @@
 package com.twitter.finagle.http
 
 import com.twitter.concurrent.AsyncQueue
+import com.twitter.conversions.time._
 import com.twitter.finagle.http.codec.ConnectionManager
-import com.twitter.finagle.http.exp.IdentityStreamTransport
+import com.twitter.finagle.http.exp.{IdentityStreamTransport, Multi, StreamTransportProxy}
 import com.twitter.finagle.transport.QueueTransport
-import com.twitter.util.{Throw, Future}
+import com.twitter.io.Reader
+import com.twitter.util.{Await, Time, Throw, Future, Promise}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.FunSuite
 
 @RunWith(classOf[JUnitRunner])
 class HttpTransportTest extends FunSuite {
+
   test("exceptions in connection manager stay within Future context") {
     val exc = new IllegalArgumentException("boo")
     val underlying = new QueueTransport(new AsyncQueue[Request], new AsyncQueue[Response])
@@ -21,5 +24,61 @@ class HttpTransportTest extends FunSuite {
     val f = trans.write(Request("google.com"))
     assert(f.isDefined)
     assert(f.poll == Some(Throw(exc)))
+  }
+
+  test("server closes after stream") {
+    val reqq = new AsyncQueue[Request]
+    val repq = new AsyncQueue[Response]
+    @volatile var closed = false
+    val repDone = Promise[Unit]
+
+    val manager = new ConnectionManager
+    val underlying = {
+      val self = new QueueTransport(repq, reqq)
+      new StreamTransportProxy[Response, Request](self) {
+
+        def write(rep: Response): Future[Unit] =
+          self.write(rep).before(repDone)
+
+        def read(): Future[Multi[Request]] =
+          self.read().map(Multi(_, Future.Unit))
+
+        override def close(d: Time) = {
+          closed = true
+          Future.Unit
+        }
+      }
+    }
+    val trans = new HttpTransport[Response, Request](underlying, manager)
+
+    val Multi(req, _) = {
+      val req = Request()
+      req.headers.set("Connection", "close")
+      reqq.offer(req)
+      Await.result(trans.read(), 10.seconds)
+    }
+    assert(!req.isChunked)
+    assert(!manager.shouldClose)
+    assert(!closed)
+
+    val rw = Reader.writable()
+    val writef = {
+      val rep = Response(Version.Http10, Status.Ok, rw)
+      rep.setChunked(true)
+      trans.write(rep)
+    }
+    assert(repq.size == 1)
+    val rep = Await.result(repq.poll(), 10.seconds)
+    assert(rep.isChunked)
+    assert(!manager.shouldClose)
+    assert(!closed)
+
+    val readf = rep.reader.read(Int.MaxValue)
+    assert(readf.poll == None)
+
+    repDone.setDone()
+    assert(Await.result(rw.close().before(readf), 10.seconds) == None)
+    assert(manager.shouldClose)
+    assert(closed)
   }
 }

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/codec/ConnectionManagerTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/codec/ConnectionManagerTest.scala
@@ -90,7 +90,7 @@ class ConnectionManagerTest extends FunSuite with MockitoSugar {
   def perform(request: Request, response: Response, shouldMarkDead: Boolean) {
     val closeP = new Promise[Throwable]
     val trans = mock[Transport[Request, Response]]
-    when(trans.close).thenReturn(Future.Done)
+    when(trans.close(any[Time])).thenReturn(Future.Done)
     when(trans.onClose).thenReturn(closeP)
 
     val disp = new HttpClientDispatcher(
@@ -108,7 +108,6 @@ class ConnectionManagerTest extends FunSuite with MockitoSugar {
 
     verify(trans, times(1)).write(any[Request])
     verify(trans, times(1)).read()
-
 
     wp.setDone()
 


### PR DESCRIPTION
Problem

When a finagle-http server receives a non-keepalive request (i.e. with Connection: close), it does not close the underlying transport. Instead it waits for the client to teardown the connection. This causes undesirable behavior: client connections go into TIME_WAIT on the remote side since they do not receive a FIN from the serverside. This can cause clients to exhaust ports when not using keepalive connections.

Solution

HttpServerDispatcher should terminate connections eagerly when a client requests that the connection be closed.

<hr/>

When running tests against linkerd, we noticed a high number of connection errors from our load generator when not reusing connections.

When connection errors occur, `netstat` on the client host shows that there are 20K+ connections to linkerd in TIME_WAIT, indicating the the client has sent a FIN and is waiting to time the connection out. Our client simply exhausts ports waiting for these connections to time out.

However, when we run this test directly against a Go application, we see no such socket leak. This is because the Go web server terminates client connections eagerly.

After introducing this change, we see the client host stabilize at about 150 sockets in TIMED_WAIT.