### PR TITLE
Rename pending-commands prop to link-pending-commands

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -109,6 +109,10 @@ Breaking API Changes
     to `ThriftMethod.SuccessType` instead of `ThriftMethod.Args` to `ThriftMethod.Result`.
     ``RB_ID=908846``
 
+  * finagle-redis: Remove pendingCommands from `c.t.f.finagle.redis.SentinelClient.Node` and
+    add linkPendingCommands for compatibility with redis 3.2 and newer.
+    ``RB_ID=??????``
+
 Runtime Behavior Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -151,6 +155,9 @@ Bug Fixes
 
   * finagle-thrift: Properly locate sub-classed MethodIface services to instantiate for serving
     BaseServiceIface implemented thrift services. ``RB_ID=907608``
+
+  * finagle-redis: The SentinelClient will no longer throw an NoSuchElementException when
+    initializing connections to a redis 3.2 or greater sentinel server. ``RB_ID=??????``
 
 Dependencies
 ~~~~~~~~~~~~

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/SentinelClient.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/SentinelClient.scala
@@ -26,7 +26,7 @@ object SentinelClient {
     val port: Int = props("port").toInt
     val runid: String = props("runid")
     val flags: Seq[String] = props("flags").split(",")
-    val pendingCommands: Int = props("pending-commands").toInt
+    val linkPendingCommands: Int = props("link-pending-commands").toInt
     val lastPingSent: Int = props("last-ping-sent").toInt
     val lastPingReply: Int = props("last-ping-reply").toInt
     val downAfterMilliseconds: Int = props("down-after-milliseconds").toInt

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/SentinelClient.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/SentinelClient.scala
@@ -26,7 +26,8 @@ object SentinelClient {
     val port: Int = props("port").toInt
     val runid: String = props("runid")
     val flags: Seq[String] = props("flags").split(",")
-    val linkPendingCommands: Int = props("link-pending-commands").toInt
+    val pendingCommands: Int = props.get("link-pending-commands")
+      .getOrElse(props("pending-commands")).toInt
     val lastPingSent: Int = props("last-ping-sent").toInt
     val lastPingReply: Int = props("last-ping-reply").toInt
     val downAfterMilliseconds: Int = props("down-after-milliseconds").toInt

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/SentinelClient.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/SentinelClient.scala
@@ -26,7 +26,10 @@ object SentinelClient {
     val port: Int = props("port").toInt
     val runid: String = props("runid")
     val flags: Seq[String] = props("flags").split(",")
-    val pendingCommands: Int = props.get("link-pending-commands")
+    /* In Redis 3.2 and newer, the property was renamed to link-pending-commands
+     * preserve compatibility with older releases.
+     */
+    val linkPendingCommands: Int = props.get("link-pending-commands")
       .getOrElse(props("pending-commands")).toInt
     val lastPingSent: Int = props("last-ping-sent").toInt
     val lastPingReply: Int = props("last-ping-reply").toInt


### PR DESCRIPTION
The sentinel properties do not include `pending-commands`, updated to the
actual property `link-pending-commands`.

Problem

When initializing the `SentinelClient` a invalid property exception is thrown
on the `pending-commands` property.

Solution

Renamed to `link-pending-commands`