### PR TITLE
Sni support

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/ssl/KeyCredentials.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/ssl/KeyCredentials.scala
@@ -1,6 +1,8 @@
 package com.twitter.finagle.ssl
 
 import java.io.File
+import java.security.PrivateKey
+import java.security.cert.X509Certificate
 
 /**
  * KeyCredentials represent the items necessary for this configured
@@ -48,4 +50,17 @@ object KeyCredentials {
    */
   case class CertKeyAndChain(certificateFile: File, keyFile: File, caCertificateFile: File)
       extends KeyCredentials
+
+  /**
+    * Indicates that this certificate and key should be used by the
+    * engine factory.
+    *
+    * @param key a PKCS#8 private key. It should not require a password.
+    *
+    * @param keyCertChain the X.509 certificate chain
+    */
+  case class KeyAndCertChain(
+      key: PrivateKey,
+      keyCertChain: Array[X509Certificate])
+    extends KeyCredentials
 }

--- a/finagle-core/src/main/scala/com/twitter/finagle/ssl/TrustCredentials.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/ssl/TrustCredentials.scala
@@ -1,6 +1,7 @@
 package com.twitter.finagle.ssl
 
 import java.io.File
+import java.security.cert.X509Certificate
 
 /**
  * TrustCredentials represent the items necessary for this configured
@@ -34,4 +35,12 @@ object TrustCredentials {
    * in PEM format.
    */
   case class CertCollection(file: File) extends TrustCredentials
+
+  /**
+    * The collection of certificates which should be used in
+    * verifying a remote peer's credentials.
+    *
+    * @certs a collection of X.509 certificates
+    */
+  case class Certificates(certs: Array[X509Certificate]) extends TrustCredentials
 }

--- a/finagle-core/src/main/scala/com/twitter/finagle/ssl/server/LegacyKeyServerEngineFactory.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/ssl/server/LegacyKeyServerEngineFactory.scala
@@ -45,6 +45,9 @@ object LegacyKeyServerEngineFactory extends SslServerEngineFactory {
           case Return(kms) => Some(kms)
           case Throw(ex) => throw SslConfigurationException(ex.getMessage, ex)
         }
+      case KeyCredentials.KeyAndCertChain(_, _) =>
+        throw SslConfigurationException.notSupported(
+          "KeyCredentials.KeyAndCertChain", "LegacyKeyServerEngineFactor")
     }
 
   /**

--- a/finagle-core/src/main/scala/com/twitter/finagle/ssl/server/LegacyServerEngineFactory.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/ssl/server/LegacyServerEngineFactory.scala
@@ -81,6 +81,9 @@ object LegacyServerEngineFactory extends SslServerEngineFactory {
           cipherSuites.orNull,
           appProtos.orNull
         )
+      case KeyCredentials.KeyAndCertChain(_, _) =>
+        throw SslConfigurationException.notSupported(
+          "KeyCredentials.KeyAndCertChain", "LegacyKeyServerEngineFactor")
     }
 
     // Explicitly set this to server mode, since calls to Ssl.server do not.

--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/Netty4SslConfigurations.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/Netty4SslConfigurations.scala
@@ -46,6 +46,8 @@ private[ssl] object Netty4SslConfigurations {
           .trustManager(InsecureTrustManagerFactory.INSTANCE)
       case TrustCredentials.CertCollection(file) =>
         builder.trustManager(file)
+      case TrustCredentials.Certificates(certificates) =>
+        builder.trustManager(certificates:_*)
     }
   }
 

--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/client/Netty4ClientEngineFactory.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/client/Netty4ClientEngineFactory.scala
@@ -48,6 +48,8 @@ class Netty4ClientEngineFactory(allocator: ByteBufAllocator, forceJdk: Boolean)
           cert <- new X509CertificateFile(certFile).readX509Certificate()
           chain <- new X509CertificateFile(chainFile).readX509Certificates()
         } yield builder.keyManager(key, cert +: chain: _*)
+      case KeyCredentials.KeyAndCertChain(key, chain) =>
+        Return(builder.keyManager(key, chain:_*))
     }
 
   /**

--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/package.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/package.scala
@@ -1,0 +1,9 @@
+package com.twitter.finagle.netty4
+
+import io.netty.util.AttributeKey
+
+package object ssl {
+
+  private[netty4] val ServerNameKey = AttributeKey.valueOf[String]("SSL_SERVER_NAME")
+  
+}

--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/server/Netty4ServerEngineFactory.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/server/Netty4ServerEngineFactory.scala
@@ -29,6 +29,8 @@ class Netty4ServerEngineFactory(allocator: ByteBufAllocator, forceJdk: Boolean)
           key <- Netty4SslConfigurations.getPrivateKey(keyFile)
           cert <- new X509CertificateFile(certFile).readX509Certificate()
         } yield SslContextBuilder.forServer(key, cert)
+      case KeyCredentials.KeyAndCertChain(key, certChain) =>
+        Return(SslContextBuilder.forServer(key, certChain: _*))
       case KeyCredentials.CertKeyAndChain(certFile, keyFile, chainFile) =>
         for {
           key <- Netty4SslConfigurations.getPrivateKey(keyFile)

--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/server/Netty4SniHandler.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/server/Netty4SniHandler.scala
@@ -1,0 +1,77 @@
+package com.twitter.finagle.netty4.ssl.server
+
+import com.twitter.finagle.ssl.Engine
+import com.twitter.finagle.ssl.server.{SslServerConfiguration, SslServerEngineFactory, SslServerSessionVerifier}
+import com.twitter.finagle.transport.Transport
+import com.twitter.util.{Return, Throw}
+import io.netty.channel.ChannelHandlerContext
+import io.netty.handler.codec.DecoderException
+import com.twitter.finagle.netty4.ssl.ServerNameKey
+import io.netty.handler.ssl.{AbstractSniHandler, SniHandler, SslContext, SslHandler}
+import io.netty.util.{AsyncMapping, ReferenceCountUtil}
+import io.netty.util.concurrent.{Future => NettyFuture, Promise}
+
+/**
+  * Delays channelActive event till ClientHello with SNI extension is processed, replaces itself with a SslHandler
+  * to continue the handshake.
+  */
+class Netty4SniHandler(mapping: SniSupport.ServerNameToContext, factory: SslServerEngineFactory,
+                       verifier: SslServerSessionVerifier) extends AbstractSniHandler[Option[SslServerConfiguration]] {
+
+  override def lookup(ctx: ChannelHandlerContext, hostname: String): NettyFuture[Option[SslServerConfiguration]] = {
+    val promise = ctx.executor().newPromise[Option[SslServerConfiguration]]
+    mapping(hostname).respond {
+      case Return(x)    => promise.setSuccess(x)
+      case Throw(exception) => promise.setFailure(exception)
+    }
+    promise
+  }
+
+  override def onLookupComplete(
+    ctx: ChannelHandlerContext,
+    hostname: String,
+    future: NettyFuture[Option[SslServerConfiguration]]
+  ): Unit = {
+    if (!future.isSuccess()) {
+      throw new DecoderException("failed to get the SslContext for " + hostname, future.cause())
+    }
+
+    ctx.channel().attr(ServerNameKey).set(hostname)
+    future.getNow match {
+      case None =>
+        val engine = new Engine(SniSupport.DenialSslContext.newEngine(ctx.channel().alloc()))
+        replaceHandler(ctx, SslServerConfiguration(), new SslHandler(engine.self))
+
+      case Some(config) =>
+        val engine: Engine = factory(config)
+        val sslHandler: SslHandler = new SslHandler(engine.self)
+        replaceHandler(ctx, config, sslHandler)
+    }
+
+  }
+
+  def replaceHandler(ctx: ChannelHandlerContext, config: SslServerConfiguration, sslHandler: SslHandler): Unit = {
+    // this method may get called after a client has already disconnected
+    val pipeline = ctx.pipeline()
+    try {
+      pipeline.addAfter("sni", "sslConnect", new SslServerVerificationHandler(sslHandler, config, verifier))
+      pipeline.replace(this, "ssl", sslHandler)
+    } finally {
+      // Since the SslHandler was not inserted into the pipeline the ownership of the SSLEngine was not
+      // transferred to the SslHandler.
+      // See https://github.com/netty/netty/issues/5678
+      if (pipeline.get(classOf[SslHandler]) != sslHandler) {
+        ReferenceCountUtil.safeRelease(sslHandler.engine())
+      }
+    }
+    ctx.fireChannelActive()
+  }
+
+  override def channelActive(ctx: ChannelHandlerContext): Unit = {
+    val channel = ctx.channel()
+    if (!channel.config().isAutoRead) {
+      channel.read()
+    }
+  }
+
+}

--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/transport/ChannelTransport.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/transport/ChannelTransport.scala
@@ -143,7 +143,7 @@ private[finagle] class ChannelTransport(
     closed.unit
   }
 
-  val peerCertificate: Option[Certificate] = ch.pipeline.get(classOf[SslHandler]) match {
+  def peerCertificate: Option[Certificate] = ch.pipeline.get(classOf[SslHandler]) match {
     case null => None
     case handler =>
       try {

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/Netty4SslTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/Netty4SslTest.scala
@@ -1,36 +1,39 @@
 package com.twitter.finagle.netty4
 
-import com.twitter.conversions.time._
 import com.twitter.finagle
-import com.twitter.finagle.Stack.Params
+import com.twitter.conversions.time._
 import com.twitter.finagle._
+import com.twitter.finagle.Stack.Params
 import com.twitter.finagle.client.{StackClient, StdStackClient, Transporter}
 import com.twitter.finagle.dispatch.{SerialClientDispatcher, SerialServerDispatcher}
+import com.twitter.finagle.netty4.ssl.server.SniSupport
 import com.twitter.finagle.param.Label
-import com.twitter.finagle.ssl.client.SslClientConfiguration
-import com.twitter.finagle.ssl.server.SslServerConfiguration
-import com.twitter.finagle.ssl.{ClientAuth, KeyCredentials, TrustCredentials}
+import com.twitter.finagle.ssl.{ClientAuth, Engine, KeyCredentials, TrustCredentials}
+import com.twitter.finagle.ssl.client.{SslClientConfiguration, SslClientEngineFactory}
+import com.twitter.finagle.ssl.server.{SslServerConfiguration, SslServerEngineFactory}
 import com.twitter.finagle.transport.{Transport, TransportContext}
 import com.twitter.finagle.transport.Transport.ServerSsl
-import com.twitter.util.{Await, Future}
+import com.twitter.util.{Await, Future, Throw}
 import io.netty.channel.ChannelPipeline
-import io.netty.handler.codec.string.{StringDecoder, StringEncoder}
 import io.netty.handler.codec.{DelimiterBasedFrameDecoder, Delimiters}
+import io.netty.handler.codec.string.{StringDecoder, StringEncoder}
+import io.netty.handler.ssl.{SslContext, SslContextBuilder}
 import io.netty.handler.ssl.util.SelfSignedCertificate
+import io.netty.util.concurrent.{Future => NettyFuture}
 import java.net.{InetAddress, InetSocketAddress, SocketAddress}
 import java.nio.charset.StandardCharsets.UTF_8
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLException
 
-import org.scalatest.Outcome
-import org.scalatest.fixture.FunSuite
+import org.scalatest.{Assertion, Outcome}
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+import org.scalatest.fixture.FunSuite
 
 object Netty4SslTest {
   case class Client(
-    clientCert: SelfSignedCertificate,
-    serverCert: SelfSignedCertificate,
-    params: Params = Params.empty,
-    stack: Stack[ServiceFactory[String, String]] = StackClient.newStack
-  ) extends StdStackClient[String, String, Client] {
+      params: Params = Params.empty,
+      stack: Stack[ServiceFactory[String, String]] = StackClient.newStack
+   ) extends StdStackClient[String, String, Client] {
 
     protected type In = String
     protected type Out = String
@@ -55,14 +58,9 @@ object Netty4SslTest {
       new SerialClientDispatcher(transport)
 
     override protected def copy1(stack: Stack[ServiceFactory[String, String]], params: Params) =
-      copy(clientCert, serverCert, params, stack)
+      copy(params, stack)
   }
-}
-
-class Netty4SslTest extends FunSuite with Eventually with IntegrationPatience {
-
-  class Ctx {
-    val serverCert = new SelfSignedCertificate("example.server.com")
+  abstract class Ctx {
     val clientCert = new SelfSignedCertificate("example.client.com")
     val allocator = io.netty.buffer.UnpooledByteBufAllocator.DEFAULT
 
@@ -77,7 +75,7 @@ class Netty4SslTest extends FunSuite with Eventually with IntegrationPatience {
       }
     }
 
-    val server = {
+    protected def mkServer(sslParams: Params): ListeningServer = {
       val service =
         new Service[String, String] {
           override def apply(request: String): Future[String] = {
@@ -90,16 +88,10 @@ class Netty4SslTest extends FunSuite with Eventually with IntegrationPatience {
           }
         }
 
-      val serverConfig = SslServerConfiguration(
-        keyCredentials =
-          KeyCredentials.CertAndKey(serverCert.certificate(), serverCert.privateKey()),
-        trustCredentials = TrustCredentials.CertCollection(clientCert.certificate()),
-        clientAuth = ClientAuth.Needed
-      )
 
       val p = Params.empty +
-        ServerSsl(Some(serverConfig)) +
-        Label("test")
+        ServerSsl(Some(SslServerConfiguration(clientAuth = ClientAuth.Needed))) +
+        Label("test") ++ sslParams
       val listener = Netty4Listener[String, String](StringServerInit, p)
       val serveTransport = (t: Transport[String, String]) => {
         if (t.peerCertificate.isEmpty)
@@ -109,24 +101,71 @@ class Netty4SslTest extends FunSuite with Eventually with IntegrationPatience {
       listener.listen(new InetSocketAddress(InetAddress.getLoopbackAddress, 0))(serveTransport(_))
     }
 
-    val clientConfig = SslClientConfiguration(
-      keyCredentials = KeyCredentials.CertAndKey(clientCert.certificate(), clientCert.privateKey()),
-      trustCredentials = TrustCredentials.CertCollection(serverCert.certificate())
-    )
-    val client = {
+    def server: ListeningServer
+
+    def mkClient(serverCert: X509Certificate, hostname: String): Service[String, String] = {
       val addr = server.boundAddress.asInstanceOf[InetSocketAddress]
-      new finagle.netty4.Netty4SslTest.Client(clientCert, serverCert).withTransport
-        .tls(clientConfig)
-        .newService(s"${addr.getHostName}:${addr.getPort}", "client")
+      new finagle.netty4.Netty4SslTest.Client().withTransport
+        .tls(SslClientConfiguration(Some(hostname)), new SslClientEngineFactory {
+        override def apply(address: Address, config: SslClientConfiguration): Engine = {
+          val ctx = SslContextBuilder.forClient.keyManager(clientCert.key(), clientCert.cert()).trustManager(serverCert).build()
+          new Engine(ctx.newEngine(allocator, hostname, -1))
+        }
+      }).newService(s"${addr.getHostName}:${addr.getPort}", "client")
     }
+
+    def client: Service[String, String]
 
     def close() = Future.collect(Seq(client.close(), server.close()))
   }
 
-  override type FixtureParam = Ctx
+  class DefaultCtx extends Ctx {
+    val serverCert = new SelfSignedCertificate("example.server.com")
+    val serverConfig = SslServerConfiguration(
+      keyCredentials = KeyCredentials.CertAndKey(serverCert.certificate(), serverCert.privateKey()),
+      trustCredentials = TrustCredentials.CertCollection(clientCert.certificate()),
+      clientAuth = ClientAuth.Needed)
+
+    override def server: ListeningServer = mkServer(Params.empty + ServerSsl(Some(serverConfig)))
+
+    override def client: Service[String, String] = mkClient(serverCert.cert(), "example.server.com")
+  }
+
+  class SniCtx extends Ctx {
+
+    val serverName = "first.server.com"
+    val serverCerts = Map(
+      serverName -> new SelfSignedCertificate(serverName),
+      "second.server.com" -> new SelfSignedCertificate("second.server.com")
+    )
+
+    private def mkConfig(serverCert: SelfSignedCertificate): SslServerConfiguration = {
+      SslServerConfiguration(
+        keyCredentials = KeyCredentials.CertAndKey(serverCert.certificate(), serverCert.privateKey()),
+        trustCredentials = TrustCredentials.CertCollection(clientCert.certificate()),
+        clientAuth = ClientAuth.Needed
+      )
+    }
+
+    override def server: ListeningServer =
+      mkServer(Params.empty + ServerSsl(Some(SslServerConfiguration(clientAuth = ClientAuth.Needed))) +
+        SniSupport.fromOption(serverCerts.get(_).map(mkConfig)))
+
+    override def client: Service[String, String] = {
+      val (hostname, serverCrt) = serverCerts.head
+      mkClient(serverCrt.cert(), hostname)
+    }
+  }
+}
+
+abstract class Netty4SslTest[A <: Netty4SslTest.Ctx] extends FunSuite with Eventually with IntegrationPatience {
+
+  def mkContext: A
+
+  override type FixtureParam = A
 
   override def withFixture(test: OneArgTest): Outcome = {
-    val ctx = new Ctx
+    val ctx = mkContext
     try {
       withFixture(test.toNoArgTest(ctx))
     } finally {
@@ -134,8 +173,39 @@ class Netty4SslTest extends FunSuite with Eventually with IntegrationPatience {
     }
   }
 
+}
+
+class Netty4NoSniSslTest extends Netty4SslTest[Netty4SslTest.DefaultCtx] {
+
   test("Peer certificate is available to service") { ctx =>
     val response = Await.result(ctx.client("security is overrated!\n"), 3.seconds)
     assert(response == "OK")
+  }
+
+  override def mkContext: Netty4SslTest.DefaultCtx = new Netty4SslTest.DefaultCtx
+}
+
+class Netty4SniSslTest extends Netty4SslTest[Netty4SslTest.SniCtx] {
+  override val mkContext: Netty4SslTest.SniCtx = new Netty4SslTest.SniCtx
+
+  test("server uses certificate assigned to the server name sent by client") { ctx =>
+    val response = Await.result(ctx.client("security is overrated!\n"), 3.seconds)
+    assert(response == "OK")
+  }
+
+  test("Unknown hostname") { ctx =>
+    val serverCert = new SelfSignedCertificate("unknown.server.com")
+    val client = ctx.mkClient(serverCert.cert(), "unknown.server.com")
+    try {
+      val future: Future[Assertion] = client("let it crash").transform {
+        case Throw(Failure(Some(t: ConnectionFailedException))) if t.getCause.isInstanceOf[SSLException] =>
+          Future.value(succeed)
+        case x =>
+          Future.value(fail("Ssl handshake should fail."))
+      }
+        Await.result(future, 3.seconds)
+    } finally {
+      Await.ready(client.close(), 3.second)
+    }
   }
 }


### PR DESCRIPTION
Depends on https://github.com/twitter/finagle/pull/603. Would appreciate a feedback, if this a right direction and what are possible improvements.

Problem

The server name indication is not supported by theNetty4ServerSslHandler at the moment.

Solution

- Netty4SniHandler is implemented. It delays channelActive event  till server_name is processed and than replaces itself with  SslHandler.
- Netty4ServerSslHandler adds the Netty4SniHandler to the pipeline  if SniParameter is available.