### PR TITLE
Pipelining dispatcher improvements

### DIFF
--- a/finagle-core/src/test/scala/com/twitter/finagle/dispatch/PipeliningDispatcherTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/dispatch/PipeliningDispatcherTest.scala
@@ -60,7 +60,7 @@ class PipeliningDispatcherTest extends FunSuite with MockitoSugar {
       f.raise(new UtilTimeoutException("boom!"))
       verify(trans, never()).close()
 
-      ctl.advance(PipeliningDispatcher.TimeToWaitForStalledPipeline)
+      ctl.advance(GenPipeliningDispatcher.TimeToWaitForStalledPipeline)
       timer.tick()
       verify(trans, times(1)).close()
     }
@@ -80,7 +80,7 @@ class PipeliningDispatcherTest extends FunSuite with MockitoSugar {
       verify(trans, never()).close()
       readP.setDone()
 
-      ctl.advance(PipeliningDispatcher.TimeToWaitForStalledPipeline)
+      ctl.advance(GenPipeliningDispatcher.TimeToWaitForStalledPipeline)
       timer.tick()
       verify(trans, never()).close()
     }

--- a/finagle-memcached/src/main/scala/com/twitter/finagle/Memcached.scala
+++ b/finagle-memcached/src/main/scala/com/twitter/finagle/Memcached.scala
@@ -1,7 +1,6 @@
 package com.twitter.finagle
 
 import _root_.java.net.SocketAddress
-
 import com.twitter.concurrent.Broker
 import com.twitter.conversions.time._
 import com.twitter.finagle
@@ -30,7 +29,6 @@ import com.twitter.hashing
 import com.twitter.io.Buf
 import com.twitter.util.registry.GlobalRegistry
 import com.twitter.util.{Closable, Duration, Monitor}
-
 import scala.collection.mutable
 
 private[finagle] object MemcachedTracingFilter {

--- a/finagle-memcached/src/main/scala/com/twitter/finagle/Memcached.scala
+++ b/finagle-memcached/src/main/scala/com/twitter/finagle/Memcached.scala
@@ -1,11 +1,12 @@
 package com.twitter.finagle
 
 import _root_.java.net.SocketAddress
+
 import com.twitter.concurrent.Broker
 import com.twitter.conversions.time._
 import com.twitter.finagle
 import com.twitter.finagle.client.{ClientRegistry, DefaultPool, StackClient, StdStackClient, Transporter}
-import com.twitter.finagle.dispatch.{GenSerialClientDispatcher, PipeliningDispatcher, SerialServerDispatcher}
+import com.twitter.finagle.dispatch.{GenSerialClientDispatcher, PipeliningDispatcher, SerialServerDispatcher, StalledPipelineTimeout}
 import com.twitter.finagle.loadbalancer.{Balancers, LoadBalancerFactory}
 import com.twitter.finagle.liveness.{FailureAccrualFactory, FailureAccrualPolicy}
 import com.twitter.finagle.memcached._
@@ -29,6 +30,7 @@ import com.twitter.hashing
 import com.twitter.io.Buf
 import com.twitter.util.registry.GlobalRegistry
 import com.twitter.util.{Closable, Duration, Monitor}
+
 import scala.collection.mutable
 
 private[finagle] object MemcachedTracingFilter {
@@ -263,6 +265,7 @@ object Memcached extends finagle.Client[Command, Response]
           new MemcachedClientDecoder,
           transport),
         params[finagle.param.Stats].statsReceiver.scope(GenSerialClientDispatcher.StatsScope),
+        params[StalledPipelineTimeout].timeout,
         DefaultTimer
       )
 

--- a/finagle-redis/src/main/scala/com/twitter/finagle/Redis.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/Redis.scala
@@ -2,7 +2,7 @@ package com.twitter.finagle
 
 import com.twitter.finagle
 import com.twitter.finagle.client._
-import com.twitter.finagle.dispatch.GenSerialClientDispatcher
+import com.twitter.finagle.dispatch.{GenSerialClientDispatcher, StalledPipelineTimeout}
 import com.twitter.finagle.netty4.{Netty4HashedWheelTimer, Netty4Transporter}
 import com.twitter.finagle.param.{ExceptionStatsHandler => _, Monitor => _, ResponseClassifier => _, Tracer => _, _}
 import com.twitter.finagle.redis.exp.RedisPool
@@ -74,7 +74,8 @@ object Redis extends Client[Command, Reply] with RedisRichClient {
     protected def newDispatcher(transport: Transport[In, Out]): Service[Command, Reply] =
       RedisPool.newDispatcher(
         new StageTransport(transport),
-        params[finagle.param.Stats].statsReceiver.scope(GenSerialClientDispatcher.StatsScope)
+        params[finagle.param.Stats].statsReceiver.scope(GenSerialClientDispatcher.StatsScope),
+        params[StalledPipelineTimeout].timeout
       )
 
     // Java-friendly forwarders

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/exp/RedisPool.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/exp/RedisPool.scala
@@ -8,7 +8,7 @@ import com.twitter.finagle.redis.protocol.{Command, Reply}
 import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.finagle.util.DefaultTimer
 import com.twitter.finagle.transport.Transport
-import com.twitter.util.{Future, Local, Time}
+import com.twitter.util.{Duration, Future, Local, Time}
 
 object RedisPool {
 
@@ -26,10 +26,11 @@ object RedisPool {
 
   def newDispatcher[T](
     transport: Transport[Command, Reply],
-    statsReceiver: StatsReceiver): Service[Command, Reply] =
+    statsReceiver: StatsReceiver,
+    stallTimeout: Duration): Service[Command, Reply] =
     useFor() match {
       case Some(Subscription) => new SubscribeDispatcher(transport)
-      case _                  => new PipeliningDispatcher(transport, statsReceiver, DefaultTimer)
+      case _                  => new PipeliningDispatcher(transport, statsReceiver, stallTimeout, DefaultTimer)
     }
 
   def module: Stackable[ServiceFactory[Command, Reply]] =

--- a/finagle-thriftmux/src/test/scala/com/twitter/finagle/thriftmux/EndToEndTest.scala
+++ b/finagle-thriftmux/src/test/scala/com/twitter/finagle/thriftmux/EndToEndTest.scala
@@ -789,7 +789,7 @@ class EndToEndTest extends FunSuite
 
     object OldPlainPipeliningThriftClient extends Thrift.Client(stack=StackClient.newStack) {
       override protected def newDispatcher(transport: Transport[ThriftClientRequest, Array[Byte]]) =
-        new PipeliningDispatcher(transport, NullStatsReceiver, new MockTimer)
+        new PipeliningDispatcher(transport, NullStatsReceiver, 10.seconds, new MockTimer)
     }
 
     val service = await(OldPlainPipeliningThriftClient.newClient(


### PR DESCRIPTION
Problem

`PipeliningDispatcher` has the following limitations:

* same type signature as the underlying `Transport`;
* hardcoded timeout for detecting a stalled pipeline;
* does not allow tracking more than the dispatched `Promise` in the pipeline.

Solution

Abstract over the dispatcher / transport types, add another type parameter for what is being tracked in the pipeline.

Add a new `Param` to allow configuring the stall timeout.
