### PR TITLE
serve multiple thrift ifaces

### DIFF
--- a/finagle-thrift/src/main/java/org/apache/thrift/protocol/TMultiplexedProtocol.java
+++ b/finagle-thrift/src/main/java/org/apache/thrift/protocol/TMultiplexedProtocol.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.thrift.protocol;
+
+import org.apache.thrift.TException;
+
+/**
+ * <code>TMultiplexedProtocol</code> is a protocol-independent concrete decorator
+ * that allows a Thrift client to communicate with a multiplexing Thrift server,
+ * by prepending the service name to the function name during function calls.
+ *
+ * <p>NOTE: THIS IS NOT USED BY SERVERS.  On the server, use {@link org.apache.thrift.TMultiplexedProcessor TMultiplexedProcessor} to handle requests
+ * from a multiplexing client.
+ *
+ * <p>This example uses a single socket transport to invoke two services:
+ *
+ * <blockquote><code>
+ *     TSocket transport = new TSocket("localhost", 9090);<br/>
+ *     transport.open();<br/>
+ *<br/>
+ *     TBinaryProtocol protocol = new TBinaryProtocol(transport);<br/>
+ *<br/>
+ *     TMultiplexedProtocol mp = new TMultiplexedProtocol(protocol, "Calculator");<br/>
+ *     Calculator.Client service = new Calculator.Client(mp);<br/>
+ *<br/>
+ *     TMultiplexedProtocol mp2 = new TMultiplexedProtocol(protocol, "WeatherReport");<br/>
+ *     WeatherReport.Client service2 = new WeatherReport.Client(mp2);<br/>
+ *<br/>
+ *     System.out.println(service.add(2,2));<br/>
+ *     System.out.println(service2.getTemperature());<br/>
+ * </code></blockquote>
+ *
+ * @see org.apache.thrift.protocol.TProtocolDecorator
+ */
+public class TMultiplexedProtocol extends TProtocolDecorator {
+
+    /** Used to delimit the service name from the function name */
+    public static final String SEPARATOR = ":";
+
+    private final String SERVICE_NAME;
+
+    /**
+     * Wrap the specified protocol, allowing it to be used to communicate with a
+     * multiplexing server.  The <code>serviceName</code> is required as it is
+     * prepended to the message header so that the multiplexing server can broker
+     * the function call to the proper service.
+     *
+     * @param protocol Your communication protocol of choice, e.g. <code>TBinaryProtocol</code>.
+     * @param serviceName The service name of the service communicating via this protocol.
+     */
+    public TMultiplexedProtocol(TProtocol protocol, String serviceName) {
+        super(protocol);
+        SERVICE_NAME = serviceName;
+    }
+
+    /**
+     * Prepends the service name to the function name, separated by TMultiplexedProtocol.SEPARATOR.
+     *
+     * @param tMessage The original message.
+     * @throws TException Passed through from wrapped <code>TProtocol</code> instance.
+     */
+    @Override
+    public void writeMessageBegin(TMessage tMessage) throws TException {
+        if (tMessage.type == TMessageType.CALL || tMessage.type == TMessageType.ONEWAY) {
+            super.writeMessageBegin(new TMessage(
+                    SERVICE_NAME + SEPARATOR + tMessage.name,
+                    tMessage.type,
+                    tMessage.seqid
+            ));
+        } else {
+            super.writeMessageBegin(tMessage);
+        }
+    }
+}

--- a/finagle-thrift/src/main/java/org/apache/thrift/protocol/TProtocolDecorator.java
+++ b/finagle-thrift/src/main/java/org/apache/thrift/protocol/TProtocolDecorator.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.thrift.protocol;
+
+import org.apache.thrift.TException;
+
+import java.nio.ByteBuffer;
+
+/**
+ * <code>TProtocolDecorator</code> forwards all requests to an enclosed
+ * <code>TProtocol</code> instance, providing a way to author concise
+ * concrete decorator subclasses.  While it has no abstract methods, it
+ * is marked abstract as a reminder that by itself, it does not modify
+ * the behaviour of the enclosed <code>TProtocol</code>.
+ *
+ * <p>See p.175 of Design Patterns (by Gamma et al.)</p>
+ * 
+ * @see org.apache.thrift.protocol.TMultiplexedProtocol
+ */
+public abstract class TProtocolDecorator extends TProtocol {
+
+    private final TProtocol concreteProtocol;
+
+    /**
+     * Encloses the specified protocol.
+     * @param protocol All operations will be forward to this protocol.  Must be non-null.
+     */
+    public TProtocolDecorator(TProtocol protocol) {
+        super(protocol.getTransport());
+        concreteProtocol = protocol;
+    }
+
+    public void writeMessageBegin(TMessage tMessage) throws TException {
+        concreteProtocol.writeMessageBegin(tMessage);
+    }
+
+    public void writeMessageEnd() throws TException {
+        concreteProtocol.writeMessageEnd();
+    }
+
+    public void writeStructBegin(TStruct tStruct) throws TException {
+        concreteProtocol.writeStructBegin(tStruct);
+    }
+
+    public void writeStructEnd() throws TException {
+        concreteProtocol.writeStructEnd();
+    }
+
+    public void writeFieldBegin(TField tField) throws TException {
+        concreteProtocol.writeFieldBegin(tField);
+    }
+
+    public void writeFieldEnd() throws TException {
+        concreteProtocol.writeFieldEnd();
+    }
+
+    public void writeFieldStop() throws TException {
+        concreteProtocol.writeFieldStop();
+    }
+
+    public void writeMapBegin(TMap tMap) throws TException {
+        concreteProtocol.writeMapBegin(tMap);
+    }
+
+    public void writeMapEnd() throws TException {
+        concreteProtocol.writeMapEnd();
+    }
+
+    public void writeListBegin(TList tList) throws TException {
+        concreteProtocol.writeListBegin(tList);
+    }
+
+    public void writeListEnd() throws TException {
+        concreteProtocol.writeListEnd();
+    }
+
+    public void writeSetBegin(TSet tSet) throws TException {
+        concreteProtocol.writeSetBegin(tSet);
+    }
+
+    public void writeSetEnd() throws TException {
+        concreteProtocol.writeSetEnd();
+    }
+
+    public void writeBool(boolean b) throws TException {
+        concreteProtocol.writeBool(b);
+    }
+
+    public void writeByte(byte b) throws TException {
+        concreteProtocol.writeByte(b);
+    }
+
+    public void writeI16(short i) throws TException {
+        concreteProtocol.writeI16(i);
+    }
+
+    public void writeI32(int i) throws TException {
+        concreteProtocol.writeI32(i);
+    }
+
+    public void writeI64(long l) throws TException {
+        concreteProtocol.writeI64(l);
+    }
+
+    public void writeDouble(double v) throws TException {
+        concreteProtocol.writeDouble(v);
+    }
+
+    public void writeString(String s) throws TException {
+        concreteProtocol.writeString(s);
+    }
+
+    public void writeBinary(ByteBuffer buf) throws TException {
+        concreteProtocol.writeBinary(buf);
+    }
+
+    public TMessage readMessageBegin() throws TException {
+        return concreteProtocol.readMessageBegin();
+    }
+
+    public void readMessageEnd() throws TException {
+        concreteProtocol.readMessageEnd();
+    }
+
+    public TStruct readStructBegin() throws TException {
+        return concreteProtocol.readStructBegin();
+    }
+
+    public void readStructEnd() throws TException {
+        concreteProtocol.readStructEnd();
+    }
+
+    public TField readFieldBegin() throws TException {
+        return concreteProtocol.readFieldBegin();
+    }
+
+    public void readFieldEnd() throws TException {
+        concreteProtocol.readFieldEnd();
+    }
+
+    public TMap readMapBegin() throws TException {
+        return concreteProtocol.readMapBegin();
+    }
+
+    public void readMapEnd() throws TException {
+        concreteProtocol.readMapEnd();
+    }
+
+    public TList readListBegin() throws TException {
+        return concreteProtocol.readListBegin();
+    }
+
+    public void readListEnd() throws TException {
+        concreteProtocol.readListEnd();
+    }
+
+    public TSet readSetBegin() throws TException {
+        return concreteProtocol.readSetBegin();
+    }
+
+    public void readSetEnd() throws TException {
+        concreteProtocol.readSetEnd();
+    }
+
+    public boolean readBool() throws TException {
+        return concreteProtocol.readBool();
+    }
+
+    public byte readByte() throws TException {
+        return concreteProtocol.readByte();
+    }
+
+    public short readI16() throws TException {
+        return concreteProtocol.readI16();
+    }
+
+    public int readI32() throws TException {
+        return concreteProtocol.readI32();
+    }
+
+    public long readI64() throws TException {
+        return concreteProtocol.readI64();
+    }
+
+    public double readDouble() throws TException {
+        return concreteProtocol.readDouble();
+    }
+
+    public String readString() throws TException {
+        return concreteProtocol.readString();
+    }
+
+    public ByteBuffer readBinary() throws TException {
+        return concreteProtocol.readBinary();
+    }
+}

--- a/finagle-thrift/src/main/scala/com/twitter/finagle/rich.scala
+++ b/finagle-thrift/src/main/scala/com/twitter/finagle/rich.scala
@@ -626,6 +626,12 @@ trait ThriftRichServer { self: Server[Array[Byte], Array[Byte]] =>
   /**
    * $serveIfaces
    */
-  def serveIfaces(addr: SocketAddress, ifaces: Map[String, AnyRef], defaultService: Option[String] = None): ListeningServer =
+  def serveIfaces(addr: SocketAddress, ifaces: Map[String, AnyRef]): ListeningServer =
+    serve(addr, serverFromIfaces(ifaces, None, protocolFactory, serverStats, maxThriftBufferSize, serverLabel))
+
+  /**
+   * $serveIfaces
+   */
+  def serveIfaces(addr: SocketAddress, ifaces: Map[String, AnyRef], defaultService: Option[String]): ListeningServer =
     serve(addr, serverFromIfaces(ifaces, defaultService, protocolFactory, serverStats, maxThriftBufferSize, serverLabel))
 }

--- a/finagle-thrift/src/main/scala/com/twitter/finagle/thrift/MultiplexedService.scala
+++ b/finagle-thrift/src/main/scala/com/twitter/finagle/thrift/MultiplexedService.scala
@@ -1,0 +1,117 @@
+package com.twitter.finagle.thrift
+
+import com.twitter.finagle.{Service, Thrift}
+import com.twitter.scrooge.TReusableMemoryTransport
+import com.twitter.util.Future
+import java.util.Arrays
+import org.apache.thrift.TApplicationException
+import org.apache.thrift.protocol._
+import org.apache.thrift.transport.TMemoryInputTransport
+import scala.collection.JavaConverters._
+import scala.util.Try
+
+class MultiplexedFinagleService(
+  services: Map[String, Service[Array[Byte], Array[Byte]]],
+  protocolFactory: TProtocolFactory,
+  maxThriftBufferSize: Int = Thrift.Server.maxThriftBufferSize)
+    extends Service[Array[Byte], Array[Byte]] {
+
+  private val serviceMap = services.mapValues(getFunctionMap)
+
+  def getFunctionMap(
+    service: Service[Array[Byte], Array[Byte]]
+  ): collection.Map[String, (TProtocol, Int) => Future[Array[Byte]]] = {
+    Try(scroogeFinagleServiceFunctionMap(service))
+      .orElse(Try(thriftFinagleServiceFunctionMap(service)))
+      .getOrElse(throw new IllegalArgumentException("%s cannot be multiplexed".format(service.getClass.getName)))
+  }
+
+  def scroogeFinagleServiceFunctionMap[T](target: AnyRef) = {
+    val m = target.getClass.getMethod("functionMap")
+    val accessible = m.isAccessible
+    m.setAccessible(true)
+    val result = m.invoke(target)
+      .asInstanceOf[collection.Map[String, (TProtocol, Int) => Future[Array[Byte]]]]
+    m.setAccessible(accessible)
+    result
+  }
+
+  def thriftFinagleServiceFunctionMap(target: AnyRef) = {
+    val f = target.getClass.getDeclaredField("functionMap")
+    val accessible = f.isAccessible
+    f.setAccessible(true)
+    val functionMap = f.get(target)
+      .asInstanceOf[java.util.Map[String, com.twitter.util.Function2[TProtocol, Integer, Future[Array[Byte]]]]]
+      .asScala
+      .mapValues(function => (prot: TProtocol, seqId: Int) => function(prot, seqId))
+    f.setAccessible(accessible)
+    functionMap
+  }
+
+  final def apply(request: Array[Byte]): Future[Array[Byte]] = {
+    val inputTransport = new TMemoryInputTransport(request)
+    val iprot = protocolFactory.getProtocol(inputTransport)
+    try {
+      val msg = iprot.readMessageBegin()
+      val index = msg.name.indexOf(TMultiplexedProtocol.SEPARATOR)
+      if (index == -1) {
+        exception(msg.name, msg.seqid, TApplicationException.PROTOCOL_ERROR,
+          s"This is a multiplexed service, with available service names: [${serviceMap.keys.mkString(", ")}]")
+      } else {
+        val serviceName = msg.name.substring(0, index)
+        val functionName = msg.name.substring(index + 1)
+        val functionMap = serviceMap.get(serviceName)
+        val func = functionMap.flatMap(_.get(functionName))
+        func match {
+          case Some(fn) =>
+            fn(iprot, msg.seqid)
+          case _ =>
+            TProtocolUtil.skip(iprot, TType.STRUCT)
+            val errorMsg = if (functionMap.isEmpty) {
+              s"""Invalid service name: ${serviceName}, available serivce names: [${serviceMap.keys.mkString(", ")}]"""
+            } else {
+              s"""Invalid method name: ${functionName}, available method names: [${functionMap.get.keys.mkString(", ")}]"""
+            }
+            exception(msg.name, msg.seqid, TApplicationException.UNKNOWN_METHOD, errorMsg)
+        }
+      }
+    } catch {
+      case e: Throwable => Future.exception(e)
+    }
+  }
+
+  private[this] def exception(name: String, seqid: Int, code: Int, message: String): Future[Array[Byte]] = {
+    try {
+      val x = new TApplicationException(code, message)
+      val memoryBuffer = reusableBuffer
+      try {
+        val oprot = protocolFactory.getProtocol(memoryBuffer)
+        oprot.writeMessageBegin(new TMessage(name, TMessageType.EXCEPTION, seqid))
+        x.write(oprot)
+        oprot.writeMessageEnd()
+        oprot.getTransport().flush()
+        Future.value(Arrays.copyOfRange(memoryBuffer.getArray(), 0, memoryBuffer.length()))
+      } finally {
+        resetBuffer(memoryBuffer)
+      }
+    } catch {
+      case e: Exception => Future.exception(e)
+    }
+  }
+
+  private[this] val tlReusableBuffer = new ThreadLocal[TReusableMemoryTransport] {
+    override def initialValue() = TReusableMemoryTransport(512)
+  }
+
+  private[this] def reusableBuffer: TReusableMemoryTransport = {
+    val buf = tlReusableBuffer.get()
+    buf.reset()
+    buf
+  }
+
+  private[this] def resetBuffer(trans: TReusableMemoryTransport) {
+    if (trans.currentCapacity > maxThriftBufferSize) {
+      tlReusableBuffer.remove()
+    }
+  }
+}

--- a/finagle-thrift/src/main/scala/com/twitter/finagle/thrift/Protocols.scala
+++ b/finagle-thrift/src/main/scala/com/twitter/finagle/thrift/Protocols.scala
@@ -78,10 +78,7 @@ object Protocols {
     binaryFactory(statsReceiver = statsReceiver)
   }
 
-  /**
-   * Multiplex the protocolFactory with the serviceName.
-   */
-  def multiplex(serviceName: String, protocolFactory: TProtocolFactory) = {
+  def multiplex(serviceName: String, protocolFactory: TProtocolFactory): TProtocolFactory = {
     new TProtocolFactory {
       def getProtocol(transport: TTransport) = {
         new TMultiplexedProtocol(protocolFactory.getProtocol(transport), serviceName)

--- a/finagle-thrift/src/main/scala/com/twitter/finagle/thrift/Protocols.scala
+++ b/finagle-thrift/src/main/scala/com/twitter/finagle/thrift/Protocols.scala
@@ -7,7 +7,7 @@ import com.twitter.util.NonFatal
 import java.nio.{ByteBuffer, CharBuffer}
 import java.nio.charset.{CoderResult, CharsetEncoder}
 import java.security.{PrivilegedExceptionAction, AccessController}
-import org.apache.thrift.protocol.{TProtocol, TProtocolFactory, TBinaryProtocol}
+import org.apache.thrift.protocol.{TMultiplexedProtocol, TProtocol, TProtocolFactory, TBinaryProtocol}
 import org.apache.thrift.transport.TTransport
 
 object Protocols {
@@ -76,6 +76,17 @@ object Protocols {
 
   def factory(statsReceiver: StatsReceiver = DefaultStatsReceiver): TProtocolFactory = {
     binaryFactory(statsReceiver = statsReceiver)
+  }
+
+  /**
+   * Multiplex the protocolFactory with the serviceName.
+   */
+  def multiplex(serviceName: String, protocolFactory: TProtocolFactory) = {
+    new TProtocolFactory {
+      def getProtocol(transport: TTransport) = {
+        new TMultiplexedProtocol(protocolFactory.getProtocol(transport), serviceName)
+      }
+    }
   }
 
   // Visible for testing purposes.

--- a/finagle-thrift/src/test/scala/com/twitter/finagle/thrift/MultiplexedServiceTest.scala
+++ b/finagle-thrift/src/test/scala/com/twitter/finagle/thrift/MultiplexedServiceTest.scala
@@ -28,7 +28,7 @@ class MultiplexedServiceTest extends FunSuite {
     )
 
     val address = new InetSocketAddress(InetAddress.getLoopbackAddress, 0)
-    val server = Thrift.server.serveIfaces(address, serviceMap)
+    val server = Thrift.server.serveIfaces(address, serviceMap, Some("extendedEcho"))
 
     val name = Name.bound(Address(server.boundAddress.asInstanceOf[InetSocketAddress]))
     val client = Thrift.client.multiplex(name, "client") { client =>
@@ -40,5 +40,8 @@ class MultiplexedServiceTest extends FunSuite {
 
     assert(Await.result(client.echo.echo("hello")) == "hello")
     assert(Await.result(client.extendedEcho.getStatus(ExtendedEcho.GetStatus.Args())) == ExtendedEcho.GetStatus.Result(Some("OK")))
+
+    val classicClient = Thrift.client.newIface[ExtendedEcho.FutureIface](name, "classic-client")
+    assert(Await.result(classicClient.getStatus()) == "OK")
   }
 }

--- a/finagle-thrift/src/test/scala/com/twitter/finagle/thrift/MultiplexedServiceTest.scala
+++ b/finagle-thrift/src/test/scala/com/twitter/finagle/thrift/MultiplexedServiceTest.scala
@@ -1,0 +1,44 @@
+package com.twitter.finagle.thrift
+
+import com.twitter.finagle.{Address, Name, Thrift}
+import com.twitter.finagle.thrift.thriftscala.{Echo, ExtendedEcho}
+import com.twitter.util.{Await, Future}
+import java.net.{InetAddress, InetSocketAddress}
+import org.junit.runner.RunWith
+import org.scalatest.{Finders, FunSuite}
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class MultiplexedServiceTest extends FunSuite {
+
+  test("serve multiple ifaces") {
+
+    class EchoService extends Echo.FutureIface {
+      override def echo(msg: String): Future[String] = Future.value(msg)
+    }
+
+    class ExtendedEchoService extends ExtendedEcho.FutureIface {
+      override def echo(msg: String): Future[String] = Future.value(msg)
+      override def getStatus(): Future[String] = Future.value("OK")
+    }
+
+    val serviceMap = Map(
+      "echo" -> new EchoService(),
+      "extendedEcho" -> new ExtendedEchoService()
+    )
+
+    val address = new InetSocketAddress(InetAddress.getLoopbackAddress, 0)
+    val server = Thrift.server.serveIfaces(address, serviceMap)
+
+    val name = Name.bound(Address(server.boundAddress.asInstanceOf[InetSocketAddress]))
+    val client = Thrift.client.multiplex(name, "client") { client =>
+      new {
+        val echo = client.newIface[Echo.FutureIface]("echo")
+        val extendedEcho = client.newServiceIface[ExtendedEcho.ServiceIface]("extendedEcho")
+      }
+    }
+
+    assert(Await.result(client.echo.echo("hello")) == "hello")
+    assert(Await.result(client.extendedEcho.getStatus(ExtendedEcho.GetStatus.Args())) == ExtendedEcho.GetStatus.Result(Some("OK")))
+  }
+}


### PR DESCRIPTION
Problem

Finagle uses an early version of libthrift, which does not support
service multiplexing.

Solution

Since 0.9.1, thrift added several classes to handle service multiplexing.
On the client side, TMultiplexedProtocol is used to decorate the
original protocol, by prefixing a user specified service name as part of
the name of request message. Finagle uses the protocols from libthrift.
All we have to do is copying TMultiplexedProtocol and related classes
from a newer version of libthrfit.

On the server side, TMultiplexedProcessor is used to inspect the
beginning of the incoming message names, and dispatch the message
to an appropriate underlying processor. Finagle does not use
processors, so we have to re-implement this.

Result

Multiple thrift services can be served through a single port, by passing
a map from service names to service implementations.

``` scala
val serviceMap = Map(
  "echo" -> new EchoService(),
  "extendedEcho" -> new ExtendedEchoService()
)

val server = Thrift.server.serveIfaces(address, serviceMap)
```

Multiple Ifaces/ServiceIfaces can be created sharing the same underlying
thrift client.

``` scala
val client = Thrift.client.multiplex(address, "client") { client =>
  new {
    val echo = client.newIface[Echo.FutureIface]("echo")
    val extendedEcho = client.newServiceIface[ExtendedEcho.ServiceIface]("extendedEcho")
  }
}

client.echo.echo("hello")
client.extendedEcho.getStatus(ExtendedEcho.GetStatus.Args())
```
