### PR TITLE
finagle-redis: Replace PATTERN with MATCH in SCAN and HSCAN

### DIFF
--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/Command.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/Command.scala
@@ -182,7 +182,7 @@ object Command {
   val WEIGHTS          = Buf.Utf8("WEIGHTS")
   val AGGREGATE        = Buf.Utf8("AGGREGATE")
   val COUNT            = Buf.Utf8("COUNT")
-  val PATTERN          = Buf.Utf8("PATTERN")
+  val MATCH            = Buf.Utf8("MATCH")
 
   /**
    * Encodes a given [[Command]] as [[Buf]].

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/Hashes.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/Hashes.scala
@@ -67,7 +67,7 @@ case class HScan(
     }
 
     pattern match {
-      case Some(pattern) => withCount ++ Seq(Command.PATTERN, pattern)
+      case Some(pattern) => withCount ++ Seq(Command.MATCH, pattern)
       case None          => withCount
     }
   }

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/Keys.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/Keys.scala
@@ -89,7 +89,7 @@ case class Scan(cursor: Long, count: Option[JLong] = None, pattern: Option[Buf] 
     }
 
     pattern match {
-      case Some(pattern) => withCount ++ Seq(Command.PATTERN, pattern)
+      case Some(pattern) => withCount ++ Seq(Command.MATCH, pattern)
       case None          => withCount
     }
   }

--- a/finagle-redis/src/test/scala/com/twitter/finagle/redis/commands/key/KeyClientIntegrationSuite.scala
+++ b/finagle-redis/src/test/scala/com/twitter/finagle/redis/commands/key/KeyClientIntegrationSuite.scala
@@ -1,9 +1,10 @@
 package com.twitter.finagle.redis.integration
 
+import com.twitter.conversions.time._
 import com.twitter.finagle.redis.RedisClientTest
 import com.twitter.finagle.redis.tags.{RedisTest, ClientTest}
 import com.twitter.io.Buf
-import com.twitter.util.Await
+import com.twitter.util.{Await, Future}
 import com.twitter.finagle.redis.util.BufToString
 import java.util.Arrays
 import org.junit.Ignore
@@ -14,11 +15,13 @@ import org.scalatest.junit.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 final class KeyClientIntegrationSuite extends RedisClientTest {
 
+  def await[A](a: Future[A]): A = Await.result(a, 5.seconds)
+
   test("Correctly perform the DEL command", RedisTest, ClientTest) {
     withRedisClient { client =>
-      Await.result(client.set(bufFoo, bufBar))
-      Await.result(client.dels(Seq(bufFoo)))
-      assert(Await.result(client.get(bufFoo)) == None)
+      await(client.set(bufFoo, bufBar))
+      await(client.dels(Seq(bufFoo)))
+      assert(await(client.get(bufFoo)) == None)
     }
   }
 
@@ -28,52 +31,54 @@ final class KeyClientIntegrationSuite extends RedisClientTest {
       val v = Buf.Utf8("10")
       val key = Buf.Utf8("mykey")
       val value = Buf.Utf8("10")
-      val expectedBytes: Array[Byte] = Array(0, -64, 10, 6, 0, -8, 114, 63, -59, -5, -5, 95, 40)
+      val expectedBytes: Array[Byte] = Array(0, -64, 10, 7, 0, -111, -83, -126, -74, 6, 100, -74, -95)
 
-      Await.result(client.set(k, v))
+      await(client.set(k, v))
       val actualResult =
-        Await.result(client.dump(key)).fold(fail("Expected result for DUMP"))(Buf.ByteArray.Owned.extract(_))
+        await(client.dump(key)).fold(fail("Expected result for DUMP"))(Buf.ByteArray.Owned.extract(_))
       assert(Arrays.equals(actualResult, expectedBytes))
-      Await.result(client.dels(Seq(bufFoo)))
-      assert(Await.result(client.dump(bufFoo)) == None)
+      await(client.dels(Seq(bufFoo)))
+      assert(await(client.dump(bufFoo)) == None)
     }
   }
 
   // Once the scan/hscan pull request gets merged into Redis master,
   // the tests can be uncommented.
-  ignore("Correctly perform the SCAN command", RedisTest, ClientTest) {
+  test("Correctly perform the SCAN command", RedisTest, ClientTest) {
     withRedisClient { client =>
-      Await.result(client.set(bufFoo, bufBar))
-      Await.result(client.set(bufBaz, bufBoo))
-      assert(BufToString(Await.result(client.scans(0, None, None)).apply(1)) == "baz")
+      await(client.set(bufFoo, bufBar))
+      await(client.set(bufBaz, bufBoo))
 
-      val withCount = Await.result(client.scans(0, Some(10), None))
-      assert(BufToString(withCount(0)) == "0")
-      assert(BufToString(withCount(1)) == "baz")
-      assert(BufToString(withCount(2)) == "foo")
+      val res = await(client.scans(0L, None, None))
+      val resList = res.flatMap(Buf.Utf8.unapply).sorted
+      assert(resList == Seq("0", "baz", "foo"))
+
+      val withCount = await(client.scans(0, Some(10), None))
+      val withCountList = withCount.flatMap(Buf.Utf8.unapply).sorted
+      assert(withCountList == Seq("0", "baz", "foo"))
 
       val pattern = Buf.Utf8("b*")
-      val withPattern = Await.result(client.scans(0, None, Some(pattern)))
-      assert(BufToString(withPattern(0)) == "0")
-      assert(BufToString(withPattern(1)) == "baz")
+      val withPattern = await(client.scans(0, None, Some(pattern)))
+      val withPatternList = withPattern.flatMap(Buf.Utf8.unapply)
+      assert(withPatternList == Seq("0", "baz"))
     }
   }
 
   test("Correctly perform the EXISTS command", RedisTest, ClientTest) {
     withRedisClient { client =>
-      Await.result(client.set(bufFoo, bufBar))
-      assert(Await.result(client.exists(bufFoo)) == true)
+      await(client.set(bufFoo, bufBar))
+      assert(await(client.exists(bufFoo)) == true)
     }
   }
 
   test("Correctly perform the TTL command", RedisTest, ClientTest) {
     withRedisClient { client =>
-      Await.result(client.set(bufFoo, bufBar))
+      await(client.set(bufFoo, bufBar))
       val time = 20L
 
-      assert(Await.result(client.expire(bufFoo, time)) == true)
+      assert(await(client.expire(bufFoo, time)) == true)
 
-      val result = Await.result(client.ttl(bufFoo)) match {
+      val result = await(client.ttl(bufFoo)) match {
         case Some(num) => num
         case None      => fail("Could not retrieve key for TTL test")
       }
@@ -83,15 +88,15 @@ final class KeyClientIntegrationSuite extends RedisClientTest {
 
   test("Correctly perform the EXPIREAT command", RedisTest, ClientTest) {
     withRedisClient { client =>
-      Await.result(client.set(bufFoo, bufBar))
+      await(client.set(bufFoo, bufBar))
 
       // TODO: this isn't actually a TTL, which means that the second assertion
       // below is true for uninteresting reasons.
       val ttl = System.currentTimeMillis() + 20000L
 
-      assert(Await.result(client.expireAt(bufFoo, ttl)) == true)
+      assert(await(client.expireAt(bufFoo, ttl)) == true)
 
-      val result = Await.result(client.ttl(bufFoo)) match {
+      val result = await(client.ttl(bufFoo)) match {
         case Some(num) => num
         case None      => fail("Could not retrieve key for TTL")
       }
@@ -103,27 +108,27 @@ final class KeyClientIntegrationSuite extends RedisClientTest {
     withRedisClient { client =>
       val fromDb = 14
       val toDb   = 15
-      Await.result(client.select(toDb))
-      Await.result(client.dels(Seq(bufFoo)))
-      Await.result(client.select(fromDb))
+      await(client.select(toDb))
+      await(client.dels(Seq(bufFoo)))
+      await(client.select(fromDb))
 
       // This following fails with an exceptions since bar is not a database.
       // assert(Await.result(client.move(bufFoo, bufBar)) == false)
 
-      Await.result(client.set(bufFoo, bufBar))
-      assert(Await.result(client.move(bufFoo, Buf.Utf8(toDb.toString))) == true)
+      await(client.set(bufFoo, bufBar))
+      assert(await(client.move(bufFoo, Buf.Utf8(toDb.toString))) == true)
 
-      Await.result(client.dels(Seq(bufFoo))) // clean up
+      await(client.dels(Seq(bufFoo))) // clean up
     }
   }
 
   test("Correctly perform the PEXPIRE & PTL commands", RedisTest, ClientTest) {
     withRedisClient { client =>
       val ttl = 100000L
-      Await.result(client.set(bufFoo, bufBar))
-      assert(Await.result(client.pExpire(bufFoo, ttl)) == true)
+      await(client.set(bufFoo, bufBar))
+      assert(await(client.pExpire(bufFoo, ttl)) == true)
 
-      val result = Await.result(client.pTtl(bufFoo)) match {
+      val result = await(client.pTtl(bufFoo)) match {
         case Some(num) => num
         case None      => fail("Could not retrieve pTtl for key")
       }
@@ -135,10 +140,10 @@ final class KeyClientIntegrationSuite extends RedisClientTest {
     withRedisClient { client =>
       val horizon = 20000L
       val ttl = System.currentTimeMillis() + horizon
-      Await.result(client.set(bufFoo, bufBar))
-      assert(Await.result(client.pExpireAt(bufFoo, ttl)) == true)
+      await(client.set(bufFoo, bufBar))
+      assert(await(client.pExpireAt(bufFoo, ttl)) == true)
 
-      val result = Await.result(client.pTtl(bufFoo)) match {
+      val result = await(client.pTtl(bufFoo)) match {
         case Some(num) => num
         case None      => fail("Could not retrieve pTtl for key")
       }

--- a/finagle-redis/src/test/scala/com/twitter/finagle/redis/commands/key/KeyCodecSuite.scala
+++ b/finagle-redis/src/test/scala/com/twitter/finagle/redis/commands/key/KeyCodecSuite.scala
@@ -36,8 +36,8 @@ final class KeyCodecSuite extends RedisRequestTest {
   test("SCAN", CodecTest) {
     assert(encodeCommand(Scan(42, None, None)) == Seq("SCAN", "42"))
     assert(encodeCommand(Scan(42, Some(10L), None)) == Seq("SCAN", "42", "COUNT", "10"))
-    assert(encodeCommand(Scan(42, None, Some(Buf.Utf8("foo")))) == Seq("SCAN", "42", "PATTERN", "foo"))
+    assert(encodeCommand(Scan(42, None, Some(Buf.Utf8("foo")))) == Seq("SCAN", "42", "MATCH", "foo"))
     assert(encodeCommand(Scan(42, Some(10L), Some(Buf.Utf8("foo")))) ==
-      Seq("SCAN", "42", "COUNT", "10", "PATTERN", "foo"))
+      Seq("SCAN", "42", "COUNT", "10", "MATCH", "foo"))
   }
 }


### PR DESCRIPTION
Problem

HSCAN and SCAN commands take an optional argument for pattern matching.
This argument is called MATCH and not PATTERN.

Solution

Replace PATTERN with MATCH in SCAN and HSCAN.

Result

Redis clients can execute SCAN and HSCAN with an optional pattern match
argument.
