### PR TITLE
Ensures 128bit trace IDs are propagated in outbound http requests

### DIFF
--- a/finagle-base-http/src/main/scala/com/twitter/finagle/http/TraceInfo.scala
+++ b/finagle-base-http/src/main/scala/com/twitter/finagle/http/TraceInfo.scala
@@ -67,7 +67,12 @@ private object TraceInfo {
     removeAllHeaders(request.headerMap)
 
     val traceId = Trace.id
-    request.headerMap.add(Header.TraceId, traceId.traceId.toString)
+    val traceIdString = if (traceId.traceIdHigh.isEmpty) {
+      traceId.traceId.toString
+    } else {
+      traceId.traceIdHigh.get.toString + traceId.traceId.toString
+    }
+    request.headerMap.add(Header.TraceId, traceIdString)
     request.headerMap.add(Header.SpanId, traceId.spanId.toString)
     // no parent id set means this is the root span
     traceId._parentId match {
@@ -81,7 +86,9 @@ private object TraceInfo {
         request.headerMap.add(Header.Sampled, sampled.toString)
       case None => ()
     }
-    request.headerMap.add(Header.Flags, JLong.toString(traceId.flags.toLong))
+    if (traceId.flags.toLong != 0L) {
+      request.headerMap.add(Header.Flags, JLong.toString(traceId.flags.toLong))
+    }
     traceRpc(request)
   }
 

--- a/finagle-base-http/src/test/scala/com/twitter/finagle/http/TraceInfoTest.scala
+++ b/finagle-base-http/src/test/scala/com/twitter/finagle/http/TraceInfoTest.scala
@@ -1,0 +1,82 @@
+package com.twitter.finagle.http
+
+import com.twitter.finagle.tracing._
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class TraceInfoTest extends FunSuite {
+
+  // The only use-case for flags is the debug flag. Don't burn headers on an edge case
+  test("setClientRequestHeaders doesn't set header on default flags") {
+    val traceContext = TraceId(None, None, SpanId(0xabc), None)
+    val req = Request(Method.Get, "/")
+
+    Trace.letId(traceContext) {
+      TraceInfo.setClientRequestHeaders(req)
+    }
+
+    assert(req.headerMap.get("X-B3-Flags").isEmpty)
+  }
+
+  // None is represented by lack of header in B3
+  test("setClientRequestHeaders doesn't set header on no sampling decision") {
+    val sampled = None
+    val traceContext = TraceId(None, None, SpanId(0xabc), sampled)
+    val req = Request(Method.Get, "/")
+
+    Trace.letId(traceContext) {
+      TraceInfo.setClientRequestHeaders(req)
+    }
+
+    assert(req.headerMap.get("X-B3-Sampled").isEmpty)
+  }
+
+  // It is important to propagate IDs downstream even when not sampled, for log correlation
+  test("setClientRequestHeaders with parent ID even when not sampled") {
+    val req = Request(Method.Get, "/")
+
+    val traceContext =
+      TraceId(Some(SpanId(0xabc)), Some(SpanId(0xdef)), SpanId(0x123), Some(false), Flags(0))
+    Trace.letId(traceContext) {
+      TraceInfo.setClientRequestHeaders(req)
+    }
+
+    assert(req.headerMap == HeaderMap(
+      "X-B3-TraceId" -> "0000000000000abc",
+      "X-B3-ParentSpanId" -> "0000000000000def",
+      "X-B3-SpanId" -> "0000000000000123",
+      "X-B3-Sampled" -> "false"
+    ))
+  }
+
+  // Particularly headers like parent ID need to be removed when a request is processed twice
+  test("setClientRequestHeaders clears old headers when no trace") {
+    val req = Request(Method.Get, "/")
+    req.headerMap.put("X-B3-TraceId", "0000000000000abc")
+    req.headerMap.put("X-B3-ParentSpanId", "0000000000000def")
+    req.headerMap.put("X-B3-SpanId", "0000000000000123")
+    req.headerMap.put("X-B3-Sampled", "false")
+    req.headerMap.put("X-B3-Flags", "1")
+
+    // clears and starts an unsampled trace
+    TraceInfo.setClientRequestHeaders(req)
+
+    assert(req.headerMap.keys == Set( "X-B3-TraceId", "X-B3-SpanId"))
+  }
+
+  test("setClientRequestHeaders writes 128-bit trace ID") {
+    val req = Request(Method.Get, "/")
+
+    val traceContext = TraceId(Some(SpanId(0xb)), None, SpanId(0x1), None, Flags(), Some(SpanId(0xa)))
+    Trace.letId(traceContext) {
+      TraceInfo.setClientRequestHeaders(req)
+    }
+
+    assert(req.headerMap == HeaderMap(
+      "X-B3-TraceId" -> "000000000000000a000000000000000b",
+      "X-B3-SpanId" -> "0000000000000001"
+    ))
+  }
+}

--- a/finagle-core/src/main/scala/com/twitter/finagle/tracing/Id.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/tracing/Id.scala
@@ -203,7 +203,7 @@ object TraceId {
  *                decision to someone further down in the stack.
  * @param flags Flags relevant to this request. Could be things like debug mode on/off. The sampled flag could eventually
  *              be moved in here.
- * @param _traceIdHigh The high 64bits of the id for this request, when the id is 128bits.
+ * @param traceIdHigh The high 64bits of the id for this request, when the id is 128bits.
  */
 final case class TraceId(
   _traceId: Option[SpanId],


### PR DESCRIPTION
Problem

When `com.twitter.finagle.tracing.traceId128Bit=true` outbound requests don't include the entire trace ID, rather only the lower 64 bits. This can result in broken traces, depending on if Zipkin is set to operate tolerantly.

Solution

This was due to a missed change where we missed setting the trace ID header according to `traceIdHigh`. This fixes that and backfills tests

Result

`X-B3-TraceId` values should be 32 lowerhex length when `com.twitter.finagle.tracing.traceId128Bit=true` and a new trace is sent downstream

See #651
