### PR TITLE
Scope dispatcher stats under client label

### DIFF
--- a/finagle-http/src/main/scala/com/twitter/finagle/Http.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/Http.scala
@@ -193,7 +193,7 @@ object Http extends Client[Request, Response] with HttpRichClient
 
     protected def endpointer: Stackable[ServiceFactory[Request, Response]] =
       new EndpointerModule[Request, Response](
-        Seq(implicitly[Stack.Param[HttpImpl]]),
+        Seq(implicitly[Stack.Param[HttpImpl]], implicitly[Stack.Param[param.Stats]]),
         { (prms: Stack.Params, addr: InetSocketAddress) =>
 
           val transporter = params[HttpImpl].transporter(prms)(addr)
@@ -203,11 +203,11 @@ object Http extends Client[Request, Response] with HttpRichClient
               // that would live for the life of the session.
               Contexts.letClearAll {
                 transporter().map { trans =>
-                  val streamTransport = params[HttpImpl].clientTransport(trans)
+                  val streamTransport = prms[HttpImpl].clientTransport(trans)
 
                   new HttpClientDispatcher(
                     new HttpTransport(streamTransport),
-                    params[param.Stats].statsReceiver.scope(GenSerialClientDispatcher.StatsScope)
+                    prms[param.Stats].statsReceiver.scope(GenSerialClientDispatcher.StatsScope)
                   )
                 }
               }

--- a/finagle-http/src/test/scala/com/twitter/finagle/HttpTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/HttpTest.scala
@@ -106,6 +106,7 @@ class HttpTest extends FunSuite {
     assert(clientReceiver.counters(Seq("stats_test_client", "http", "status", "404")) == 1)
     assert(clientReceiver.counters(Seq("stats_test_client", "http", "status", "4XX")) == 1)
     assert(clientReceiver.stats(Seq("stats_test_client", "http", "response_size")) == Seq(5.0))
+    assert(clientReceiver.gauges.contains(Seq("stats_test_client", "dispatcher", "serial", "queue_size")))
   }
 
   test("server uses custom response classifier when specified") {


### PR DESCRIPTION
Problem

Dispatcher stats are not scoped under the client label.  This is inconsistent
with all other client stats.

Solution

Modify the endpointer module to use the StatReceiver from the Stack.Params
passed into the module rather than the Stack.Params set on the StackClient.
These are mostly identicial except that `newClient` scopes the StatsReceiver
with the label and passes it into the Stack but does not update the
Stack.Params on the StackClient.

Result

Dispatcher stats are scoped under the client label.