### PR TITLE
finagle-doc: fix incorrect link

### DIFF
--- a/doc/src/sphinx/Metrics.rst
+++ b/doc/src/sphinx/Metrics.rst
@@ -206,7 +206,7 @@ These stats pertain to the HTTP protocol.
   responses are not automatically retried.
 
 These metrics are added by
-:src:`StatsFilter <com/twitter/finagle/http/filter/StatsFilter.scala>` and can be enabled by
+:finagle-http-src:`StatsFilter <com/twitter/finagle/http/filter/StatsFilter.scala>` and can be enabled by
 using `.withHttpStats` on `Http.Client` and `Http.Server`.
 
 **status/<statusCode>**

--- a/doc/src/sphinx/metrics/LoadBalancing.rst
+++ b/doc/src/sphinx/metrics/LoadBalancing.rst
@@ -22,7 +22,7 @@ All Balancers
 **meanweight**
   A gauge tracking the arithmetic mean of the weights of the endpoints
   being load-balanced across. Does not apply to
-  :src:`HeapBalancer <com/twitter/finagle/loadbalancer/HeapBalancer.scala>`.
+  :src:`HeapLeastLoaded <com/twitter/finagle/loadbalancer/heap/HeapLeastLoaded.scala>`.
 
 **adds**
   A counter of the number of hosts added to the loadbalancer.


### PR DESCRIPTION
Problem

- HeapBalancer.scala was moved to HeapLeastLoaded.scala.

- StatsFilter.scala was moved to finagle-http module.

Solution

fix it.