### PR TITLE
Tolerates reads of 128 bit X-B3-TraceId

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/tracing/Id.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/tracing/Id.scala
@@ -49,7 +49,11 @@ object SpanId {
 
   def fromString(spanId: String): Option[SpanId] =
     try {
-      Some(SpanId(new RichU64String(spanId).toU64Long))
+      // Tolerates 128 bit X-B3-TraceId by reading the right-most 16 hex
+      // characters (as opposed to overflowing a U64 and starting a new trace).
+      val length = spanId.length()
+      val lower64Bits = if (length <= 16) spanId else spanId.substring(length - 16)
+      Some(SpanId(new RichU64String(lower64Bits).toU64Long))
     } catch {
       case NonFatal(_) => None
     }

--- a/finagle-core/src/test/scala/com/twitter/finagle/tracing/SpanIdTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/tracing/SpanIdTest.scala
@@ -18,6 +18,12 @@ class SpanIdTest extends FunSuite {
     assert(SpanId.fromString("7b").get.toLong == 123L)
   }
 
+  test("create a span from a 128bit hex string by dropping high bits") {
+    val hex128Bits = "463ac35c9f6413ad48485a3953bb6124"
+    val lower64Bits = "48485a3953bb6124"
+    assert(SpanId.fromString(hex128Bits).get == SpanId.fromString(lower64Bits).get)
+  }
+
   test("return None if string is not valid hex") {
     assert(SpanId.fromString("rofl") == None)
   }

--- a/finagle-thrift/src/main/ruby/lib/finagle-thrift/trace.rb
+++ b/finagle-thrift/src/main/ruby/lib/finagle-thrift/trace.rb
@@ -100,13 +100,14 @@ module Trace
   end
 
   class SpanId
-    HEX_REGEX = /^[a-f0-9]{16}$/i
+    HEX_REGEX = /^[a-f0-9]{16,32}$/i
     MAX_SIGNED_I64 = 9223372036854775807
     MASK = (2 ** 64) - 1
 
     def self.from_value(v)
       if v.is_a?(String) && v =~ HEX_REGEX
-        new(v.hex)
+        # drops any bits higher than 64 by selecting right-most 16 characters
+        new(v.length > 16 ? v[v.length - 16, 16].hex : v.hex)
       elsif v.is_a?(Numeric)
         new(v)
       elsif v.is_a?(SpanId)

--- a/finagle-thrift/src/main/ruby/test/trace_test.rb
+++ b/finagle-thrift/src/main/ruby/test/trace_test.rb
@@ -19,6 +19,11 @@ class TraceIdTest < Test::Unit::TestCase
     id2 = Trace::SpanId.from_value(id.to_s)
     assert_equal id.to_i, id2.to_i
   end
+
+  def test_span_id_128
+    from_hex_128 = Trace::SpanId.from_value('463ac35c9f6413ad48485a3953bb6124')
+    assert_equal from_hex_128.to_s, '48485a3953bb6124'
+  end
 end
 
 class TraceTest < Test::Unit::TestCase


### PR DESCRIPTION
Problem

The first step of transitioning to 128bit `X-B3-TraceId` is tolerantly reading 32 character long ids. Until a change is made, those propagating 128bit ids to finagle will have their traces restarted due to a parse failure.

Solution

I've changed the SpanId parser to leniently parse an unsigned 64bit long from a lower-hex string. This works by throwing away the high bits (any characters left of 16 characters)

Result

When a 128bit id like `X-B3-TraceId: 463ac35c9f6413ad48485a3953bb6124` is received, the lower 64 bits (right most 16 characters ex48485a3953bb6124) will become the trace id as opposed to having the trace restarted.

Fixes #552