### PR TITLE
Delay service instantiation till TLS handshake finished

### DIFF
--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/channel/ConnectPromiseDelayListeners.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/channel/ConnectPromiseDelayListeners.scala
@@ -1,7 +1,7 @@
 package com.twitter.finagle.netty4.channel
 
 import io.netty.channel._
-import io.netty.util.concurrent.{Future => NettyFuture, GenericFutureListener}
+import io.netty.util.concurrent.{GenericFutureListener, Future => NettyFuture}
 
 /**
  * This trait provides [[GenericFutureListener]]s that are useful for implementing handlers
@@ -10,7 +10,7 @@ import io.netty.util.concurrent.{Future => NettyFuture, GenericFutureListener}
  *
  * For example, this is used by:
  *
- * - [[com.twitter.finagle.netty4.ssl.SslConnectHandler]]
+ * - [[com.twitter.finagle.netty4.ssl.client.SslClientConnectHandler]
  * - [[com.twitter.finagle.netty4.proxy.HttpProxyConnectHandler]]
  * - [[com.twitter.finagle.netty4.proxy.Netty4ProxyConnectHandler]]
  */

--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/channel/ServerBridge.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/channel/ServerBridge.scala
@@ -1,7 +1,7 @@
 package com.twitter.finagle.netty4.channel
 
 import com.twitter.finagle.transport.Transport
-import io.netty.channel.{ChannelInitializer, Channel}
+import io.netty.channel.{Channel, ChannelHandlerContext, ChannelInboundHandlerAdapter, ChannelInitializer}
 import io.netty.channel.ChannelHandler.Sharable
 
 /**
@@ -11,10 +11,10 @@ import io.netty.channel.ChannelHandler.Sharable
 private[netty4] class ServerBridge[In, Out](
     transportFac: Channel => Transport[In, Out],
     serveTransport: Transport[In, Out] => Unit)
-  extends ChannelInitializer[Channel] {
+  extends ChannelInboundHandlerAdapter {
 
-  def initChannel(ch: Channel): Unit = {
-    val transport: Transport[In, Out] = transportFac(ch)
+  override def channelActive(ctx: ChannelHandlerContext): Unit = {
+    val transport: Transport[In, Out] = transportFac(ctx.channel())
     serveTransport(transport)
   }
 }

--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/client/Netty4ClientSslHandler.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/client/Netty4ClientSslHandler.scala
@@ -1,7 +1,7 @@
 package com.twitter.finagle.netty4.ssl.client
 
 import com.twitter.finagle.client.Transporter
-import com.twitter.finagle.netty4.ssl.{Alpn, SslConnectHandler}
+import com.twitter.finagle.netty4.ssl.Alpn
 import com.twitter.finagle.ssl.{ApplicationProtocols, Engine, SessionVerifier}
 import com.twitter.finagle.ssl.client.{SslClientConfiguration, SslClientEngineFactory}
 import com.twitter.finagle.transport.Transport
@@ -81,18 +81,18 @@ private[netty4] class Netty4ClientSslHandler(
   private[this] def createSslConnectHandler(
     sslHandler: SslHandler,
     config: SslClientConfiguration
-  ): SslConnectHandler = {
+  ): SslClientConnectHandler = {
     val sessionValidation = config.hostname
       .map(SessionVerifier.hostname)
       .getOrElse(SessionVerifier.AlwaysValid)
 
-    new SslConnectHandler(sslHandler, sessionValidation)
+    new SslClientConnectHandler(sslHandler, sessionValidation)
   }
 
   private[this] def addHandlersToPipeline(
     pipeline: ChannelPipeline,
     sslHandler: SslHandler,
-    sslConnectHandler: SslConnectHandler
+    sslConnectHandler: SslClientConnectHandler
   ): Unit = {
     pipeline.addFirst("sslConnect", sslConnectHandler)
     pipeline.addFirst("ssl", sslHandler)
@@ -113,7 +113,7 @@ private[netty4] class Netty4ClientSslHandler(
       val combined: SslClientConfiguration = combineApplicationProtocols(config)
       val engine: Engine = factory(address, combined)
       val sslHandler: SslHandler = createSslHandler(engine)
-      val sslConnectHandler: SslConnectHandler = createSslConnectHandler(sslHandler, combined)
+      val sslConnectHandler: SslClientConnectHandler = createSslConnectHandler(sslHandler, combined)
       addHandlersToPipeline(ch.pipeline(), sslHandler, sslConnectHandler)
     }
   }

--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/client/SslClientConnectHandler.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/client/SslClientConnectHandler.scala
@@ -1,9 +1,9 @@
-package com.twitter.finagle.netty4.ssl
+package com.twitter.finagle.netty4.ssl.client
 
-import com.twitter.finagle.netty4.channel.{ConnectPromiseDelayListeners, BufferingChannelOutboundHandler}
+import com.twitter.finagle.netty4.channel.{BufferingChannelOutboundHandler, ConnectPromiseDelayListeners}
 import io.netty.channel._
 import io.netty.handler.ssl.SslHandler
-import io.netty.util.concurrent.{Future => NettyFuture, GenericFutureListener}
+import io.netty.util.concurrent.{GenericFutureListener, Future => NettyFuture}
 import java.net.SocketAddress
 import javax.net.ssl.SSLSession
 
@@ -14,7 +14,7 @@ import javax.net.ssl.SSLSession
  * If `sessionValidation` returns `Some` exception, an [[SSLSession]] considered invalid and the
  * connect promise failed with this exception and the channel is closed.
  */
-private[netty4] class SslConnectHandler(
+private[netty4] class SslClientConnectHandler(
     ssl: SslHandler,
     sessionValidation: SSLSession => Option[Throwable])
   extends ChannelOutboundHandlerAdapter

--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/server/Netty4ServerSslHandler.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/server/Netty4ServerSslHandler.scala
@@ -53,8 +53,13 @@ private[netty4] class Netty4ServerSslHandler(
     // create an `SslHandler`.
     new SslHandler(engine.self)
 
-  private[this] def addHandlerToPipeline(pipeline: ChannelPipeline, sslHandler: SslHandler): Unit =
+  private[this] def addHandlersToPipeline(pipeline: ChannelPipeline,
+    sslHandler: SslHandler,
+    sslConnectHandler: SslServerConnectHandler
+  ): Unit = {
+    pipeline.addFirst("sslConnect", sslConnectHandler)
     pipeline.addFirst("ssl", sslHandler)
+  }
 
   /**
    * In this method, an `Engine` is created by an `SslServerEngineFactory` via
@@ -69,7 +74,7 @@ private[netty4] class Netty4ServerSslHandler(
       val combined: SslServerConfiguration = combineApplicationProtocols(config)
       val engine: Engine = factory(combined)
       val sslHandler: SslHandler = createSslHandler(engine)
-      addHandlerToPipeline(ch.pipeline(), sslHandler)
+      addHandlersToPipeline(ch.pipeline(), sslHandler, new SslServerConnectHandler(sslHandler))
     }
   }
 }

--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/server/SslServerConnectHandler.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/server/SslServerConnectHandler.scala
@@ -1,0 +1,28 @@
+package com.twitter.finagle.netty4.ssl.server
+
+import io.netty.channel.{Channel, ChannelHandlerContext, ChannelInboundHandlerAdapter}
+import io.netty.handler.ssl.SslHandler
+import io.netty.util.concurrent.{GenericFutureListener, Future => NettyFuture}
+
+
+/**
+  * Delays `channelRegistered` event until the TLS handshake is successfully finished.
+  */
+private[netty4] class SslServerConnectHandler(ssl: SslHandler) extends ChannelInboundHandlerAdapter { self =>
+
+  override def channelActive(ctx: ChannelHandlerContext): Unit = {
+    val channel = ctx.channel()
+    ssl.handshakeFuture().addListener(new GenericFutureListener[NettyFuture[Channel]] {
+      override def operationComplete(future: NettyFuture[Channel]): Unit = {
+        if (future.isSuccess) {
+          ctx.pipeline().remove(self)
+          ctx.fireChannelActive()
+        }
+      }
+    })
+    if (!channel.config().isAutoRead) {
+      channel.read()
+    }
+  }
+
+}

--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/transport/ChannelTransport.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/transport/ChannelTransport.scala
@@ -139,7 +139,7 @@ private[finagle] class ChannelTransport(ch: Channel) extends Transport[Any, Any]
     closed.unit
   }
 
-  val peerCertificate: Option[Certificate] = ch.pipeline.get(classOf[SslHandler]) match {
+  def peerCertificate: Option[Certificate] = ch.pipeline.get(classOf[SslHandler]) match {
     case null => None
     case handler =>
       try {

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/Netty4SslTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/Netty4SslTest.scala
@@ -1,0 +1,124 @@
+package com.twitter.finagle.netty4
+
+import com.twitter.conversions.time._
+import com.twitter.finagle
+import com.twitter.finagle.Stack.Params
+import com.twitter.finagle._
+import com.twitter.finagle.client.{StackClient, StdStackClient, Transporter}
+import com.twitter.finagle.dispatch.{SerialClientDispatcher, SerialServerDispatcher}
+import com.twitter.finagle.param.Label
+import com.twitter.finagle.ssl.client.{SslClientConfiguration, SslClientEngineFactory}
+import com.twitter.finagle.ssl.server.{SslServerConfiguration, SslServerEngineFactory}
+import com.twitter.finagle.ssl.{ClientAuth, Engine, KeyCredentials, TrustCredentials}
+import com.twitter.finagle.transport.Transport
+import com.twitter.finagle.transport.Transport.ServerSsl
+import com.twitter.util.{Await, Future}
+import io.netty.channel.ChannelPipeline
+import io.netty.handler.codec.string.{StringDecoder, StringEncoder}
+import io.netty.handler.codec.{DelimiterBasedFrameDecoder, Delimiters}
+import io.netty.handler.ssl.SslContextBuilder
+import io.netty.handler.ssl.util.SelfSignedCertificate
+import java.net.{InetAddress, InetSocketAddress, SocketAddress}
+import java.nio.charset.StandardCharsets.UTF_8
+
+import org.scalatest.Outcome
+import org.scalatest.fixture.FunSuite
+import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+
+object Netty4SslTest {
+  case class Client(clientCert: SelfSignedCertificate, serverCert: SelfSignedCertificate,
+      params: Params = Params.empty,
+      stack: Stack[ServiceFactory[String, String]] = StackClient.newStack)
+    extends StdStackClient[String, String, Client] {
+
+    override protected type In = String
+    override protected type Out = String
+
+    override protected def newTransporter(addr: SocketAddress): Transporter[String, String] =
+      Netty4Transporter.raw[String, String](pipeline => {
+        pipeline.addLast(new DelimiterBasedFrameDecoder(8192, Delimiters.lineDelimiter(): _*))
+        pipeline.addLast(new StringDecoder())
+        pipeline.addLast(new StringEncoder())
+      }, addr, params)
+
+    override protected def newDispatcher(transport: Transport[String, String]): Service[String, String] =
+      new SerialClientDispatcher(transport)
+
+    override protected def copy1(stack: Stack[ServiceFactory[String, String]], params: Params) =
+      copy(clientCert, serverCert, params, stack)
+  }
+}
+
+class Netty4SslTest extends FunSuite with Eventually with IntegrationPatience {
+
+  class Ctx {
+    val serverCert = new SelfSignedCertificate("example.server.com")
+    val clientCert = new SelfSignedCertificate("example.client.com")
+    val allocator = io.netty.buffer.UnpooledByteBufAllocator.DEFAULT
+
+    private object StringServerInit extends (ChannelPipeline => Unit) {
+      def apply(pipeline: ChannelPipeline): Unit = {
+        pipeline.addLast("line", new DelimiterBasedFrameDecoder(100, Delimiters.lineDelimiter(): _*))
+        pipeline.addLast("stringDecoder", new StringDecoder(UTF_8))
+        pipeline.addLast("stringEncoder", new StringEncoder(UTF_8))
+      }
+    }
+
+    val server = {
+      val service =
+        new Service[String, String] {
+          override def apply(request: String): Future[String] = {
+            Future.value(
+              Transport.peerCertificate match {
+                case Some(_) => "OK\n"
+                case None => "ERROR\n"
+              }
+            )
+          }
+        }
+
+      val serverConfig = SslServerConfiguration(
+        keyCredentials = KeyCredentials.CertAndKey(serverCert.certificate(), serverCert.privateKey()),
+        trustCredentials = TrustCredentials.CertCollection(clientCert.certificate()),
+        clientAuth = ClientAuth.Needed)
+
+      val p = Params.empty +
+        ServerSsl(Some(serverConfig)) +
+        Label("test")
+      val listener = Netty4Listener[String, String](StringServerInit, p)
+      val serveTransport = (t: Transport[String, String]) => {
+        if (t.peerCertificate.isEmpty) throw new IllegalStateException("No peer certificate in transport")
+        new SerialServerDispatcher(t, service)
+      }
+      listener.listen(new InetSocketAddress(InetAddress.getLoopbackAddress, 0))(serveTransport(_))
+    }
+
+    val clientConfig = SslClientConfiguration(
+      keyCredentials = KeyCredentials.CertAndKey(clientCert.certificate(), clientCert.privateKey()),
+      trustCredentials = TrustCredentials.CertCollection(serverCert.certificate()))
+    val client = {
+      val addr = server.boundAddress.asInstanceOf[InetSocketAddress]
+      new finagle.netty4.Netty4SslTest.Client(clientCert, serverCert)
+        .withTransport.tls(clientConfig)
+        .newService(s"${addr.getHostName}:${addr.getPort}", "client")
+    }
+
+    def close() = Future.collect(Seq(client.close(), server.close()))
+  }
+
+  override type FixtureParam = Ctx
+
+  override def withFixture(test: OneArgTest): Outcome = {
+    val ctx = new Ctx
+    try {
+      withFixture(test.toNoArgTest(ctx))
+    } finally {
+      Await.ready(ctx.close(), 3.seconds)
+    }
+  }
+
+  test("Peer certificate is available to service") { ctx =>
+    val response = Await.result(ctx.client("security is overrated!\n"), 3.seconds)
+    assert(response == "OK")
+  }
+}

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/client/Netty4ClientSslHandlerTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/client/Netty4ClientSslHandlerTest.scala
@@ -2,10 +2,8 @@ package com.twitter.finagle.netty4.ssl.client
 
 import com.twitter.finagle.{Address, Stack}
 import com.twitter.finagle.client.Transporter
-import com.twitter.finagle.netty4.ssl.SslConnectHandler
 import com.twitter.finagle.ssl.{KeyCredentials, TrustCredentials}
-import com.twitter.finagle.ssl.client.{
-  SslClientConfiguration, SslClientEngineFactory, SslContextClientEngineFactory}
+import com.twitter.finagle.ssl.client.{SslClientConfiguration, SslClientEngineFactory, SslContextClientEngineFactory}
 import com.twitter.finagle.transport.Transport
 import com.twitter.io.TempFile
 import io.netty.channel.embedded.EmbeddedChannel
@@ -56,7 +54,7 @@ class Netty4ClientSslHandlerTest extends FunSuite {
     val sslHandler = pipeline.get(classOf[SslHandler])
     assert(sslHandler == null)
 
-    val sslConnectHandler = pipeline.get(classOf[SslConnectHandler])
+    val sslConnectHandler = pipeline.get(classOf[SslClientConnectHandler])
     assert(sslConnectHandler == null)
 
     ch.finishAndReleaseAll()
@@ -83,7 +81,7 @@ class Netty4ClientSslHandlerTest extends FunSuite {
       val sslHandler = pipeline.get(classOf[SslHandler])
       assert(sslHandler != null)
 
-      val sslConnectHandler = pipeline.get(classOf[SslConnectHandler])
+      val sslConnectHandler = pipeline.get(classOf[SslClientConnectHandler])
       assert(sslConnectHandler != null)
 
       val sslEngine = sslHandler.engine()

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/client/SslConnectHandlerTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/client/SslConnectHandlerTest.scala
@@ -1,15 +1,15 @@
-package com.twitter.finagle.netty4.ssl
+package com.twitter.finagle.netty4.ssl.client
 
 import io.netty.channel.Channel
 import io.netty.channel.embedded.EmbeddedChannel
 import io.netty.handler.ssl.SslHandler
 import io.netty.util.concurrent.DefaultPromise
-import org.junit.runner.RunWith
-import org.scalatest.{FunSuite, OneInstancePerTest}
-import org.scalatest.junit.JUnitRunner
-import org.mockito.Mockito._
 import java.net.InetSocketAddress
 import javax.net.ssl.{SSLEngine, SSLSession}
+import org.junit.runner.RunWith
+import org.mockito.Mockito._
+import org.scalatest.{FunSuite, OneInstancePerTest}
+import org.scalatest.junit.JUnitRunner
 import org.scalatest.mockito.MockitoSugar
 
 @RunWith(classOf[JUnitRunner])
@@ -30,7 +30,7 @@ class SslConnectHandlerTest extends FunSuite with MockitoSugar with OneInstanceP
   }
 
   test("success") {
-    channel.pipeline().addFirst(new SslConnectHandler(sslHandler, _ => None))
+    channel.pipeline().addFirst(new SslClientConnectHandler(sslHandler, _ => None))
     val connectPromise = channel.connect(fakeAddress)
     assert(!connectPromise.isDone)
 
@@ -46,7 +46,7 @@ class SslConnectHandlerTest extends FunSuite with MockitoSugar with OneInstanceP
 
   test("failed session validation") {
     val e = new Exception("whoa")
-    channel.pipeline().addFirst(new SslConnectHandler(sslHandler, _ => Some(e)))
+    channel.pipeline().addFirst(new SslClientConnectHandler(sslHandler, _ => Some(e)))
     val connectPromise = channel.connect(fakeAddress)
     assert(!connectPromise.isDone)
 
@@ -61,7 +61,7 @@ class SslConnectHandlerTest extends FunSuite with MockitoSugar with OneInstanceP
   }
 
   test("cancelled after connected") {
-    channel.pipeline().addFirst(new SslConnectHandler(sslHandler, _ => None))
+    channel.pipeline().addFirst(new SslClientConnectHandler(sslHandler, _ => None))
     val connectPromise = channel.connect(fakeAddress)
     assert(!connectPromise.isDone)
 
@@ -72,7 +72,7 @@ class SslConnectHandlerTest extends FunSuite with MockitoSugar with OneInstanceP
   }
 
   test("failed handshake") {
-    channel.pipeline().addFirst(new SslConnectHandler(sslHandler, _ => None))
+    channel.pipeline().addFirst(new SslClientConnectHandler(sslHandler, _ => None))
     val connectPromise = channel.connect(fakeAddress)
     assert(!connectPromise.isDone)
 


### PR DESCRIPTION
Problem

https://github.com/twitter/finagle/issues/600

Solution

- changing `ChannelTransport.peerCertificate` from `val` to `def`
- call `serveTransport` either after successful handshake, if a `SslHandler` is installed into pipeline or immediately, if none.

