### PR TITLE
Added `withHttpStats` config to Http.[Server|Client].

### DIFF
--- a/doc/src/sphinx/Metrics.rst
+++ b/doc/src/sphinx/Metrics.rst
@@ -195,6 +195,10 @@ These stats pertain to the HTTP protocol.
   A counter of the number of non-retryable HTTP 503 responses the Http server returns. Those
   responses are not automatically retried.
 
+These metrics are added by
+:src:`StatsFilter <com/twitter/finagle/http/filter/StatsFilter.scala>` and can be enabled by
+using `.withHttpStats` on `Http.Client` and `Http.Server`.
+
 **status/<statusCode>**
   A counter of the number of responses received, or returned for servers, that had this
   statusCode.
@@ -204,10 +208,10 @@ These stats pertain to the HTTP protocol.
   count as 5XX for this counter.
 
 **time/<statusCode>**
-  Metric on duration per Http status code.
+  A histogram on duration per Http status code.
 
 **time/<statusCategory>**
-  Metric on duration per Http status code category.
+  A histogram on duration per Http status code category.
 
 
 Mux

--- a/doc/src/sphinx/Metrics.rst
+++ b/doc/src/sphinx/Metrics.rst
@@ -195,6 +195,21 @@ These stats pertain to the HTTP protocol.
   A counter of the number of non-retryable HTTP 503 responses the Http server returns. Those
   responses are not automatically retried.
 
+**status/<statusCode>**
+  A counter of the number of responses received, or returned for servers, that had this
+  statusCode.
+
+**status/<statusClass>**
+  Same as **status/statusCode** but aggregated per category, e.g. all 500 range responses
+  count as 5XX for this counter.
+
+**time/<statusCode>**
+  Metric on duration per Http status code.
+
+**time/<statusCategory>**
+  Metric on duration per Http status code category.
+
+
 Mux
 ---
 

--- a/doc/src/sphinx/Metrics.rst
+++ b/doc/src/sphinx/Metrics.rst
@@ -189,10 +189,10 @@ These stats pertain to the HTTP protocol.
 
 **nacks**
   A counter of the number of retryable HTTP 503 responses the Http server returns. Those
-  responses are automatically retried by Finagle Http client.
+  responses are automatically retried by Finagle HTTP client.
 
 **nonretryable_nacks**
-  A counter of the number of non-retryable HTTP 503 responses the Http server returns. Those
+  A counter of the number of non-retryable HTTP 503 responses the HTTP server returns. Those
   responses are not automatically retried.
 
 These metrics are added by
@@ -208,10 +208,10 @@ using `.withHttpStats` on `Http.Client` and `Http.Server`.
   count as 5XX for this counter.
 
 **time/<statusCode>**
-  A histogram on duration per Http status code.
+  A histogram on duration in milliseconds per HTTP status code.
 
 **time/<statusCategory>**
-  A histogram on duration per Http status code category.
+  A histogram on duration in milliseconds per HTTP status code category.
 
 
 Mux

--- a/finagle-core/src/main/scala/com/twitter/finagle/Stack.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/Stack.scala
@@ -455,6 +455,11 @@ object Stack {
       Node(this, (prms, next) => Leaf(this, make(next.make(prms))), next)
   }
 
+  class NoOpModule[T](val role: Role, val description: String) extends Module0[T] {
+    override def make(next: T): T =
+      next
+  }
+
   /** A module of 1 parameter. */
   abstract class Module1[P1: Param, T] extends Stackable[T] {
     final val parameters: Seq[Stack.Param[_]] =

--- a/finagle-core/src/main/scala/com/twitter/finagle/Stack.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/Stack.scala
@@ -456,7 +456,7 @@ object Stack {
   }
 
   class NoOpModule[T](val role: Role, val description: String) extends Module0[T] {
-    override def make(next: T): T =
+    def make(next: T): T =
       next
   }
 

--- a/finagle-http/src/main/scala/com/twitter/finagle/Http.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/Http.scala
@@ -174,6 +174,7 @@ object Http extends Client[Request, Response] with HttpRichClient
         .replace(TraceInitializerFilter.role, new HttpClientTraceInitializer[Request, Response])
         .prepend(http.TlsFilter.module)
         .prepend(nonChunkedPayloadSize)
+        .prepend(new Stack.NoOpModule(http.filter.StatsFilter.role, http.filter.StatsFilter.description))
 
     private def params: Stack.Params =
       StackClient.defaultParams +
@@ -272,8 +273,8 @@ object Http extends Client[Request, Response] with HttpRichClient
     /**
      * Enable the collection of HTTP specific metrics. See [[http.filter.StatsFilter]].
      */
-    def enableHttpStats(): Client =
-      withStack(http.filter.StatsFilter.module +: stack)
+    def withHttpStats: Client =
+      withStack(stack.replace(http.filter.StatsFilter.role, http.filter.StatsFilter.module[Request]))
 
     // Java-friendly forwarders
     // See https://issues.scala-lang.org/browse/SI-8905
@@ -323,6 +324,7 @@ object Http extends Client[Request, Response] with HttpRichClient
         .replace(StackServer.Role.preparer, HttpNackFilter.module)
         .prepend(nonChunkedPayloadSize)
         .prepend(ServerContextFilter.module)
+        .prepend(new Stack.NoOpModule(http.filter.StatsFilter.role, http.filter.StatsFilter.description))
 
     private def params: Stack.Params =
       StackServer.defaultParams +
@@ -414,8 +416,8 @@ object Http extends Client[Request, Response] with HttpRichClient
     /**
      * Enable the collection of HTTP specific metrics. See [[http.filter.StatsFilter]].
      */
-    def enableHttpStats(): Server =
-      withStack(http.filter.StatsFilter.module +: stack)
+    def withHttpStats: Server =
+      withStack(stack.replace(http.filter.StatsFilter.role, http.filter.StatsFilter.module[Request]))
 
     // Java-friendly forwarders
     // See https://issues.scala-lang.org/browse/SI-8905

--- a/finagle-http/src/main/scala/com/twitter/finagle/Http.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/Http.scala
@@ -274,7 +274,7 @@ object Http extends Client[Request, Response] with HttpRichClient
      * Enable the collection of HTTP specific metrics. See [[http.filter.StatsFilter]].
      */
     def withHttpStats: Client =
-      withStack(stack.replace(http.filter.StatsFilter.role, http.filter.StatsFilter.module[Request]))
+      withStack(stack.replace(http.filter.StatsFilter.role, http.filter.StatsFilter.module))
 
     // Java-friendly forwarders
     // See https://issues.scala-lang.org/browse/SI-8905
@@ -417,7 +417,7 @@ object Http extends Client[Request, Response] with HttpRichClient
      * Enable the collection of HTTP specific metrics. See [[http.filter.StatsFilter]].
      */
     def withHttpStats: Server =
-      withStack(stack.replace(http.filter.StatsFilter.role, http.filter.StatsFilter.module[Request]))
+      withStack(stack.replace(http.filter.StatsFilter.role, http.filter.StatsFilter.module))
 
     // Java-friendly forwarders
     // See https://issues.scala-lang.org/browse/SI-8905

--- a/finagle-http/src/main/scala/com/twitter/finagle/Http.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/Http.scala
@@ -268,6 +268,13 @@ object Http extends Client[Request, Response] with HttpRichClient
     def withCompressionLevel(level: Int): Client =
       configured(param.CompressionLevel(level))
 
+
+    /**
+     * Enable the collection of HTTP specific metrics. See [[http.filter.StatsFilter]].
+     */
+    def enableHttpStats(): Client =
+      withStack(http.filter.StatsFilter.module +: stack)
+
     // Java-friendly forwarders
     // See https://issues.scala-lang.org/browse/SI-8905
     override val withSessionPool: SessionPoolingParams[Client] =
@@ -403,6 +410,12 @@ object Http extends Client[Request, Response] with HttpRichClient
      */
     def withMaxInitialLineSize(size: StorageUnit): Server =
       configured(param.MaxInitialLineSize(size))
+
+    /**
+     * Enable the collection of HTTP specific metrics. See [[http.filter.StatsFilter]].
+     */
+    def enableHttpStats(): Server =
+      withStack(http.filter.StatsFilter.module +: stack)
 
     // Java-friendly forwarders
     // See https://issues.scala-lang.org/browse/SI-8905

--- a/finagle-http/src/main/scala/com/twitter/finagle/http/filter/StatsFilter.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/http/filter/StatsFilter.scala
@@ -9,17 +9,17 @@ object StatsFilter {
   val role: Stack.Role = Stack.Role("HttpStatsFilter")
   val description: String = "HTTP Stats"
 
-  def module[Req <: Request]: Stackable[ServiceFactory[Req, Response]] =
-    new Stack.Module1[param.Stats, ServiceFactory[Req, Response]] {
+  def module: Stackable[ServiceFactory[Request, Response]] =
+    new Stack.Module1[param.Stats, ServiceFactory[Request, Response]] {
       val role = StatsFilter.role
       val description = StatsFilter.description
 
       def make(statsParam: param.Stats,
-               next: ServiceFactory[Req, Response]): ServiceFactory[Req, Response] = {
+               next: ServiceFactory[Request, Response]): ServiceFactory[Request, Response] = {
         if (statsParam.statsReceiver.isNull)
           next
         else
-          new StatsFilter[Req](statsParam.statsReceiver).andThen(next)
+          new StatsFilter[Request](statsParam.statsReceiver.scope("http")).andThen(next)
       }
     }
 

--- a/finagle-http/src/main/scala/com/twitter/finagle/http/filter/StatsFilter.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/http/filter/StatsFilter.scala
@@ -6,20 +6,20 @@ import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.util._
 
 object StatsFilter {
-  val role = Stack.Role("HttpStatsFilter")
+  val role: Stack.Role = Stack.Role("HttpStatsFilter")
+  val description: String = "HTTP Stats"
 
   def module[Req <: Request]: Stackable[ServiceFactory[Req, Response]] =
     new Stack.Module1[param.Stats, ServiceFactory[Req, Response]] {
       val role = StatsFilter.role
-      val description = "Register HTTP Stats"
+      val description = StatsFilter.description
 
-      override def make(statsParam: param.Stats,
-                        next: ServiceFactory[Req, Response]): ServiceFactory[Req, Response] = {
-        if (statsParam.statsReceiver.isNull) {
+      def make(statsParam: param.Stats,
+               next: ServiceFactory[Req, Response]): ServiceFactory[Req, Response] = {
+        if (statsParam.statsReceiver.isNull)
           next
-        } else {
+        else
           new StatsFilter[Req](statsParam.statsReceiver).andThen(next)
-        }
       }
     }
 
@@ -49,7 +49,7 @@ class StatsFilter[REQUEST <: Request](stats: StatsReceiver)
     future respond {
       case Return(response) =>
         count(elapsed(), response)
-      case Throw(_)         =>
+      case Throw(_) =>
         // Treat exceptions as empty 500 errors
         val response = Response(request.version, Status.InternalServerError)
         count(elapsed(), response)

--- a/finagle-http/src/test/scala/com/twitter/finagle/HttpTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/HttpTest.scala
@@ -7,7 +7,7 @@ import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finagle.service.{ResponseClass, ResponseClassifier}
 import com.twitter.finagle.stats.InMemoryStatsReceiver
 import com.twitter.finagle.toggle.flag
-import com.twitter.util.{Await, Future}
+import com.twitter.util.{Await, Duration, Future}
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
@@ -71,15 +71,15 @@ class HttpTest extends FunSuite {
         .withStatsReceiver(clientReceiver)
         .newService("localhost:" + server.boundAddress.asInstanceOf[InetSocketAddress].getPort, "stats_test_client")
 
-    Await.result(client(Request()))
+    Await.result(client(Request()), Duration.fromSeconds(5))
 
-    assert(serverReceiver.counters(Seq("stats_test_server", "status", "404")) == 1)
-    assert(serverReceiver.counters(Seq("stats_test_server", "status", "4XX")) == 1)
-    assert(serverReceiver.stats(Seq("stats_test_server", "response_size")) == Seq(5.0))
+    assert(serverReceiver.counters(Seq("stats_test_server", "http", "status", "404")) == 1)
+    assert(serverReceiver.counters(Seq("stats_test_server", "http", "status", "4XX")) == 1)
+    assert(serverReceiver.stats(Seq("stats_test_server", "http", "response_size")) == Seq(5.0))
 
-    assert(clientReceiver.counters(Seq("stats_test_client", "status", "404")) == 1)
-    assert(clientReceiver.counters(Seq("stats_test_client", "status", "4XX")) == 1)
-    assert(clientReceiver.stats(Seq("stats_test_client", "response_size")) == Seq(5.0))
+    assert(clientReceiver.counters(Seq("stats_test_client", "http", "status", "404")) == 1)
+    assert(clientReceiver.counters(Seq("stats_test_client", "http", "status", "4XX")) == 1)
+    assert(clientReceiver.stats(Seq("stats_test_client", "http", "response_size")) == Seq(5.0))
   }
 
   test("server uses default response classifier when toggle disabled") {

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/filter/StatsFilterTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/filter/StatsFilterTest.scala
@@ -3,7 +3,7 @@ package com.twitter.finagle.http.filter
 import com.twitter.finagle.Service
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finagle.stats.InMemoryStatsReceiver
-import com.twitter.util.{Await, Future, Time}
+import com.twitter.util.{Await, Duration, Future, Time}
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
@@ -24,7 +24,7 @@ class StatsFilterTest extends FunSuite {
     }
 
     Time.withCurrentTimeFrozen { _ =>
-      Await.result(filter(Request()))
+      Await.result(filter(Request()), Duration.fromSeconds(5))
     }
 
     assert(receiver.counters(Seq("status", "404")) == 1)


### PR DESCRIPTION
Problem

com.twitter.finagle.http.filter.StatsFilter Is missing a corresponding module
so it cannot be conveniently added to a Stack.

Solution

Added the module, added the `withHttpStats` methods to Client and Server.

Result

It is now possible to effortlessly enable Http specific statistics on both
http servers and clients.