### PR TITLE
finagle-{core, memcached, ostrich4}: Use collection.breakOut

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/netty3/socks/SocksConnectHandler.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/netty3/socks/SocksConnectHandler.scala
@@ -7,6 +7,7 @@ import java.nio.charset.StandardCharsets.{US_ASCII, UTF_8}
 import java.util.concurrent.atomic.AtomicReference
 import org.jboss.netty.buffer.{ChannelBuffer, ChannelBuffers}
 import org.jboss.netty.channel._
+import scala.collection.breakOut
 
 object SocksConnectHandler {
   // Throwables used as `cause` fields for ConnectionFailedExceptions.
@@ -70,8 +71,8 @@ class SocksConnectHandler(
   private[this] val buf = ChannelBuffers.dynamicBuffer()
   private[this] val bytes = new Array[Byte](4)
   private[this] val connectFuture = new AtomicReference[ChannelFuture](null)
-  private[this] val authenticationMap =
-    authenticationSettings.map { setting => setting.typeByte -> setting }.toMap
+  private[this] val authenticationMap: Map[Byte, AuthenticationSetting] =
+    authenticationSettings.map { setting => setting.typeByte -> setting }(breakOut)
   private[this] val supportedTypes = authenticationMap.keys.toArray.sorted
 
   // following Netty's ReplayingDecoderBuffer, we throw this when we run out of bytes

--- a/finagle-core/src/main/scala/com/twitter/finagle/util/InetSocketAddressUtil.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/util/InetSocketAddressUtil.scala
@@ -1,6 +1,7 @@
 package com.twitter.finagle.util
 
 import java.net.{InetAddress, InetSocketAddress, SocketAddress, UnknownHostException}
+import scala.collection.breakOut
 
 object InetSocketAddressUtil {
 
@@ -54,9 +55,9 @@ object InetSocketAddressUtil {
 
   private[finagle] def resolveHostPortsSeq(hostPorts: Seq[HostPort]): Seq[Seq[SocketAddress]] =
     hostPorts map { case (host, port) =>
-      (InetAddress.getAllByName(host) map { addr =>
+      InetAddress.getAllByName(host).map { addr =>
         new InetSocketAddress(addr, port)
-      }).toSeq
+      }(breakOut)
     }
 
   /**
@@ -72,11 +73,11 @@ object InetSocketAddressUtil {
   def parseHosts(hosts: String): Seq[InetSocketAddress] = {
     if (hosts == ":*") return Seq(new InetSocketAddress(0))
 
-    (parseHostPorts(hosts) map { case (host, port) =>
+    parseHostPorts(hosts).map[InetSocketAddress, List[InetSocketAddress]] { case (host, port) =>
       if (host == "")
         new InetSocketAddress(port)
       else
         new InetSocketAddress(host, port)
-    }).toList
+    }(breakOut)
   }
 }

--- a/finagle-core/src/main/scala/com/twitter/finagle/util/StackRegistry.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/util/StackRegistry.scala
@@ -4,6 +4,7 @@ import com.twitter.finagle.Stack
 import com.twitter.finagle.param.{Label, ProtocolLibrary}
 import com.twitter.util.registry.GlobalRegistry
 import java.util.concurrent.atomic.AtomicInteger
+import scala.collection.breakOut
 import scala.language.existentials
 
 object StackRegistry {
@@ -25,7 +26,7 @@ object StackRegistry {
           case p: Product =>
             // TODO: many case classes have a $outer field because they close over an outside scope.
             // this is not very useful, and it might make sense to filter them out in the future.
-            val fields = p.getClass.getDeclaredFields.map(_.getName).toSeq
+            val fields = p.getClass.getDeclaredFields.map(_.getName)(breakOut)
             val valueFunctions = p.productIterator.map(v => () => v.toString).toSeq
             seq ++ fields.zipAll(valueFunctions, "<unknown>", () => "<unknown>")
           case _ => seq

--- a/finagle-memcached/src/main/scala/com/twitter/finagle/memcached/TwemcacheCacheClient.scala
+++ b/finagle-memcached/src/main/scala/com/twitter/finagle/memcached/TwemcacheCacheClient.scala
@@ -7,6 +7,7 @@ import com.twitter.finagle.memcached.protocol.Exists
 import com.twitter.finagle.Service
 import com.twitter.io.Buf
 import com.twitter.util.{Future, Time}
+import scala.collection.breakOut
 
 // Client interface supporting twemcache commands
 trait TwemcacheClient extends Client {
@@ -57,7 +58,7 @@ trait TwemcacheConnectedClient extends TwemcacheClient { self: ConnectedClient =
   def getvResult(keys: Iterable[String]): Future[GetsResult] = {
     try {
       if (keys==null) throw new IllegalArgumentException("Invalid keys: keys cannot be null")
-      val bufs =  keys.map { Buf.Utf8(_) }.toSeq
+      val bufs =  keys.map { Buf.Utf8(_) }(breakOut)
       rawGet(Getv(bufs)).map { GetsResult(_) } // map to GetsResult as the response format are the same
     }  catch {
       case t: IllegalArgumentException => Future.exception(new ClientError(t.getMessage + " For keys: " + keys))
@@ -114,7 +115,7 @@ trait TwemcachePartitionedClient extends TwemcacheClient { self: PartitionedClie
       keys: Iterable[String])(f: (TwemcacheClient, Iterable[String]) => Future[A]
       ): Future[Seq[A]] = {
     Future.collect(
-      keys.groupBy(twemcacheClientOf).map(Function.tupled(f)).toSeq
+      keys.groupBy(twemcacheClientOf).map(Function.tupled(f))(breakOut)
     )
   }
 }

--- a/finagle-memcached/src/main/scala/com/twitter/finagle/memcached/util/Bufs.scala
+++ b/finagle-memcached/src/main/scala/com/twitter/finagle/memcached/util/Bufs.scala
@@ -2,6 +2,7 @@ package com.twitter.finagle.memcached.util
 
 import com.google.common.base.Strings
 import com.twitter.io.Buf
+import scala.collection.breakOut
 import scala.language.implicitConversions
 
 private[finagle] object Bufs {
@@ -25,7 +26,7 @@ private[finagle] object Bufs {
       null
     }
     else {
-      strings.map(nonEmptyStringToBuf).toSeq
+      strings.map(nonEmptyStringToBuf)(breakOut)
     }
   }
 

--- a/finagle-ostrich4/src/main/scala/com/twitter/finagle/stats/OstrichExporter.scala
+++ b/finagle-ostrich4/src/main/scala/com/twitter/finagle/stats/OstrichExporter.scala
@@ -7,13 +7,15 @@ import com.twitter.io.Buf
 import com.twitter.ostrich.stats.{StatsListener, Stats => FStats}
 import com.twitter.util.Future
 import com.twitter.util.registry.GlobalRegistry
+import scala.collection.breakOut
+import scala.util.matching.Regex
 
 object ostrichFilterRegex extends GlobalFlag(Seq.empty[String], "Ostrich filter regex")
 
 class OstrichExporter extends HttpMuxHandler {
   val pattern = "/stats.json"
 
-  val regexes = ostrichFilterRegex().toList.map(_.r)
+  val regexes: List[Regex] = ostrichFilterRegex().map(_.r)(breakOut)
 
   GlobalRegistry.get.put(
     Seq("stats", "ostrich", "counters_latched"),


### PR DESCRIPTION
Problem

use `map(...)(breakOut)` is slightly more efficient than `map(...).toSeq` and so on.

Solution

replace `map(...).toSeq`, `toList`, `toMap` with `map(...)(breakOut)`.