### PR TITLE
ZooKeeper exists watch now ignores session state events

### DIFF
--- a/finagle-serversets/src/main/scala/com/twitter/finagle/serverset2/client/apache/ApacheWatcher.scala
+++ b/finagle-serversets/src/main/scala/com/twitter/finagle/serverset2/client/apache/ApacheWatcher.scala
@@ -5,16 +5,18 @@ import com.twitter.finagle.stats.{NullStatsReceiver, StatsReceiver}
 import com.twitter.util.Var
 import org.apache.zookeeper.{Watcher, WatchedEvent}
 
-private[serverset2] class ApacheWatcher(statsIn: StatsReceiver = NullStatsReceiver)
+private[serverset2] class ApacheWatcher(statsIn: StatsReceiver = NullStatsReceiver, watchSessionStateEvents: Boolean = true)
     extends Watcher with EventStats {
   protected val stats = statsIn
   val state = Var[WatchState](WatchState.Pending)
   def process(event: WatchedEvent) = {
     event.getType match {
       case Watcher.Event.EventType.None =>
-        EventDeliveryThread.offer(
-          state,
-          WatchState.SessionState(ApacheSessionState(event.getState)))
+        if (watchSessionStateEvents) {
+          EventDeliveryThread.offer(
+            state,
+            WatchState.SessionState(ApacheSessionState(event.getState)))
+        }
       case e =>
         EventDeliveryThread.offer(
           state,

--- a/finagle-serversets/src/main/scala/com/twitter/finagle/serverset2/client/apache/ApacheZooKeeper.scala
+++ b/finagle-serversets/src/main/scala/com/twitter/finagle/serverset2/client/apache/ApacheZooKeeper.scala
@@ -117,7 +117,7 @@ private[serverset2] class ApacheZooKeeper private[apache](zk: zookeeper.ZooKeepe
   }
 
   def existsWatch(path: String): Future[Watched[Option[Data.Stat]]] = {
-    val watcher = new ApacheWatcher
+    val watcher = new ApacheWatcher(watchSessionStateEvents=false)
     val rv = new Promise[Watched[Option[Data.Stat]]]
     val cb = new StatCallback {
       def processResult(ret: Int, path: String, ctx: Object, stat: zookeeper.data.Stat) =


### PR DESCRIPTION
Hi all, this regarding this oom: https://groups.google.com/forum/#!topic/finaglers/_wSvPz0YKjE

This fix may be too naive, but I couldn't see any other way of handling this problem given how the existsWatch method is called.  Most of all I'd like to get the discussion going on how we can get this ApacheWatcher leak fixed.

========

Problem

When a ZooKeeper "exists" watch is triggered because the path being
watched is created or deleted, ZooKeeper removes that watch, and it has
to be re-added in order to receive further notifications about the
watched path.

However the exists watch also gets triggered for ZooKeeper session events
(connected, disconnected etc) - for those events, ZooKeeper does not remove
the watch, so it doesn't have to be re-added.

Currently the code that re-adds the watch does not distinguish between
event types and always re-adds a new watch, causing an ApacheWatcher
memory leak each time the watch is triggered for a session event type.

Solution

Filter out session event types when watching for path existence
