### PR TITLE
finagle-http: fix connection management for non-keepalive requests.

### DIFF
--- a/finagle-http/src/main/scala/com/twitter/finagle/http/codec/ConnectionManager.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/http/codec/ConnectionManager.scala
@@ -9,9 +9,26 @@ import com.twitter.util.{Future, Promise}
  * codec implementations are in {Server,Client}ConnectionManager.
  */
 private[finagle] class ConnectionManager {
+
+  /** Indicates whether the connection should be closed when it becomes idle. */
   private[this] var isKeepAlive = false
+
+  /** When false, the connection is busy servicing a a request. */
   private[this] var isIdle = true
-  private[this] var activeStreams, pendingResponses = 0
+
+  /**
+   * Indicates the number of chunked messages currently being
+   * transmitted on this connection. Practically, on [0, 2].
+   */
+  private[this] var activeStreams = 0
+
+  /**
+   * Indicates the number of requests that have been issues that have
+   * not yet received a response. Practically, on [0, 1]
+   */
+  private[this] var pendingResponses = 0
+
+  /** Satisfied when the connection is ready to be torn down. */
   private[this] val closeP = new Promise[Unit]
 
   def observeMessage(message: Message, onFinish: Future[Unit]): Unit = synchronized {

--- a/finagle-http/src/main/scala/com/twitter/finagle/http/codec/ConnectionManager.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/http/codec/ConnectionManager.scala
@@ -11,7 +11,7 @@ import com.twitter.util.{Future, Promise}
 private[finagle] class ConnectionManager {
   private[this] var isKeepAlive = false
   private[this] var isIdle = true
-  private[this] var activeStreams = 0
+  private[this] var activeStreams, requestsObserved, responsesObserved = 0
   private[this] val closeP = new Promise[Unit]
 
   def observeMessage(message: Message, onFinish: Future[Unit]): Unit = synchronized {
@@ -23,12 +23,14 @@ private[finagle] class ConnectionManager {
   }
 
   def observeRequest(request: Request, onFinish: Future[Unit]): Unit = synchronized {
+    requestsObserved += 1
     isIdle = false
     isKeepAlive = request.isKeepAlive
     handleIfStream(onFinish)
   }
 
   def observeResponse(response: Response, onFinish: Future[Unit]): Unit = synchronized {
+    responsesObserved += 1
     if ((!response.isChunked && response.contentLength.isEmpty) || !response.isKeepAlive) isKeepAlive = false
 
     // If a response isn't chunked, then we're done with this request,
@@ -50,7 +52,7 @@ private[finagle] class ConnectionManager {
 
   private[this] def endStream(): Unit = synchronized {
     activeStreams -= 1
-    isIdle = activeStreams == 0
+    isIdle = activeStreams == 0 && requestsObserved == responsesObserved
   }
 
   def shouldClose(): Boolean = synchronized { isIdle && !isKeepAlive }


### PR DESCRIPTION
Problem

When issuing HTTP/1.0 or non-keep-alive requests (i.e. with Connection: close),
the connection may be marked as closable before a request/response has
completed.  Specifically, when finagle-http's ConnectionManager observes a
non-keepalive request, it may satisfy onClose before a response is observed.
This causes the entire connection to be torn down (and the response canceled)
before the response can be received.

Solution

Consider a connection to be closable only when an equal number of requests and
responses have been observed.

Fixes twitter/finagle#549