### PR TITLE
Don't run a a thriftmux test on Travis builds

### DIFF
--- a/finagle-thriftmux/src/test/scala/com/twitter/finagle/thriftmux/EndToEndTest.scala
+++ b/finagle-thriftmux/src/test/scala/com/twitter/finagle/thriftmux/EndToEndTest.scala
@@ -934,6 +934,8 @@ class EndToEndTest extends FunSuite
     }
   }
 
+  // This test uses excessive memory so skip on SBT builds
+  if (!sys.props.contains("SKIP_SBT"))
   test("ThriftMux client to Thrift server ") {
     val iface = new TestService.FutureIface {
       def query(x: String) = Future.value(x + x)

--- a/sbt
+++ b/sbt
@@ -21,8 +21,7 @@ fi
 
 [ -f ~/.sbtconfig ] && . ~/.sbtconfig
 
-# -Xmx is set slightly below the Travis limit of 4GB to avoid getting SIGKILL'ed
-# https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments
+# the -DSKIP_SBT flag is set to skip tests that shouldn't be run with sbt.
 java -ea                          \
   $SBT_OPTS                       \
   $JAVA_OPTS                      \
@@ -37,6 +36,7 @@ java -ea                          \
   -XX:MaxTenuringThreshold=0      \
   -Xss8M                          \
   -Xms512M                        \
-  -Xmx3584M                       \
+  -Xmx2G                          \
+  -DSKIP_SBT=1                    \
   -server                         \
   -jar $sbtjar "$@"


### PR DESCRIPTION
__Travis build test. Do not merge.__

Problem

The test in finagle-thriftmux c.t.f.t.EndToEndTest:"ThriftMux client to
Thrift server " allocates a 2 GB byte array, and this causes problems
with the 2 GB memory limit of Travis and sbt builds.

Solution

Disable the test on sbt builds using a flag, "SKIP_SBT".