### PR TITLE
specify Scala version in quickstart for versions >= `6.36.0`.

### DIFF
--- a/doc/src/sphinx/Quickstart.rst
+++ b/doc/src/sphinx/Quickstart.rst
@@ -22,6 +22,7 @@ Setting up SBT
 
 We'll use sbt_ to build our project. Finagle is published to Maven Central,
 so little setup is needed: see the ``build.sbt`` in the ``quickstart`` directory.
+Also ensure that you're using ``scala`` ``2.11`` as of ``6.36.0``.
 
 .. parsed-literal::
 

--- a/doc/src/sphinx/Quickstart.rst
+++ b/doc/src/sphinx/Quickstart.rst
@@ -22,7 +22,7 @@ Setting up SBT
 
 We'll use sbt_ to build our project. Finagle is published to Maven Central,
 so little setup is needed: see the ``build.sbt`` in the ``quickstart`` directory.
-Also ensure that you're using ``scala`` ``2.11`` as of ``6.36.0``.
+We no longer support ``scala`` ``2.10``.
 
 .. parsed-literal::
 


### PR DESCRIPTION
Problem

The quickstart doesn't specify the scala version based on the version of Finagle used. See: https://github.com/twitter/finagle/issues/546#issuecomment-241270739

Solution

Simple modifications that add a line note specifying which Scala version to use as of `6.36.0`.

Result

An extra line will be added to the quickstart specifying the Scala version to use.

