### PR TITLE
finagle-mysql: ability to toggle CLIENT_FOUND_ROWS flag

### DIFF
--- a/finagle-mysql/src/main/scala/com/twitter/finagle/Mysql.scala
+++ b/finagle-mysql/src/main/scala/com/twitter/finagle/Mysql.scala
@@ -182,6 +182,14 @@ object Mysql extends com.twitter.finagle.Client[Request, Result] with MysqlRichC
     def withCharset(charset: Short): Client =
       configured(Handshake.Charset(charset))
 
+    /**
+      * Don't set the CLIENT_FOUND_ROWS flag when connected to the
+      * server. This will make "INSERT ... ON DUPLICATE KEY UPDATE"
+      * statements return the "correct" update count.
+      */
+    def withAffectedRows(): Client =
+      configured(Handshake.FoundRows(false))
+
     // Java-friendly forwarders
     // See https://issues.scala-lang.org/browse/SI-8905
     override val withSessionPool: SessionPoolingParams[Client] =

--- a/finagle-mysql/src/main/scala/com/twitter/finagle/Mysql.scala
+++ b/finagle-mysql/src/main/scala/com/twitter/finagle/Mysql.scala
@@ -183,9 +183,11 @@ object Mysql extends com.twitter.finagle.Client[Request, Result] with MysqlRichC
       configured(Handshake.Charset(charset))
 
     /**
-      * Don't set the CLIENT_FOUND_ROWS flag when connected to the
-      * server. This will make "INSERT ... ON DUPLICATE KEY UPDATE"
+      * Don't set the CLIENT_FOUND_ROWS flag when establishing a new
+      * session. This will make "INSERT ... ON DUPLICATE KEY UPDATE"
       * statements return the "correct" update count.
+      *
+      * See https://dev.mysql.com/doc/refman/5.7/en/information-functions.html#function_row-count
       */
     def withAffectedRows(): Client =
       configured(Handshake.FoundRows(false))

--- a/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Handshake.scala
+++ b/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Handshake.scala
@@ -101,7 +101,8 @@ object Handshake {
  * @param charset default character established with the server.
  *
  * @param enableFoundRows if the server should return the number
- * of found (matched) rows, not the number of changed rows.
+ * of found (matched) rows, not the number of changed rows for
+ * UPDATE and INSERT ... ON DUPLICATE KEY UPDATE statements.
  *
  * @param maxPacketSize max size of a command packet that the
  * client intends to send to the server. The largest possible


### PR DESCRIPTION
**Summary:** Added `withAffectedRows()` function to the MySQL client which when used, will disable the `CLIENT_FOUND_ROWS` flag.

**Note: This change was made on the master branch since there was a dependency issue with the scrooge-sbt-plugin.**

**Problem**

Original issue: #637

Unable to change the `CLIENT_FOUND_ROWS` flag. The flag (which `finagle-mysql` enables by default) changes the behavior of affected-rows for `UPDATE` and `INSERT ... ON DUPLICATE KEY UPDATE` statements.

From the [manual](https://dev.mysql.com/doc/refman/5.7/en/information-functions.html#function_found-rows) (v5.7):

For [UPDATE](https://dev.mysql.com/doc/refman/5.7/en/update.html) statements, the affected-rows value by default is the number of rows actually changed. If you specify the `CLIENT_FOUND_ROWS` flag to [mysql_real_connect()](https://dev.mysql.com/doc/refman/5.7/en/mysql-real-connect.html) when connecting to [mysqld](https://dev.mysql.com/doc/refman/5.7/en/mysqld.html), the affected-rows value is the number of rows “found”; that is, matched by the `WHERE` clause.

For [INSERT ... ON DUPLICATE KEY UPDATE](https://dev.mysql.com/doc/refman/5.7/en/insert-on-duplicate.html) statements, the affected-rows value per row is 1 if the row is inserted as a new row, 2 if an existing row is updated, and 0 if an existing row is set to its current values. If you specify the `CLIENT_FOUND_ROWS` flag, the affected-rows value is 1 (not 0) if an existing row is set to its current values.

**Solution**

Added `withAffectedRows()` on `Mysql.client` which when used removes the `FoundRows` capability when connecting to the server.

My implementation adds another argument to the `Handshake` case class to follow how `ConnectWithDB` is handled. I've also considered checking for the param in `Handshake.apply` and if added passing it with `Capability.baseCap - Capability.FoundRows`.