### PR TITLE
finagle-core: Fix Scaladoc param name

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/client/StackClient.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/client/StackClient.scala
@@ -424,7 +424,7 @@ trait StackClient[Req, Rep] extends StackBasedClient[Req, Rep]
  *
  * @see The [[https://twitter.github.io/finagle/guide/Clients.html user guide]]
  *      for further details on Finagle clients and their configuration.
-  * @see [[StackClient.newStack]] for the default modules used by Finagle
+ * @see [[StackClient.newStack]] for the default modules used by Finagle
  *      clients.
  */
 trait EndpointerStackClient[Req, Rep, This <: EndpointerStackClient[Req, Rep, This]]

--- a/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/p2c/P2CLeastLoaded.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/p2c/P2CLeastLoaded.scala
@@ -10,7 +10,7 @@ import com.twitter.util.Activity
  * An O(1), concurrent, least-loaded fair load balancer. This uses the ideas
  * behind "power of 2 choices" [1].
  *
- * @param activity An activity that updates with the set of nodes over which
+ * @param endpoints An activity that updates with the set of nodes over which
  * we distribute load.
  *
  * @param maxEffort the maximum amount of "effort" we're willing to

--- a/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/p2c/P2CPeakEwma.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/p2c/P2CPeakEwma.scala
@@ -15,7 +15,7 @@ import com.twitter.finagle.{NoBrokersAvailableException, ServiceFactory}
  * only cautiously. Peak EWMA takes history into account, so that
  * slow behavior is penalized relative to the supplied decay time.
  *
- * @param activity An activity that updates with the set of node pairs
+ * @param endpoints An activity that updates with the set of node pairs
  * over which we distribute load.
  *
  * @param decayTime The window of latency observations.


### PR DESCRIPTION
Problem

There is some difference between Scaladoc and real param name.

Solution

Fix Scaladoc param name.