### PR TITLE
finagle-redis: Implement SCAN commands for sets and sorted sets

### DIFF
--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/SetCommands.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/SetCommands.scala
@@ -104,4 +104,16 @@ private[redis] trait SetCommands { self: BaseClient =>
         Future.value(ReplyFormat.toBuf(messages).toSet)
       case EmptyMBulkReply => Future.value(ImmutableSet.empty)
     }
+
+  /**
+    * Returns keys in given set `key`, starting at `cursor`.
+    */
+  def sScan(
+    key: Buf, cursor: JLong, count: Option[JLong], pattern: Option[Buf]
+  ): Future[Seq[Buf]] =
+    doRequest(SScan(key, cursor, count, pattern)) {
+      case MBulkReply(messages) => Future.value(ReplyFormat.toBuf(messages))
+      case EmptyMBulkReply      => Future.Nil
+    }
+
 }

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/SortedSetCommands.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/SortedSetCommands.scala
@@ -200,4 +200,15 @@ private[redis] trait SortedSetCommands { self: BaseClient =>
     doRequest(ZRange(key, start, stop, if (withScores) Some(WithScores) else None)) {
       parseMBulkReply(withScores)
     }
+
+  /**
+    * Returns keys in given set `key`, starting at `cursor`.
+    */
+  def zScan(
+    key: Buf, cursor: JLong, count: Option[JLong], pattern: Option[Buf]
+  ): Future[Seq[Buf]] =
+    doRequest(ZScan(key, cursor, count, pattern)) {
+      case MBulkReply(messages) => Future.value(ReplyFormat.toBuf(messages))
+      case EmptyMBulkReply      => Future.Nil
+    }
 }

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/Command.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/Command.scala
@@ -79,6 +79,7 @@ object Command {
   val ZREVRANGE         = Buf.Utf8("ZREVRANGE")
   val ZREVRANGEBYSCORE  = Buf.Utf8("ZREVRANGEBYSCORE")
   val ZREVRANK          = Buf.Utf8("ZREVRANK")
+  val ZSCAN             = Buf.Utf8("ZSCAN")
   val ZSCORE            = Buf.Utf8("ZSCORE")
   val ZUNIONSTORE       = Buf.Utf8("ZUNIONSTORE")
 
@@ -91,6 +92,7 @@ object Command {
   val SPOP              = Buf.Utf8("SPOP")
   val SRANDMEMBER       = Buf.Utf8("SRANDMEMBER")
   val SINTER            = Buf.Utf8("SINTER")
+  val SSCAN             = Buf.Utf8("SSCAN")
 
   // Miscellaneous
   val PING              = Buf.Utf8("PING")

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/Sets.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/Sets.scala
@@ -52,7 +52,7 @@ case class SScan(
   pattern: Option[Buf] = None
   ) extends Command {
   def name: Buf  = Command.SSCAN
-  def toBuf: Seq[Buf] = {
+  override def body: Seq[Buf] = {
     val bufs = Seq(key, Buf.Utf8(cursor.toString))
     val withCount = count match {
       case Some(count) => bufs ++ Seq(Command.COUNT, Buf.Utf8(count.toString))

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/Sets.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/Sets.scala
@@ -51,17 +51,16 @@ case class SScan(
   count: Option[JLong] = None,
   pattern: Option[Buf] = None
   ) extends Command {
-  def command: String  = Commands.SSCAN
-  def toBuf: Buf = {
-    val bufs = Seq(CommandBytes.HSCAN, key, StringToBuf(cursor.toString))
+  def name: Buf  = Command.SSCAN
+  def toBuf: Seq[Buf] = {
+    val bufs = Seq(key, Buf.Utf8(cursor.toString))
     val withCount = count match {
-      case Some(count) => bufs ++ Seq(CommandBytes.COUNT, StringToBuf(count.toString))
-      case None => bufs
+      case Some(count) => bufs ++ Seq(Command.COUNT, Buf.Utf8(count.toString))
+      case None        => bufs
     }
-    val withPattern = pattern match {
-      case Some(pattern) => withCount ++ Seq(CommandBytes.PATTERN, pattern)
-      case None => withCount
+    pattern match {
+      case Some(pattern) => withCount ++ Seq(Command.PATTERN, pattern)
+      case None          => withCount
     }
-    RedisCodec.toUnifiedBuf(withPattern)
   }
 }

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/SortedSets.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/SortedSets.scala
@@ -342,17 +342,16 @@ case class ZScan(
   count: Option[JLong] = None,
   pattern: Option[Buf] = None
   ) extends Command {
-  def command: String  = Commands.ZSCAN
-  def toBuf: Buf = {
-    val bufs = Seq(CommandBytes.HSCAN, key, StringToBuf(cursor.toString))
+  def name: Buf  = Command.ZSCAN
+  def toBuf: Seq[Buf] = {
+    val bufs = Seq(key, Buf.Utf8(cursor.toString))
     val withCount = count match {
-      case Some(count) => bufs ++ Seq(CommandBytes.COUNT, StringToBuf(count.toString))
+      case Some(count) => bufs ++ Seq(Command.COUNT, Buf.Utf8(count.toString))
       case None        => bufs
     }
-    val withPattern = pattern match {
-      case Some(pattern) => withCount ++ Seq(CommandBytes.PATTERN, pattern)
+    pattern match {
+      case Some(pattern) => withCount ++ Seq(Command.PATTERN, pattern)
       case None          => withCount
     }
-    RedisCodec.toUnifiedBuf(withPattern)
   }
 }

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/SortedSets.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/SortedSets.scala
@@ -343,7 +343,7 @@ case class ZScan(
   pattern: Option[Buf] = None
   ) extends Command {
   def name: Buf  = Command.ZSCAN
-  def toBuf: Seq[Buf] = {
+  override def body: Seq[Buf] = {
     val bufs = Seq(key, Buf.Utf8(cursor.toString))
     val withCount = count match {
       case Some(count) => bufs ++ Seq(Command.COUNT, Buf.Utf8(count.toString))


### PR DESCRIPTION
Problem

finagle-redis does not support the SSCAN and ZSCAN commands for
sets and sorted sets, respectively.

Solution

Implement SSCAN and ZSCAN in finagle-redis.
