### PR TITLE
finagle-http: Fix SpnegoAuthenticator test failing due to missing realm

### DIFF
--- a/finagle-http/src/test/scala/com/twitter/finagle/http/SpnegoAuthenticatorTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/SpnegoAuthenticatorTest.scala
@@ -114,7 +114,8 @@ class SpnegoAuthenticatorTest extends FunSuite with MockitoSugar {
     }
 
     val jaas = new JaasLoginTest
-    val principal = new KerberosPrincipal("krbtgt/random") // Needs to start with 'krbtgt/'
+    // Needs to start with 'krbtgt/' and have a realm (@REALM.NAME).
+    val principal = new KerberosPrincipal("krbtgt/random@TEST.REALM")
 
     // End date for TGT has not passed yet, ticket is valid
     val goodTicket = createTicketWithEndTime(Time.Top, principal)


### PR DESCRIPTION
Problem / Solution

We create a KerberosPrincipal in SpnegoAuthenticatorTest so we can test the
validity of a ticket under that principal. KerberosPrincipal has a check to see
if a realm has been provided (an @{NAME} appended to the end). If a realm is
not provided, the constructor will look on the machine running the test to see
if a default realm has been configured. Since CI does not have a default realm
configured, the test failed. We append a realm to the end of the name provided
to KerberosPrincipal in order to avoid this exception.