### PR TITLE
finagle-{core, http, redis, thrift}: Remove semicolons at end of lines

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/netty3/transport/ChannelTransport.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/netty3/transport/ChannelTransport.scala
@@ -114,7 +114,7 @@ class ChannelTransport[In, Out](ch: Channel)
     // more consistent threading model where callbacks are invoked
     // on the event loop thread.
     ch.getPipeline().sendDownstream(
-      new DownstreamMessageEvent(ch, writeFuture, msg, null));
+      new DownstreamMessageEvent(ch, writeFuture, msg, null))
 
     // We avoid setting an interrupt handler on the future exposed
     // because the backing opertion isn't interruptible.

--- a/finagle-core/src/main/scala/com/twitter/finagle/ssl/JSSE.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/ssl/JSSE.scala
@@ -78,8 +78,8 @@ object JSSE {
    * Get a client from the given Context
    */
   def client(ctx: SSLContext): Engine = {
-    val sslEngine = ctx.createSSLEngine();
-    sslEngine.setUseClientMode(true);
+    val sslEngine = ctx.createSSLEngine()
+    sslEngine.setUseClientMode(true)
     new Engine(sslEngine)
   }
 
@@ -87,8 +87,8 @@ object JSSE {
    * Get a client from the given Context
    */
   def client(ctx: SSLContext, host: String, port: Int): Engine = {
-    val sslEngine = ctx.createSSLEngine(host, port);
-    sslEngine.setUseClientMode(true);
+    val sslEngine = ctx.createSSLEngine(host, port)
+    sslEngine.setUseClientMode(true)
     new Engine(sslEngine)
   }
 

--- a/finagle-core/src/test/scala/com/twitter/finagle/StatusTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/StatusTest.scala
@@ -76,8 +76,10 @@ class StatusTest
 
   test("Ordering spot check") {
     val ord = Array(Status.Closed, Status.Busy, Status.Open)
-    val idx2 = for { left <- Gen.choose(0, ord.length-1);
-      right <- Gen.choose(0, ord.length-1) } yield (left, right)
+    val idx2 = for {
+      left <- Gen.choose(0, ord.length - 1)
+      right <- Gen.choose(0, ord.length - 1)
+    } yield (left, right)
 
     forAll(idx2) { case (left, right) =>
       assert(Ordering[Status].compare(ord(left), ord(right)).signum == (left - right).signum)

--- a/finagle-core/src/test/scala/com/twitter/finagle/builder/EndToEndTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/builder/EndToEndTest.scala
@@ -341,7 +341,7 @@ class EndToEndTest extends FunSuite with StringClient with StringServer {
 
   test("ClientBuilder should be properly instrumented on success") {
     val always = new Service[String, String] {
-      def apply(request: String) = Future.value("pong");
+      def apply(request: String) = Future.value("pong")
     }
     val address = new InetSocketAddress(InetAddress.getLoopbackAddress, 0)
     val server = ServerBuilder()
@@ -381,7 +381,7 @@ class EndToEndTest extends FunSuite with StringClient with StringServer {
 
   test("ClientBuilderClient.ofCodec should be properly instrumented on success") {
     val always = new Service[String, String] {
-      def apply(request: String) = Future.value("pong");
+      def apply(request: String) = Future.value("pong")
     }
     val address = new InetSocketAddress(InetAddress.getLoopbackAddress, 0)
     val server = ServerBuilder()

--- a/finagle-core/src/test/scala/com/twitter/finagle/util/ChanTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/util/ChanTest.scala
@@ -31,9 +31,9 @@ class ChanTest extends FunSuite {
       }
     }
 
-    t0.start();
+    t0.start()
     t1.start()
-    t0.join();
+    t0.join()
     t1.join()
 
     assert(threads.toSeq == Seq(t0, t1))

--- a/finagle-http/src/main/scala/com/twitter/finagle/http/SpnegoAuthenticator.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/http/SpnegoAuthenticator.scala
@@ -238,7 +238,7 @@ object SpnegoAuthenticator {
         var tokenOut: Token = null
         do {
           tokenOut = subjectDoAction(initContextAction(context, tokenIn))
-        } while (tokenOut == null);
+        } while (tokenOut == null)
         tokenOut
       }
 

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/util/TestServer.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/util/TestServer.scala
@@ -1,6 +1,5 @@
 package com.twitter.finagle.redis.util
 
-import java.lang.ProcessBuilder
 import java.net.InetSocketAddress
 import java.io.{BufferedWriter, FileWriter, PrintWriter, File}
 import com.twitter.finagle.Redis
@@ -19,7 +18,7 @@ object RedisCluster { self =>
   def addresses: Seq[Option[InetSocketAddress]] = instanceStack.map { i => i.address }
 
   def hostAddresses(from: Int = 0, until: Int = instanceStack.size): String = {
-    require(instanceStack.length > 0)
+    require(instanceStack.nonEmpty)
     addresses.slice(from, until).map { address =>
       val addy = address.get
       "%s:%d".format("127.0.0.1", addy.getPort())
@@ -54,7 +53,7 @@ object RedisCluster { self =>
     override def run() {
       self.instanceStack.foreach { instance => instance.stop() }
     }
-  });
+  })
 }
 
 sealed trait RedisMode
@@ -78,7 +77,7 @@ class ExternalRedis(mode: RedisMode = RedisMode.Standalone) {
 
   private[this] def findAddress() {
     var tries = 100
-    while (address == None && tries >= 0) {
+    while (address.isEmpty && tries >= 0) {
       address = Some(RandomSocket.nextAddress())
       if (forbiddenPorts.contains(address.get.getPort)) {
         address = None

--- a/finagle-serversets/src/test/scala/com/twitter/finagle/zookeeper/ZkInstance.scala
+++ b/finagle-serversets/src/test/scala/com/twitter/finagle/zookeeper/ZkInstance.scala
@@ -21,7 +21,7 @@ class ZkInstance {
   }
 
   lazy val zookeeperConnectString =
-    zookeeperAddress.getHostName() + ":" + zookeeperAddress.getPort();
+    zookeeperAddress.getHostName() + ":" + zookeeperAddress.getPort()
 
   def start() {
     started = true

--- a/finagle-thrift/src/main/scala/com/twitter/finagle/thrift/RichRequestHeader.scala
+++ b/finagle-thrift/src/main/scala/com/twitter/finagle/thrift/RichRequestHeader.scala
@@ -1,4 +1,4 @@
-package com.twitter.finagle.thrift;
+package com.twitter.finagle.thrift
 
 import com.twitter.finagle.{Dentry, Dtab, Path, NameTree}
 import com.twitter.finagle.tracing.{Flags, SpanId, TraceId}


### PR DESCRIPTION
Problem

The semicolon at the end of the line is unnecessary.

Solution

Removed semicolons.