### PR TITLE
Initial support for Curator Service Discovery records

### DIFF
--- a/finagle-serversets/src/main/scala/com/twitter/finagle/serverset2/Entry.scala
+++ b/finagle-serversets/src/main/scala/com/twitter/finagle/serverset2/Entry.scala
@@ -51,18 +51,13 @@ case class Endpoint(
 }
 
 object Entry {
-  private val EndpointPrefix = "member_"
-
   /**
    * Parse a JSON response from ZooKeeper into a Seq[Entry].
    */
   def parseJson(path: String, json: String): Seq[Entry] = {
     val basename = path.split("/").last
 
-    if (basename startsWith EndpointPrefix)
-      Endpoint.parseJson(json) map (_.copy(memberId = basename))
-    else
-      Nil
+    Endpoint.parseJson(json) map (_.copy(memberId = basename))
   }
 }
 

--- a/finagle-serversets/src/main/scala/com/twitter/finagle/serverset2/ServiceDiscoverer.scala
+++ b/finagle-serversets/src/main/scala/com/twitter/finagle/serverset2/ServiceDiscoverer.scala
@@ -7,7 +7,7 @@ import com.twitter.logging.Logger
 import com.twitter.util._
 
 private[serverset2] object ServiceDiscoverer {
-  val EndpointGlob = "/member_"
+  val EndpointGlob = "/"
   val VectorGlob = "/vector_"
 
   /**

--- a/finagle-serversets/src/test/scala/com/twitter/finagle/serverset2/EntryTest.scala
+++ b/finagle-serversets/src/test/scala/com/twitter/finagle/serverset2/EntryTest.scala
@@ -13,6 +13,9 @@ class EntryTest extends FunSuite {
   val exampleJson2 =
     """{"status": "ALIVE", "additionalEndpoints": {"aurora": {"host": "10.0.0.1", "port": %d}, "http": {"host": "10.0.0.1", "port": %d}}, "serviceEndpoint": {"host": "10.0.0.1", "port": %d}, "shard": 0}"""
       .format(port, port, port)
+  val exampleCuratorJson =
+    """{"name": "/example-service", "id": "00000000-0000-0000-0000-000000000000", "address": "10.0.0.1", "port": %d, "sslPort": null, "payload": null, "registrationTimeUTC": 1234567890123, "serviceType": "DYNAMIC", "uriSpec": {"parts": [{"value": "scheme", "variable": true}, {"value": "://", "variable": false}, {"value": "address", "variable": true}, {"value": ":", "variable": false}, {"value": "port", "variable": true}]}}"""
+      .format(port)
 
   test("Endpoint.parseJson: ok input") {
     val eps = Endpoint.parseJson(exampleJson)
@@ -48,5 +51,12 @@ class EntryTest extends FunSuite {
 
   test("Endpoint.parseJson: bad input") {
     assert(Endpoint.parseJson("hello, world!").isEmpty)
+  }
+
+  test("Endpoint.parseJson: ok curator input") {
+    val eps = Endpoint.parseJson(exampleCuratorJson)
+    assert(
+      eps ==
+        Seq(Endpoint(Array(null), "10.0.0.1", port, Int.MinValue, Endpoint.Status.Alive, "")))
   }
 }


### PR DESCRIPTION
I suspect a final implementation of this will look a bit different, but the code I've included here can be treated as a minimal straw man for solving the problem.

At Salesforce we have a mixed service discovery environment, with some services announcing via [Curator's Discovery Service](http://curator.apache.org/curator-x-discovery/) and others using Finagle's serversets. Currently we're maintaining an internal Finagle fork with the changes necessary to consume those records, but it would be great if we could get those changes merged back into mainline.

