### PR TITLE
fix to force English to HTTP date format

### DIFF
--- a/finagle-base-http/src/main/scala/com/twitter/finagle/http/Message.scala
+++ b/finagle-base-http/src/main/scala/com/twitter/finagle/http/Message.scala
@@ -7,7 +7,7 @@ import com.twitter.util.{Closable, Duration, Future}
 import java.io._
 import java.util.{Iterator => JIterator}
 import java.nio.charset.Charset
-import java.util.{Date, TimeZone}
+import java.util.{Date, Locale, TimeZone}
 import org.apache.commons.lang.StringUtils
 import org.apache.commons.lang.time.FastDateFormat
 import org.jboss.netty.buffer.{
@@ -542,7 +542,8 @@ object Message {
   val ContentTypeWwwFrom = ContentTypeWwwForm
 
   private val HttpDateFormat = FastDateFormat.getInstance("EEE, dd MMM yyyy HH:mm:ss",
-                                                          TimeZone.getTimeZone("GMT"))
+                                                          TimeZone.getTimeZone("GMT"),
+                                                          Locale.ENGLISH)
   def httpDateFormat(date: Date): String =
     HttpDateFormat.format(date) + " GMT"
 }

--- a/finagle-base-http/src/test/scala/com/twitter/finagle/http/MessageTest.scala
+++ b/finagle-base-http/src/test/scala/com/twitter/finagle/http/MessageTest.scala
@@ -2,6 +2,7 @@ package com.twitter.finagle.http
 
 import com.twitter.conversions.time._
 import com.twitter.io.Buf
+import java.util.Date
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
@@ -46,6 +47,10 @@ class MessageTest extends FunSuite {
     response.accept = "A,,c;param,;d,;"
     assert(response.accept.toList == "A" :: "c;param" :: ";d" :: ";" :: Nil)
     assert(response.acceptMediaTypes.toList == "a" :: "c" :: Nil)
+
+    assert(response.date == None)
+    response.date = new Date(0L)
+    assert(response.date == Some("Thu, 01 Jan 1970 00:00:00 GMT"))
   }
 
   test("charset") {
@@ -319,5 +324,9 @@ class MessageTest extends FunSuite {
 
     assert(response.contentString == "hello")
     assert(response.length        == 5)
+  }
+
+  test("httpDateFormat"){
+    assert(Message.httpDateFormat(new Date(0L)) == "Thu, 01 Jan 1970 00:00:00 GMT")
   }
 }


### PR DESCRIPTION
**Problem**

In `finagle-base-http`, `Message.httpDateFormat()` uses JavaVM-default locale to format the specified date. For this reason, it generate incorrect HTTP date headers in non-English locales and some HTTP clients cannot recognize the value as date.

```
scala> System.getProperty("user.language")
res2: String = ja
scala> com.twitter.finagle.http.Message.httpDateFormat(new Date(0L))
res3: String = 木, 01 1 1970 00:00:00 GMT
```

 In Japanese, the `木` means `Thu` but it violates _wkday_ for [HTTP Full Date Spec](https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3.1). The `Message.httpDateFormat()` used by `date_=()`, `expires_=()` and `lastModified_=()` in class `Message`.

**Solution**

I added `Locale.ENGLISH` parameter to `FastDateFormat.getInstance()` to force _wkday_ in English. It seems to work very well in Japanese environment.

The other workaround is to use `headerMap.add(String,Date)` instead of these. This method uses another date-format implimentation in `HeaderMap.format(Date)'.