### PR TITLE
InetResolver can now be created with a custom FuturePool

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/InetResolver.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/InetResolver.scala
@@ -10,7 +10,7 @@ import com.twitter.logging.Logger
 import com.twitter.util.{Await, Closable, Var, _}
 import java.net.{InetAddress, InetSocketAddress, UnknownHostException}
 
-private[finagle] class DnsResolver(statsReceiver: StatsReceiver)
+private[finagle] class DnsResolver(statsReceiver: StatsReceiver, resolvePool: FuturePool)
   extends (String => Future[Seq[InetAddress]]) {
 
   private[this] val dnsLookupFailures = statsReceiver.counter("dns_lookup_failures")
@@ -33,7 +33,7 @@ private[finagle] class DnsResolver(statsReceiver: StatsReceiver)
     } else {
       dnsLookups.incr()
       dnsCond.acquire().flatMap { permit =>
-        FuturePool.unboundedPool(InetAddress.getAllByName(host).toSeq)
+        resolvePool(InetAddress.getAllByName(host).toSeq)
           .onFailure { e =>
             log.info(s"Failed to resolve $host. Error $e")
             dnsLookupFailures.incr()
@@ -49,16 +49,18 @@ private[finagle] class DnsResolver(statsReceiver: StatsReceiver)
  */
 object InetResolver {
   def apply(): Resolver = apply(DefaultStatsReceiver)
-  def apply(unscopedStatsReceiver: StatsReceiver): Resolver = {
+  def apply(resolvePool: FuturePool): Resolver = apply(DefaultStatsReceiver, resolvePool)
+  def apply(unscopedStatsReceiver: StatsReceiver, resolvePool: FuturePool = FuturePool.unboundedPool): Resolver = {
     val statsReceiver = unscopedStatsReceiver.scope("inet").scope("dns")
-    new InetResolver(new DnsResolver(statsReceiver), statsReceiver, Some(5.seconds))
+    new InetResolver(new DnsResolver(statsReceiver, resolvePool), statsReceiver, Some(5.seconds), resolvePool)
   }
 }
 
 private[finagle] class InetResolver(
   resolveHost: String => Future[Seq[InetAddress]],
   statsReceiver: StatsReceiver,
-  pollIntervalOpt: Option[Duration])
+  pollIntervalOpt: Option[Duration],
+  resolvePool: FuturePool)
   extends Resolver {
   import InetSocketAddressUtil._
 
@@ -131,7 +133,7 @@ private[finagle] class InetResolver(
             }
           }
           timer.schedule(pollInterval.fromNow, pollInterval) {
-            FuturePool.unboundedPool(updater(()))
+            resolvePool(updater(()))
           }
         case None =>
           Closable.nop
@@ -189,7 +191,7 @@ object FixedInetResolver {
   ): InetResolver = {
     val statsReceiver = unscopedStatsReceiver.scope("inet").scope("dns")
     new FixedInetResolver(cache(
-      new DnsResolver(statsReceiver), maxCacheSize, backoffs, timer), statsReceiver)
+      new DnsResolver(statsReceiver, FuturePool.unboundedPool), maxCacheSize, backoffs, timer), statsReceiver)
   }
 
   // A size-bounded FutureCache backed by a LoaderCache
@@ -237,7 +239,7 @@ object FixedInetResolver {
 private[finagle] class FixedInetResolver(
   cache: LoadingCache[String, Future[Seq[InetAddress]]],
   statsReceiver: StatsReceiver)
-  extends InetResolver(CaffeineCache.fromLoadingCache(cache), statsReceiver, None) {
+  extends InetResolver(CaffeineCache.fromLoadingCache(cache), statsReceiver, None, FuturePool.unboundedPool) {
 
   override val scheme = FixedInetResolver.scheme
 

--- a/finagle-core/src/test/scala/com/twitter/finagle/InetResolverTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/InetResolverTest.scala
@@ -108,7 +108,6 @@ class InetResolverTest extends FunSuite {
         assert(b.contains(Address("127.0.0.1", 80)))
       case _ => fail()
     }
-
     assert(latch.await(maxWaitTimeout))
   }
 }

--- a/finagle-core/src/test/scala/com/twitter/finagle/InetResolverTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/InetResolverTest.scala
@@ -109,7 +109,5 @@ class InetResolverTest extends FunSuite {
     }
 
     assert(latch.await(pollInterval * 2))
-
   }
-
 }

--- a/finagle-core/src/test/scala/com/twitter/finagle/InetResolverTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/InetResolverTest.scala
@@ -101,17 +101,14 @@ class InetResolverTest extends FunSuite {
     val inetResolverWithPool = new InetResolver(resolveLoopback, DefaultStatsReceiver, Some(pollInterval), resolvePool)
 
     val maxWaitTimeout = Duration(500, TimeUnit.MILLISECONDS)
-    Time.withCurrentTimeFrozen { timeControl =>
-      val addr = inetResolverWithPool.bind("127.0.0.1:80")
-      val f = addr.changes.filter(_ != Addr.Pending).toFuture
-      Await.result(f, maxWaitTimeout) match {
-        case Addr.Bound(b, meta) if meta.isEmpty =>
-          assert(b.contains(Address("127.0.0.1", 80)))
-        case _ => fail()
-      }
-
-      timeControl.advance(pollInterval)
-      assert(latch.await(maxWaitTimeout))
+    val addr = inetResolverWithPool.bind("127.0.0.1:80")
+    val f = addr.changes.filter(_ != Addr.Pending).toFuture
+    Await.result(f, maxWaitTimeout) match {
+      case Addr.Bound(b, meta) if meta.isEmpty =>
+        assert(b.contains(Address("127.0.0.1", 80)))
+      case _ => fail()
     }
+
+    assert(latch.await(maxWaitTimeout))
   }
 }

--- a/finagle-core/src/test/scala/com/twitter/finagle/InetResolverTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/InetResolverTest.scala
@@ -1,9 +1,11 @@
 package com.twitter.finagle
 
 import com.twitter.conversions.time._
-import com.twitter.finagle.stats.InMemoryStatsReceiver
-import com.twitter.util.{Future, Await}
-import java.net.{UnknownHostException, InetAddress}
+import com.twitter.finagle.stats.{DefaultStatsReceiver, InMemoryStatsReceiver}
+import com.twitter.util._
+import java.net.{InetAddress, UnknownHostException}
+import java.util.concurrent.TimeUnit
+
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
@@ -12,12 +14,12 @@ import org.scalatest.junit.JUnitRunner
 class InetResolverTest extends FunSuite {
   val statsReceiver = new InMemoryStatsReceiver
 
-  val dnsResolver = new DnsResolver(statsReceiver)
+  val dnsResolver = new DnsResolver(statsReceiver, FuturePool.unboundedPool)
   def resolveHost(host: String): Future[Seq[InetAddress]] = {
     if (host.isEmpty || host.equals("localhost")) dnsResolver(host)
     else Future.exception(new UnknownHostException())
   }
-  val resolver = new InetResolver(resolveHost, statsReceiver, None)
+  val resolver = new InetResolver(resolveHost, statsReceiver, None, FuturePool.unboundedPool)
 
   test("local address") {
     val empty = resolver.bind(":9990")
@@ -74,6 +76,40 @@ class InetResolverTest extends FunSuite {
     }
     assert(statsReceiver.counter("successes")() > 0)
     assert(statsReceiver.stat("lookup_ms")().size > 0)
+  }
+
+  test("updates using custom future pool") {
+    class TestPool(latch: CountDownLatch) extends FuturePool {
+      private val delegate = FuturePool.unboundedPool
+      override def apply[T](f: => T): Future[T] = {
+        latch.countDown()
+        delegate(f)
+      }
+    }
+
+    val latch = new CountDownLatch(1) // DnsResolver will use the pool
+    val resolvePool = new TestPool(latch)
+
+    val dnsResolverWithPool = new DnsResolver(DefaultStatsReceiver, resolvePool)
+
+    def resolveLoopback(host: String): Future[Seq[InetAddress]] = {
+      if (host.equals("127.0.0.1")) dnsResolverWithPool(host)
+      else Future.exception(new UnknownHostException())
+    }
+
+    val pollInterval = Duration(100, TimeUnit.MILLISECONDS)
+    val inetResolverWithPool = new InetResolver(resolveLoopback, DefaultStatsReceiver, Some(pollInterval), resolvePool)
+
+    val addr = inetResolverWithPool.bind("127.0.0.1:80")
+    val f = addr.changes.filter(_ != Addr.Pending).toFuture
+    Await.result(f) match {
+      case Addr.Bound(b, meta) if meta.isEmpty =>
+        assert(b.contains(Address("127.0.0.1", 80)))
+      case _ => fail()
+    }
+
+    assert(latch.await(pollInterval * 2))
+
   }
 
 }


### PR DESCRIPTION
Problem

The `InetResolver` by default uses a unbounded threadpool under the hood. This can be a problem for applications that want to control over number of threads. see https://github.com/twitter/finagle/issues/544

Solution

Added optional `FuturePool` argument to the InetResolver factory. Applications can now create a custom `Resolver` which uses delegation and a custom `InetResolver`.

Notes

- `FixedInetResolver` is unchanged
- I tried to extend my test in `InetResolverTest` to also cover uses of the pool in `bindHostPortsToAddr` but for some reason the update timer is never executed. I think it requires a different test setup with the `Var` and `Addr` that I would need help with.
