### PR TITLE
finagle-doc: fix finagle/clientregistry/size metrics description

### DIFF
--- a/doc/src/sphinx/metrics/Finagle.rst
+++ b/doc/src/sphinx/metrics/Finagle.rst
@@ -47,7 +47,7 @@ ClientRegistry
 
 **finagle/clientregistry/size**
   A gauge of the current number of clients registered in the
-  :src:`HashedWheelTimer.Default <com/twitter/finagle/client/ClientRegistry.scala>`.
+  :src:`ClientRegistry <com/twitter/finagle/client/ClientRegistry.scala>`.
 
 Name Resolution
 <<<<<<<<<<<<<<<


### PR DESCRIPTION
Problem

document of finagle/clientregistry/size is wrong.

`finagle/clientregistry/size` is a ClientRegistry metrics but,
description is `registered in the HashedWheelTimer.Default.`

ref: https://github.com/twitter/finagle/commit/4acff045686f90

Solution

fix it