### PR TITLE
StatsFilter decrements pending metric also on exceptions

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/service/StatsFilter.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/service/StatsFilter.scala
@@ -1,13 +1,11 @@
 package com.twitter.finagle.service
 
-import java.util.concurrent.atomic.LongAdder
-import java.util.concurrent.TimeUnit
-
 import com.twitter.finagle.Filter.TypeAgnostic
 import com.twitter.finagle._
 import com.twitter.finagle.stats.{ExceptionStatsHandler, MultiCategorizingExceptionStatsHandler, StatsReceiver}
 import com.twitter.util._
-
+import java.util.concurrent.atomic.LongAdder
+import java.util.concurrent.TimeUnit
 import scala.util.control.NonFatal
 
 object StatsFilter {

--- a/finagle-core/src/main/scala/com/twitter/finagle/service/StatsFilter.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/service/StatsFilter.scala
@@ -8,6 +8,8 @@ import com.twitter.finagle._
 import com.twitter.finagle.stats.{ExceptionStatsHandler, MultiCategorizingExceptionStatsHandler, StatsReceiver}
 import com.twitter.util._
 
+import scala.util.control.NonFatal
+
 object StatsFilter {
   val role: Stack.Role = Stack.Role("RequestStats")
 
@@ -160,33 +162,33 @@ class StatsFilter[Req, Rep](
 
     outstandingRequestCount.increment()
 
-    try {
-      service(request).respond { response =>
-        outstandingRequestCount.decrement()
-        if (!isBlackholeResponse(response)) {
-          dispatchCount.incr()
-          responseClassifier.applyOrElse(
-            ReqRep(request, response),
-            ResponseClassifier.Default
-          ) match {
-            case ResponseClass.Failed(_) =>
-              latencyStat.add(elapsed().inUnit(timeUnit))
-              response match {
-                case Throw(e) =>
-                  exceptionStatsHandler.record(statsReceiver, e)
-                case _ =>
-                  exceptionStatsHandler.record(statsReceiver, SyntheticException)
-              }
-            case ResponseClass.Successful(_) =>
-              successCount.incr()
-              latencyStat.add(elapsed().inUnit(timeUnit))
-          }
+    val result = try {
+      service(request)
+    } catch { case NonFatal(e) =>
+      Future.exception(e)
+    }
+
+    result.respond { response =>
+      outstandingRequestCount.decrement()
+      if (!isBlackholeResponse(response)) {
+        dispatchCount.incr()
+        responseClassifier.applyOrElse(
+          ReqRep(request, response),
+          ResponseClassifier.Default
+        ) match {
+          case ResponseClass.Failed(_) =>
+            latencyStat.add(elapsed().inUnit(timeUnit))
+            response match {
+              case Throw(e) =>
+                exceptionStatsHandler.record(statsReceiver, e)
+              case _ =>
+                exceptionStatsHandler.record(statsReceiver, SyntheticException)
+            }
+          case ResponseClass.Successful(_) =>
+            successCount.incr()
+            latencyStat.add(elapsed().inUnit(timeUnit))
         }
       }
-    } catch {
-      case e: Throwable =>
-        outstandingRequestCount.decrement()
-        throw e
     }
   }
 }

--- a/finagle-core/src/main/scala/com/twitter/finagle/service/StatsFilter.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/service/StatsFilter.scala
@@ -1,7 +1,7 @@
 package com.twitter.finagle.service
 
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.LongAdder
+import java.util.concurrent.TimeUnit
 
 import com.twitter.finagle.Filter.TypeAgnostic
 import com.twitter.finagle._

--- a/finagle-core/src/test/scala/com/twitter/finagle/service/StatsFilterTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/service/StatsFilterTest.scala
@@ -5,12 +5,9 @@ import com.twitter.finagle.stats.{CategorizingExceptionStatsHandler, ExceptionSt
 import com.twitter.finagle._
 import com.twitter.util._
 import java.util.concurrent.TimeUnit
-
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
-
-import scala.util.control.ControlThrowable
 
 @RunWith(classOf[JUnitRunner])
 class StatsFilterTest extends FunSuite {
@@ -147,16 +144,35 @@ class StatsFilterTest extends FunSuite {
   test("don't report pending requests after uncaught exceptions") {
     val receiver = new InMemoryStatsReceiver()
     val service = new Service[String, String] {
-      def apply(request: String): Future[String] = throw new Exception("broken")
+      def apply(request: String): Future[String] = throw new IllegalStateException("broken")
     }
+
     val statsFilter = new StatsFilter[String, String](receiver, BasicExceptions)
+
+    // verifies that before the Exception is thrown, the pending metric in the StatsFilter is incremented to 1
+    val verifyingFilter = new SimpleFilter[String, String] {
+      private val incremented = receiver.counter("incremented")
+      override def apply(request: String, service: Service[String, String]): Future[String] = {
+        val pendingRequests = receiver.gauges(Seq("pending"))().toInt
+        incremented.incr(pendingRequests)
+        service(request)
+      }
+    }
+
+    // not chaining using andThen here because that wraps any raw Exception inside a Future.exception
     val chain = new Service[String, String] {
-      def apply(request: String): Future[String] = statsFilter.apply(request, service)
+      def apply(request: String): Future[String] = statsFilter.apply(
+        request, (request: String) => verifyingFilter.apply(request, service)
+      )
     }
 
     assert(receiver.gauges(Seq("pending"))() == 0.0)
-    chain("foo")
+    intercept[IllegalStateException] {
+      Await.result(chain("foo"))
+    }
     assert(receiver.gauges(Seq("pending"))() == 0.0)
+
+    assert(receiver.counter("incremented")() == 1)
   }
 
   test("should count failure requests only after they are finished") {


### PR DESCRIPTION
Problem

I have seen in our graphs that the `pending` metric in the `StatsFilter` slowly but steadily increases over time. When `service(request)` in `StatsFilter.apply` throws an uncaught exception, the gauge isn't decremented. 

see https://github.com/twitter/finagle/issues/594

Solution

Wrap the `service(request)` call in a `try-catch` and decrement before re-throwing the original exception.

Result

`pending` gauge is properly decremented. 

**Note** if you compose the `StatsFilter` with a `Service` using `andThen` (which `StatsFilterTest` does), this will use `Service.rescue` under the hood - wrapping all non fatal exceptions in a `Future.exception`. This is the reason the unit test throws a fatal exception to verify the fix. However, if I hit this problem in my application, this must mean that either my service is not wrapped  using `Service.rescue` or I am hitting a fatal exception that doesn't bring my JVM down?! I am using Finagle 6.42.0 and this is how the service is created:

```
val thriftService = new FooService()

ThriftMux.server
      .configured(param.Label("thrift"))
      .serveIface(new InetSocketAddress(10200), thriftService)
```