### PR TITLE
fixes #533: FinestIOExceptionMessages to include "An existing connection was forcibly closed by the remote host" adding windows specific IOException that indicates that the socket was closed externally to be logged with FINEST level

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/netty3/Netty3Listener.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/netty3/Netty3Listener.scala
@@ -347,10 +347,11 @@ case class Netty3Listener[In, Out](
 
 private[netty3] object ServerBridge {
   private val FinestIOExceptionMessages = Set(
-    "Connection reset by peer",
-    "Broken pipe",
-    "Connection timed out",
+    "Connection reset by peer", // Found on linux
+    "Broken pipe", // Found on linux
+    "Connection timed out", // Found on linux NIO1
     "No route to host",
+    "An existing connection was forcibly closed by the remote host", // Found on windows
     "")
 }
 


### PR DESCRIPTION
Problem

When running the service on Windows and the client socket is closed from the client side the log is being polluted with WARNINGS containing exceptions: "An existing connection was forcibly closed by the remote host"

Solution

This exception message should be added to the existing list of messages to be logged with the FINEST level

Result

adding windows specific IOException that indicates that the socket was closed externally to be logged with FINEST level
