### PR TITLE
Fix doclinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ protocols.
 
 For extensive documentation, please see the
 [user guide](https://twitter.github.io/finagle/guide/) and
-[API documentation](https://twitter.github.io/finagle/docs/#com.twitter.finagle.package)
+[API documentation](https://twitter.github.io/finagle/docs/com/twitter/finagle)
 websites. Documentation improvements are always welcome, so please send patches
 our way.
 

--- a/doc/src/sphinx/FAQ.rst
+++ b/doc/src/sphinx/FAQ.rst
@@ -53,12 +53,12 @@ A simplified code snippet that exemplifies the intra-process structure:
        However, this will still hold if the client call was in the context
        of a Future combinator (ex. `Future#select`, `Future#join`, etc.)
 
-This is the source of the :API:`CancelledRequestException <com.twitter.finagle.CancelledRequestException>` --
+This is the source of the :API:`CancelledRequestException <com/twitter/finagle/CancelledRequestException>` --
 when a Finagle client receives the cancellation interrupt while a request is pending, it
 fails that request with this exception. A special case of this is when a request is in the process
-of establishing a session and is instead interrupted with a :API:`CancelledConnectionException <com.twitter.finagle.CancelledConnectionException>`
+of establishing a session and is instead interrupted with a :API:`CancelledConnectionException <com/twitter/finagle/CancelledConnectionException>`
 
-You can disable this behavior by using the :API:`MaskCancelFilter <com.twitter.finagle.filter.MaskCancelFilter>`:
+You can disable this behavior by using the :API:`MaskCancelFilter <com/twitter/finagle/filter/MaskCancelFilter>`:
 
 .. code-block:: scala
 
@@ -218,7 +218,7 @@ What service behavior will change when upgrading to Mux?
 
 With Mux, Finagle multiplexes several requests onto a single connection. As a
 consequence, traditional forms of connection-pooling are no longer required. Thus
-Mux employs `com.twitter.finagle.pool.SingletonPool <http://twitter.github.io/finagle/docs/#com.twitter.finagle.pool.SingletonPool>`_,
+Mux employs :API:`SingletonPool <com/twitter/finagle/pool/SingletonPool>`,
 which exposes new stats:
 
 - ``connects``, ``connections``, and ``closes`` stats should drop, since
@@ -234,7 +234,7 @@ which exposes new stats:
 
 *ClientBuilder configuration*
 
-Certain `ClientBuilder <http://twitter.github.io/finagle/docs/#com.twitter.finagle.builder.ClientBuilder>`_
+Certain :API:`ClientBuilder <com/twitter/finagle/builder/ClientBuilder>`
 settings related to connection pooling become obsolete:
 ``hostConnectionCoresize``, ``hostConnectionLimit``, ``hostConnectionIdleTime``,
 ``hostConnectionMaxWaiters``, and ``expHostConnectionBufferSize``
@@ -250,7 +250,7 @@ be impacted:
 - Obsolete stats: ``idle/idle``, ``idle/refused``, and ``idle/closed``
 
 *ServerBuilder configuration*
-Certain `ServerBuilder <http://twitter.github.io/finagle/docs/#com.twitter.finagle.builder.ServerBuilder>`_
+Certain :API:`ServerBuilder <com/twitter/finagle/builder/ServerBuilder>`
 connection management settings become obsolete: ``openConnectionsThresholds``.
 
 What is ThriftMux?
@@ -258,5 +258,5 @@ What is ThriftMux?
 
 .. _whats_thriftmux:
 
-`ThriftMux <http://twitter.github.io/finagle/docs/#com.twitter.finagle.ThriftMux$>`_
+:API:`ThriftMux <com/twitter/finagle/ThriftMux$>`
 is an implementation of the Thrift protocol built on top of Mux.

--- a/doc/src/sphinx/FAQ.rst
+++ b/doc/src/sphinx/FAQ.rst
@@ -56,7 +56,7 @@ A simplified code snippet that exemplifies the intra-process structure:
 This is the source of the :API:`CancelledRequestException <com.twitter.finagle.CancelledRequestException>` --
 when a Finagle client receives the cancellation interrupt while a request is pending, it
 fails that request with this exception. A special case of this is when a request is in the process
-of establishing a session and is instead interrupted with a :API:`CancelledConnectException <com.twitter.finagle.CancelledConnectException>`
+of establishing a session and is instead interrupted with a :API:`CancelledConnectionException <com.twitter.finagle.CancelledConnectionException>`
 
 You can disable this behavior by using the :API:`MaskCancelFilter <com.twitter.finagle.filter.MaskCancelFilter>`:
 

--- a/doc/src/sphinx/Names.rst
+++ b/doc/src/sphinx/Names.rst
@@ -5,12 +5,12 @@ Names and Naming in Finagle
 
 Finagle uses *names* [#names]_ to identify network locations. Names must be
 supplied when constructing a Finagle client through
-:api:`ClientBuilder.dest <com.twitter.finagle.builder.ClientBuilder>`
+:api:`ClientBuilder.dest <com/twitter/finagle/builder/ClientBuilder>`
 or through implementations of :api:`Client
-<com.twitter.finagle.Client>`.
+<com/twitter/finagle/Client>`.
 
 Names are represented by the data-type :api:`Name
-<com.twitter.finagle.Name>` comprising two variants:
+<com/twitter/finagle/Name>` comprising two variants:
 
 ``case class Name.Bound(va: Var[Addr])``
 	Identifies a set of network locations. ``Var[Addr]`` (see :ref:`addr`)
@@ -19,10 +19,10 @@ Names are represented by the data-type :api:`Name
 
 ``case class Name.Path(path: Path)``
 	Represents a name denoted by a hierarchical :api:`path
-	<com.twitter.finagle.Path>`, represented by a sequence of byte
+	<com/twitter/finagle/Path>`, represented by a sequence of byte
 	strings.
 
-:api:`Resolver.eval <com.twitter.finagle.Resolver$>` parses strings
+:api:`Resolver.eval <com/twitter/finagle/Resolver$>` parses strings
 into `Names`. Strings of the form
 
 ::
@@ -144,7 +144,7 @@ specially by Finagle, similarly to resolver schemes. Paths of the form
 
 	/$/namer/path..
 
-uses the given :api:`Namer <com.twitter.finagle.Namer>` to interpret the
+uses the given :api:`Namer <com/twitter/finagle/Namer>` to interpret the
 remaining path. This allows Finagle to translate paths into addresses. For
 example
 
@@ -315,12 +315,12 @@ delegation expressing this override.
 
 Finagle has protocol support for delegation passing in :ref:`TTwitter
 <thrift_and_scrooge>`, :ref:`Mux <mux>`, its variant :api:`ThriftMux
-<com.twitter.finagle.ThriftMux$>`, and :api:`HTTP
-<com.twitter.finagle.Http$>`. When these protocols are used,
+<com/twitter/finagle/ThriftMux$>`, and :api:`HTTP
+<com/twitter/finagle/Http$>`. When these protocols are used,
 delegations that are added dynamically to a request are in effect
 throughout the distributed request graph --- i.e. scope of the
 namespace is a transaction. Delegations are added dynamically through
-the :api:`Dtab <com.twitter.finagle.Dtab$>` API.
+the :api:`Dtab <com/twitter/finagle/Dtab$>` API.
 
 (This is a powerful facility that should be used with care.)
 
@@ -330,8 +330,8 @@ Addr
 ----
 
 `Name.Bound` comprises a ``Var[Addr]``, representing a dynamically
-changing :api:`Addr <com.twitter.finagle.Addr>`. (:util:`Var
-<com.twitter.util.Var>` implements a form of self-adjusting
+changing :api:`Addr <com/twitter/finagle/Addr>`. (:util:`Var
+<com/twitter/util/Var>` implements a form of self-adjusting
 computation); ``Addrs`` are in one of 3 states:
 
 ``Addr.Pending``

--- a/doc/src/sphinx/Protocols.rst
+++ b/doc/src/sphinx/Protocols.rst
@@ -71,7 +71,7 @@ A ServiceIface is a collection of Services, one for each Thrift method. Call the
 
 .. includecode:: ../../../finagle-example/src/main/scala/com/twitter/finagle/example/thrift/ThriftServiceIfaceExample.scala#thriftclientapi-call
 
-Thrift services can be combined with :api:`Filters <com.twitter.finagle.Filter$>`.
+Thrift services can be combined with :api:`Filters <com/twitter/finagle/Filter$>`.
 
 .. includecode:: ../../../finagle-example/src/main/scala/com/twitter/finagle/example/thrift/ThriftServiceIfaceExample.scala#thriftclientapi-filters
    :language: scala
@@ -86,13 +86,13 @@ Another way to construct Thrift clients is using the method interface:
 .. includecode:: ../../../finagle-example/src/main/scala/com/twitter/finagle/example/thrift/ThriftServiceIfaceExample.scala#thriftclientapi-methodiface
    :language: scala
 
-To convert the Service interface to the method interface use :api:`Thrift.newMethodIface <com.twitter.finagle.Thrift$>`:
+To convert the Service interface to the method interface use :api:`Thrift.newMethodIface <com/twitter/finagle/Thrift$>`:
 
 .. includecode:: ../../../finagle-example/src/main/scala/com/twitter/finagle/example/thrift/ThriftServiceIfaceExample.scala#thriftclientapi-method-adapter
    :language: scala
 
 The complete example is at `ThriftServiceIfaceExample.scala <https://github.com/twitter/finagle/blob/develop/finagle-example/src/main/scala/com/twitter/finagle/example/thrift/ThriftServiceIfaceExample.scala>`_.
-Check out the `finagle-thrift` :api:`API <com.twitter.finagle.Thrift$>`
+Check out the `finagle-thrift` :api:`API <com/twitter/finagle/Thrift$>`
 for more info.
 
 .. _mux:
@@ -164,21 +164,21 @@ transactions while taking advantage of Finagle's :ref:`client stack <client_modu
 connection pooling. The implementation supports both the MySQL binary and string protocols.
 
 A client can be constructed using the
-:api:`Mysql <com.twitter.finagle.Mysql$>` protocol object:
+:api:`Mysql <com/twitter/finagle/Mysql$>` protocol object:
 
 .. includecode:: code/protocols/mysql.scala#client
    :language: scala
 
-We configure the :api:`client's connection pool <com.twitter.finagle.client.DefaultPool>` to be
+We configure the :api:`client's connection pool <com/twitter/finagle/client/DefaultPool>` to be
 compatible with our MySQL server. The constructor returns a Finagle :ref:`ServiceFactory <service_factory>`
-from :api:`mysql.Request <com.twitter.finagle.mysql.Request>` to :api:`mysql.Result <com.twitter.finagle.mysql.Result>`
+from :api:`mysql.Request <com/twitter/finagle/mysql/Request>` to :api:`mysql.Result <com/twitter/finagle/mysql/Result>`
 which we can use to query the db:
 
 .. includecode:: code/protocols/mysql.scala#query0
    :language: scala
 
-A :api:`ResultSet <com.twitter.finagle.mysql.ResultSet>` makes it easy to extract
-:api:`Values <com.twitter.finagle.mysql.Value>` based on column names. For example, we can
+A :api:`ResultSet <com/twitter/finagle/mysql/ResultSet>` makes it easy to extract
+:api:`Values <com/twitter/finagle/mysql/Value>` based on column names. For example, we can
 implement the above `processRow` as a pattern match on expected values:
 
 .. includecode:: code/protocols/mysql.scala#processRow
@@ -196,7 +196,7 @@ and we can select:
    :language: scala
 
 Note that `select` takes care of checking out the service and returning it to the pool. `select` and
-other useful methods are available on :api:`mysql.Client <com.twitter.finagle.mysql.Client>` which is returned
+other useful methods are available on :api:`mysql.Client <com/twitter/finagle/mysql/Client>` which is returned
 from the call to `newRichClient`.
 
 For a more involved example see the Finagle `example project <https://github.com/twitter/finagle/blob/master/finagle-example/src/main/scala/com/twitter/finagle/example/mysql/Example.scala>`_.

--- a/doc/src/sphinx/conf.py
+++ b/doc/src/sphinx/conf.py
@@ -46,8 +46,8 @@ version = sbt_versions.release_to_version(release)
 extlinks = {
   'issue': ('https://github.com/twitter/finagle/issues/%s', 'issue #'),
   'ex': ('https://github.com/twitter/finagle/blob/finagle-example/src/main/scala/%s', 'Finagle example '),
-  'api': ('http://twitter.github.io/finagle/docs/#%s', ''),
-  'util': ('http://twitter.github.io/util/docs/#%s', ''),
+  'api': ('http://twitter.github.io/finagle/docs/%s', ''),
+  'util': ('http://twitter.github.io/util/docs/%s', ''),
   'util-core-src': ("https://github.com/twitter/util/blob/master/util-core/src/main/scala/%s", 'util-core github repo'),
   'util-stats-src': ("https://github.com/twitter/util/blob/master/util-stats/src/main/scala/%s", 'util-stats github repo'),
   'finagle-http-src': ("https://github.com/twitter/finagle/blob/master/finagle-http/src/main/scala/%s", 'finagle-http github repo'),

--- a/doc/src/sphinx/developers/Extending.rst
+++ b/doc/src/sphinx/developers/Extending.rst
@@ -374,7 +374,7 @@ Netty 4 `ChannelPipeline <http://netty.io/4.1/api/io/netty/channel/ChannelPipeli
 Transporter
 -----------
 
-A :src:`Transporter <com/twitter/finagle/clients/Transporter.scala>` is responsible for connecting
+A :src:`Transporter <com/twitter/finagle/client/Transporter.scala>` is responsible for connecting
 a :ref:`Transport <transport_interface>` to a peer; it establishes a session. Finagle provides
 a :src:`Netty3Transporter <com/twitter/finagle/netty3/Netty3Transporter.scala>` and a
 :finagle-netty4-src:`Netty4Transporter <com/twitter/finagle/netty4/Netty4Transporter.scala>`,

--- a/doc/src/sphinx/developers/Extending.rst
+++ b/doc/src/sphinx/developers/Extending.rst
@@ -30,7 +30,7 @@ Stack
 
 Finagle's clients and servers comprise many relatively simple
 components, arranged together in a stack. Each component is a
-:api:`ServiceFactory <com.twitter.finagle.ServiceFactory>` that
+:api:`ServiceFactory <com/twitter/finagle/ServiceFactory>` that
 composes other service factories. We've seen this before:
 :doc:`filters <ServicesAndFilters>` are a kind of component.
 
@@ -49,22 +49,22 @@ becomes onerous; it become very difficult to:
 - parameterize each component, for example to set the sizes of
   connection pools
 - inject dependencies such as
-  :util:`StatsReceiver <com.twitter.finagle.stats.StatsReceiver>` implementations
+  :util:`StatsReceiver <com/twitter/finagle/stats/StatsReceiver>` implementations
 - rearrange any part of the stack, for example to remove an
   unused timeout filter
 - modify the stack for a specific use, for example to replace
   the connection pooling implementation or the load balancer
 
 Traditionally, the :api:`ClientBuilder
-<com.twitter.finagle.builder.ClientBuilder>` and :api:`ServerBuilder
-<com.twitter.finagle.builder.ServerBuilder>` performed this duty in
+<com/twitter/finagle/builder/ClientBuilder>` and :api:`ServerBuilder
+<com/twitter/finagle/builder/ServerBuilder>` performed this duty in
 the manner just described. While it worked well for a while, it
 ultimately proved inflexible. With the needs and requirements of the
 various protocol implementations like :ref:`Mux's <mux>`, as well as
 more sophisticated new features, the builders became unworkable
 monoliths.
 
-:api:`Stack <com.twitter.finagle.Stack>` formalizes the concept of a
+:api:`Stack <com/twitter/finagle/Stack>` formalizes the concept of a
 *stackable* component and treats a sequence of stackable components as
 a first-class (immutable) value that may be manipulated like any other
 collection. For example, modules may be inserted or removed from the
@@ -72,7 +72,7 @@ stack; you can map one stack to another, for example when
 parameterizing individual modules.
 
 The stack abstraction also formalizes the concept of a *parameter*—i.e.
-a map of values used to construct an object. :api:`Stack.Params <com.twitter.finagle.Stack$.Params>`
+a map of values used to construct an object. :api:`Stack.Params <com/twitter/finagle/Stack$$Params>`
 is a kind of type-safe map used to hold parameters.
 
 ``Stack`` and ``Param`` work together like this: ``Stack`` represents the stack
@@ -82,8 +82,8 @@ to extract the final ``ServiceFactory`` that represents the entirety of the stac
 we simply call ``stack.make(params)``.
 
 Finagle defines default (polymorphic) stacks for both
-:api:`clients <com.twitter.finagle.client.StackClient$@newStack[Req,Rep]:com.twitter.finagle.Stack[com.twitter.finagle.ServiceFactory[Req,Rep]]>` and
-:api:`servers <com.twitter.finagle.server.StackServer$@newStack[Req,Rep]:com.twitter.finagle.Stack[com.twitter.finagle.ServiceFactory[Req,Rep]]>`.
+:api:`clients <com/twitter/finagle/client/StackClient$#newStack[Req,Rep]:com.twitter.finagle.Stack[com.twitter.finagle.ServiceFactory[Req,Rep]]>` and
+:api:`servers <com/twitter/finagle/server/StackServer$#newStack[Req,Rep]:com.twitter.finagle.Stack[com.twitter.finagle.ServiceFactory[Req,Rep]]>`.
 
 We'll now discuss the constituent parts of Finagle's clients and servers.
 

--- a/finagle-mysql/README.md
+++ b/finagle-mysql/README.md
@@ -1,5 +1,5 @@
 *finagle-mysql* is a MySQL driver built for Finagle. The project provides a simple query API with
 support for prepared statements and transactions while leveraging Finagle's
 [client stack](http://twitter.github.io/finagle/guide/Clients.html) for connection pooling,
-load balancing, etc. See the [API](http://twitter.github.io/finagle/docs/#com.twitter.finagle.Mysql$)
+load balancing, etc. See the [API](http://twitter.github.io/finagle/docs/com/twitter/finagle/Mysql$)
 or [docs](http://twitter.github.io/finagle/guide/Protocols.html#mysql) for usage examples.


### PR DESCRIPTION
Problem

- some doc link target was incorrect. 
- scaladoc url schema has changed, so link to the scaladoc was broken

Solution

fix it.