### PR TITLE
Tolerates X-B3-Sampled: 1

### DIFF
--- a/finagle-http/src/main/scala/com/twitter/finagle/http/Codec.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/http/Codec.scala
@@ -13,7 +13,7 @@ import com.twitter.finagle.stats.{NullStatsReceiver, ServerStatsReceiver, StatsR
 import com.twitter.finagle.tracing.{Flags, SpanId, Trace, TraceId, TraceInitializerFilter}
 import com.twitter.finagle.transport.Transport
 import com.twitter.util.{Closable, StorageUnit}
-import java.lang.{Long => JLong}
+import java.lang.{Long => JLong, Boolean => JBoolean}
 import org.jboss.netty.channel._
 import org.jboss.netty.handler.codec.frame.TooLongFrameException
 import org.jboss.netty.handler.codec.http._
@@ -336,13 +336,11 @@ private object TraceInfo {
               else
                 None
 
-            val sampled = if (!request.headerMap.contains(Header.Sampled)) {
+            val maybeSampled = request.headerMap.getOrNull(Header.Sampled)
+            val sampled = if (maybeSampled == null) {
               None
             } else {
-              try Some(request.headerMap(Header.Sampled).toBoolean)
-              catch { case _: IllegalArgumentException =>
-                None
-              }
+              Some("1".equals(maybeSampled) || JBoolean.valueOf(maybeSampled))
             }
 
             val flags = getFlags(request)


### PR DESCRIPTION
Problem

Currently, when the http codec reads `X-B3-Sampled: true`, a trace is
continued. Otherwise, it is stopped (as opposed to restarting), as other
values are interpreted as false. Most Zipkin instrumentation send
`X-B3-Sampled: 1` even if they tolerantly read `X-B3-Sampled: true`.

Solution

This change tolerantly reads '1', and also skips allocating an exception
for other values. In a future version of Finagle, we should start
writing `1`, IMHO.

Result

This change makes Finagle tolerantly read `X-B3-Sampled: 1`, so that
traces made by other libraries don't stop when they hit a Finagle
service. For example, this makes Finagle compatible with Brave and zipkin-js

See #617