### PR TITLE
Fix Services & Filters docs

### DIFF
--- a/doc/src/sphinx/ServicesAndFilters.rst
+++ b/doc/src/sphinx/ServicesAndFilters.rst
@@ -31,7 +31,7 @@ To use an HTTP client:
   import com.twitter.finagle.Service
   import com.twitter.finagle.http
 
-  val httpService: Service[http.Request, http.Request] = ???
+  val httpService: Service[http.Request, http.Response] = ???
 
   httpService(Request("/foo/bar")).onSuccess { response: http.Response =>
     println("received response " + response.contentString)


### PR DESCRIPTION
The type signature of a service should be `Service[Req, Rep]` but it is currently showing `Service[Req, Req]` in the docs