### PR TITLE
Lower max heap size to 3GB (-Xmx3G)

### DIFF
--- a/sbt
+++ b/sbt
@@ -28,10 +28,7 @@ java -ea                          \
   $JAVA_OPTS                      \
   -Djava.net.preferIPv4Stack=true \
   -XX:+AggressiveOpts             \
-  -XX:+UseParNewGC                \
-  -XX:+UseConcMarkSweepGC         \
-  -XX:+CMSParallelRemarkEnabled   \
-  -XX:+CMSClassUnloadingEnabled   \
+  -XX:+UseG1GC                    \
   -XX:ReservedCodeCacheSize=128m  \
   -XX:SurvivorRatio=128           \
   -XX:MaxTenuringThreshold=0      \

--- a/sbt
+++ b/sbt
@@ -37,6 +37,6 @@ java -ea                          \
   -XX:MaxTenuringThreshold=0      \
   -Xss8M                          \
   -Xms512M                        \
-  -Xmx3584M                       \
+  -Xmx3G                          \
   -server                         \
   -jar $sbtjar "$@"


### PR DESCRIPTION
Problem

Travis build is still failing sporadically due to excessive memory usage during sbt builds. Specifically, a test in [finagle-thriftmux](https://github.com/twitter/finagle/blob/7efeb4cc2babd7c99731090fa76ad960627fce14/finagle-thriftmux/src/test/scala/com/twitter/finagle/thriftmux/EndToEndTest.scala#L937) is attempting to allocate a 2GB `Array[Byte]`.

Solution

Lower the max heap size to 3GB. This should be enough, but there is a chance it will fail due to fragmentation of the heap (if I understand the current GC settings correctly...).