### PR TITLE
finagle-core: Add tailrec annotation

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/NameTree.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/NameTree.scala
@@ -200,6 +200,7 @@ object NameTree {
   /**
    * A string parseable by [[com.twitter.finagle.NameTree.read NameTree.read]].
    */
+  @tailrec
   def show[T: Showable](tree: NameTree[T]): String = tree match {
     case Union(Weighted(_, tree)) => show(tree)
     case Alt(tree) => show(tree)
@@ -211,6 +212,7 @@ object NameTree {
     case _ => show1(tree)
   }
 
+  @tailrec
   private def show1[T: Showable](tree: NameTree[T]): String = tree match {
     case Union(Weighted(_, tree)) => show1(tree)
     case Alt(tree) => show1(tree)
@@ -227,6 +229,7 @@ object NameTree {
     case _ => showSimple(tree)
   }
 
+  @tailrec
   private def showSimple[T: Showable](tree: NameTree[T]): String = tree match {
     case Union(Weighted(_, tree)) => showSimple(tree)
     case Alt(tree) => showSimple(tree)

--- a/finagle-core/src/main/scala/com/twitter/finagle/builder/SourceTrackingMonitor.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/builder/SourceTrackingMonitor.scala
@@ -5,6 +5,7 @@ import com.twitter.logging.HasLogLevel
 import com.twitter.util.Monitor
 import java.io.IOException
 import java.util.logging.{Level, Logger}
+import scala.annotation.tailrec
 
 /**
  * A monitor that unrolls the exception causes to report source information if any
@@ -29,6 +30,7 @@ class SourceTrackingMonitor(logger: Logger, which: String) extends Monitor {
     false
   }
 
+  @tailrec
   private[this] def unrollCauses(exc: Throwable, res: Seq[String] = Nil): Seq[String] = exc match {
     case null => res.reverse
     case se: SourcedException => unrollCauses(se.getCause, se.serviceName +: res)


### PR DESCRIPTION
Problem

Some tail recursive methods have no `@tailrec` annotation.

Solution

Added `@tailrec` annotation.