### PR TITLE
finagle-core: Fix BufChannelBuffer.getLong()

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/netty3/BufChannelBuffer.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/netty3/BufChannelBuffer.scala
@@ -349,10 +349,10 @@ private class BufChannelBuffer(val buf: Buf, endianness: ByteOrder) extends Abst
         (bytes(0) & 0xff).toLong |
         ((bytes(1) & 0xff).toLong << 8) |
         ((bytes(2) & 0xff).toLong << 16) |
-        ((bytes(3) & 0xff).toLong << 24)
-        ((bytes(4) & 0xff).toLong << 32)
-        ((bytes(5) & 0xff).toLong << 40)
-        ((bytes(6) & 0xff).toLong << 48)
+        ((bytes(3) & 0xff).toLong << 24) |
+        ((bytes(4) & 0xff).toLong << 32) |
+        ((bytes(5) & 0xff).toLong << 40) |
+        ((bytes(6) & 0xff).toLong << 48) |
         ((bytes(7) & 0xff).toLong << 56)
     }
   }

--- a/finagle-core/src/test/scala/com/twitter/finagle/netty3/BufChannelBufferTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/netty3/BufChannelBufferTest.scala
@@ -441,6 +441,23 @@ class BufChannelBufferTest extends FunSuite with BeforeAndAfter {
     }
   }
 
+  test("test random long access (specified LITTLE_ENDIAN)") {
+    val endianness = ByteOrder.LITTLE_ENDIAN
+    val bytes = new Array[Byte](CAPACITY)
+    val wrapped = ChannelBuffers.wrappedBuffer(endianness, bytes)
+    0.until(CAPACITY - 7, 8) foreach { i =>
+      val value = random.nextLong()
+      wrapped.setLong(i, value)
+    }
+    val bcb = new BufChannelBuffer(Buf.ByteArray.Owned(bytes), endianness)
+
+    random.setSeed(seed)
+    0.until(CAPACITY - 7, 8) foreach { i =>
+      val value = random.nextLong()
+      assert(value == bcb.getLong(i))
+    }
+  }
+
   test("setZero") {
     intercept[ReadOnlyBufferException] {
       buffer.setZero(0, 1)


### PR DESCRIPTION
Problem

In the case of specifying LITTLE_ENDIAN, due to lack of `|` operator `BufChannelBuffer.getLong()` returns incorrect value.

Solution

Fix `BufChannelBuffer.getLong()` method by adding `|` operator.

Result

Even in the case of specifying LITTLE_ENDIAN, `BufChannelBuffer.getLong()` returns correct value.