### PR TITLE
finagle-redis: Redis cluster management

### DIFF
--- a/finagle-redis/src/it/scala/com/twitter/finagle/redis/ClusterTest.scala
+++ b/finagle-redis/src/it/scala/com/twitter/finagle/redis/ClusterTest.scala
@@ -1,0 +1,185 @@
+package com.twitter.finagle.redis
+
+import com.twitter.finagle.Redis
+import com.twitter.finagle.redis.protocol.ClusterNode
+import com.twitter.finagle.redis.util.{RedisCluster, RedisMode}
+import com.twitter.io.Buf
+import com.twitter.util.{Await, Future}
+import java.net.InetSocketAddress
+import org.scalatest.BeforeAndAfterAll
+
+trait ClusterClientTest extends RedisTest with BeforeAndAfterAll {
+
+  val TotalHashSlots: Int = 16384
+  val LastHashSlot: Int = TotalHashSlots-1
+
+  val primaryCount: Int
+
+  val replicasPerPrimary: Int = 1
+
+  lazy val serverCount = primaryCount + primaryCount * replicasPerPrimary
+
+  override def beforeAll(): Unit = {
+    RedisCluster.start(count = serverCount, mode = RedisMode.Cluster)
+  }
+
+  override def afterAll(): Unit = RedisCluster.stopAll()
+
+  protected def assertSlots(client: ClusterClient, expected: Seq[(Int, Int)]): Unit =  {
+    val id = Await.result(client.nodeId()).get
+    val slots = Await.result(client.slots)
+
+    val slotsOnId = slots.filter(_.master.id == Some(id))
+    assert(slotsOnId.size == expected.size)
+
+    val orderedSlots = slotsOnId.map(s => (s.start, s.end)).sorted
+    assert(orderedSlots == expected)
+  }
+
+  protected def assertEqualInfo(clients: Seq[ClusterClient], expected: Seq[(String, String)])
+    (f: ClusterClient => Future[Map[String, String]]): Unit = {
+    for(client <- clients) {
+      val info = Await.result(f(client))
+
+      // make sure info contains all (k,v)-pairs from expected
+      assert(info.filter(expected.contains(_)).size == expected.size)
+    }
+  }
+
+  // Starts and configures a cluster with primaryCount*replicasPerPrimary servers
+  // - All servers know each other
+  // - The list of slot ranges are assigned round robin to the primaries
+  //   Start and end of the range are inclusive
+  //   Defaults to assigning all slots to the primary with index 0
+  protected def startCluster(slots: Seq[(Int, Int)] = Seq()): Unit = {
+    val allSlots = if(slots.size == 0) Seq((0, LastHashSlot)) else slots
+
+    // check if all slots are covered
+    val coveredSlots = allSlots.map { case (start, end) => (start to end) }.flatten
+    assert(coveredSlots.size == TotalHashSlots)
+    assert(coveredSlots.sorted == (0 until TotalHashSlots))
+
+    val clients: Seq[ClusterClient] = (0 until serverCount).map(newClusterClient)
+    val primaries = clients.slice(0, primaryCount)
+    val replicas = clients.slice(primaryCount, clients.size)
+
+    // assign all slots to the primaries (first primaryCount servers)
+    for(((start, end), index) <- allSlots.zipWithIndex) {
+      Await.result(primaries(index % primaryCount).addSlots((start to end)))
+    }
+
+    // let the nodes meet each other
+    for((client, index) <- clients.zipWithIndex) {
+      // take the next client in the ring 
+      val nextServer = RedisCluster.address((index + 1) % clients.size).get
+      Await.result(client.meet(nextServer))
+    }
+
+    // make sure that all servers know the cluster config
+    waitUntilAsserted("Cluster slot assignment and meet completed") {
+      val expected = Seq(
+        "cluster_known_nodes" -> serverCount.toString,
+        // number of primaries that have slots assigned
+        "cluster_size" -> Math.min(allSlots.size, primaryCount).toString,
+        "cluster_slots_assigned" -> TotalHashSlots.toString,
+        "cluster_slots_ok" -> TotalHashSlots.toString)
+
+      assertEqualInfo(clients, expected)(_.clusterInfo)
+    }
+
+    // assign replicas to their primaries (round-robin)
+    for((client, index) <- replicas.zipWithIndex) {
+      val primaryId = Await.result(primaries(index % primaryCount).nodeId())
+      assert(primaryId.nonEmpty)
+      Await.result(client.replicate(primaryId.get))
+    }
+
+    // check that all primaries have replicas connected
+    waitUntilAsserted("Primaries are connected with replicas") {
+      val expected = Seq(
+        "role" -> "master",
+        "connected_slaves" -> replicasPerPrimary.toString)
+
+      assertEqualInfo(primaries, expected)(_.infoMap)
+    }
+
+    // check that all replicas are connected to primaries
+    waitUntilAsserted("Replicas are connected with primaries") {
+      val expected = Seq(
+        "role" -> "slave",
+        "master_link_status" -> "up"
+      )
+
+      assertEqualInfo(replicas, expected)(_.infoMap)
+    }
+
+    // Finally, lets wait for the entire cluster to be ok
+    waitUntilAsserted("All servers report that the cluster is ok") {
+      assertEqualInfo(clients, Seq("cluster_state" -> "ok"))(_.clusterInfo)
+    }
+
+    clients.foreach(_.close())
+  }
+
+  private def migrateSlotKeys(src: ClusterClient, destAddr: InetSocketAddress, slot: Int): Future[Unit] = {
+    def migrateKeys(keys: Seq[Buf]): Future[Unit] = {
+      if(keys.size == 0) Future.Unit
+      else {
+        for {
+          _ <- src.migrate(destAddr, keys)
+          _ <- migrateSlotKeys(src, destAddr, slot)
+        } yield ()
+      }
+    }
+
+    for {
+      keys <- src.getKeysInSlot(slot)
+      _ <- migrateKeys(keys)
+    } yield ()
+
+  }
+
+
+
+  private def reshardSingle(a: ClusterClient, aId: String, b: ClusterClient, bNode: ClusterNode)(slot: Int): Future[Unit] = for {
+    // The protocol has four steps:
+    // https://redis.io/commands/cluster-setslot#redis-cluster-live-resharding-explained
+ 
+    // 1. We send B: CLUSTER SETSLOT 10 IMPORTING A (propose)
+    _ <- b.setSlotImporting(slot, aId)
+
+    // 2. We send A: CLUSTER SETSLOT 10 MIGRATING B (accept)
+    _ <- a.setSlotMigrating(slot, bNode.id.get)
+
+    // 3. Migrate data when it exists
+    _ <- migrateSlotKeys(a, bNode.addr, slot)
+
+    // 4. Send both A, B: CLUSTER SETSLOT 10 NODE B (commit)
+    _ <- a.setSlotNode(slot, bNode.id.get)
+    _ <- b.setSlotNode(slot, bNode.id.get)
+  } yield ()
+
+  protected def reshard(a: ClusterClient, b: ClusterClient, slots: Seq[Int]): Future[Unit] = for {
+    aId <- a.nodeId()
+    bNode <- b.node()
+    _ <- Future.join(slots.map(reshardSingle(a, aId.get, b, bNode.get)))
+  } yield ()
+
+  
+  private def newClusterClient(index: Int): ClusterClient = {
+    ClusterClient(
+      Redis.client.newClient(RedisCluster.hostAddresses(from = index, until = index + 1))
+    )
+  }
+ 
+  protected def withClusterClient(index: Int)(testCode: ClusterClient => Any) {
+    val client = newClusterClient(index)
+    try { testCode(client) } finally { client.close() }
+  }
+
+  protected def withClusterClients(indices: Int*)(testCode: Seq[ClusterClient] => Any) {
+    val clients = indices.map(newClusterClient)
+    try { testCode(clients) } finally { clients.foreach(_.close()) }
+  }
+
+}

--- a/finagle-redis/src/it/scala/com/twitter/finagle/redis/commands/cluster/ClusterClientIntegrationSuite.scala
+++ b/finagle-redis/src/it/scala/com/twitter/finagle/redis/commands/cluster/ClusterClientIntegrationSuite.scala
@@ -1,0 +1,138 @@
+package com.twitter.finagle.redis.integration
+
+import com.twitter.conversions.time._
+import com.twitter.finagle.redis.{ClusterClient, ClusterClientTest, ServerError}
+import com.twitter.finagle.redis.tags.{ClientTest, RedisTest}
+import com.twitter.finagle.redis.util.{BufToString, RedisCluster}
+import com.twitter.finagle.util.DefaultTimer
+import com.twitter.io.Buf
+import com.twitter.logging.Logger
+import com.twitter.util.{Await, Awaitable, Future, Time}
+import org.junit.Ignore
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@Ignore
+@RunWith(classOf[JUnitRunner])
+final class ClusterClientIntegrationSuite extends ClusterClientTest {
+
+  // Generate hash keys/slots for testing:
+  // while true; do r=`openssl rand -hex 4`;
+  // s=`echo "cluster keyslot $r" | redis-cli | cut -f2`; echo "$s,$r"; done
+
+  val primaryCount: Int = 2
+
+  test("Correctly retrieve CLUSTER INFO", RedisTest, ClientTest) {
+    withClusterClient(0) { client =>
+      val info = Await.result(client.clusterInfo)
+
+      // cluster info has 11 entries
+      assert(info.size == 11)
+      assert(info.contains("cluster_size"))
+    }
+  }
+
+  test("Correctly retrieve empty slots using SLOTS", RedisTest, ClientTest) {
+    withClusterClient(0) { client =>
+      val slots = Await.result(client.slots)
+
+      assert(slots == Seq())
+    }
+  }
+
+  test("Correctly assign slots to a server using ADDSLOTS", RedisTest, ClientTest) {
+    withClusterClient(0) { client =>
+      // assign a single slot
+      Await.result(client.addSlots(Seq(0)))
+      val slotSingle = Await.result(client.slots)
+      assert(slotSingle.size == 1)
+      assert(slotSingle.head.start == 0 && slotSingle.head.end == 0)
+ 
+      Await.result(client.addSlots((1 until 100)))
+      val slotRange = Await.result(client.slots)
+      assert(slotRange.size == 1)
+      assert(slotRange.head.start == 0 && slotRange.head.end == 99)
+ 
+      val info = Await.result(client.clusterInfo)
+
+      assert(info.get("cluster_slots_assigned") == Some("100"))
+    }
+  }
+
+  test("Correctly retrieve assigned slots using SLOTS", RedisTest, ClientTest) {
+    withClusterClient(0) { client =>
+      val slots = Await.result(client.slots)
+
+      assert(slots.size == 1)
+      val s = slots.head
+      assert(s.start == 0 && s.end == 99 && s.master.addr.getHostName == "localhost" && s.replicas.size == 0)
+    }
+  }
+
+  test("Return an error when using REPLICATE on a replica that does not know the primary", RedisTest, ClientTest) {
+    withClusterClients(0, primaryCount) { case Seq(primary, replica) =>
+      // select the first backup as a replica
+      val primaryId = Await.result(primary.nodeId())
+
+      assert(primaryId.nonEmpty)
+
+      // should throw a server error since the replica does not yet know the primary
+      val error = intercept[ServerError](Await.result(replica.replicate(primaryId.get)))
+
+      assert(error.getMessage == (s"ERR Unknown node ${primaryId.get}"))
+    }
+  }
+
+  test("Correctly MEET a primary and a replica", RedisTest, ClientTest) {
+    withClusterClients(0, primaryCount) { case Seq(primary, replica) =>
+      // select the first backup as a replica
+      val replicaAddr = RedisCluster.address(primaryCount).get
+
+      Await.result(primary.meet(replicaAddr))
+
+      waitUntilAsserted("Cluster size updated") {
+        val primaryInfo = Await.result(primary.clusterInfo)
+        val replicaInfo = Await.result(replica.clusterInfo)
+        assert(primaryInfo.get("cluster_known_nodes") == Some("2"))
+        assert(replicaInfo.get("cluster_known_nodes") == Some("2"))
+
+        // cluster is still of size 1 since it includes primaries only
+        assert(primaryInfo.get("cluster_size") == Some("1"))
+        assert(replicaInfo.get("cluster_size") == Some("1"))
+      }
+    }
+  }
+
+  test("Correctly return the list of nodes with NODES", RedisTest, ClientTest) {
+    withClusterClients(0, primaryCount) { case Seq(primary, replica) =>
+      // select the first backup as a replica
+      val primaryNodes = Await.result(primary.nodes())
+      val replicaNodes = Await.result(replica.nodes())
+
+      assert(primaryNodes.size == 2)
+      assert(replicaNodes.size == 2)
+      assert(primaryNodes.filter(_.isMyself).head.id !=
+        replicaNodes.filter(_.isMyself).head.id)
+    }
+  }
+
+  test("Correctly assign a node as replica using REPLICATE", RedisTest, ClientTest) {
+    withClusterClients(0, primaryCount) { case Seq(primary, replica) =>
+      // select the first backup as a replica
+      val primaryId = Await.result(primary.nodeId())
+
+      assert(primaryId.nonEmpty)
+
+      Await.result(replica.replicate(primaryId.get))
+
+      waitUntilAsserted("Replication complete") {
+        val primaryInfo = Await.result(primary.infoMap())
+        assert(primaryInfo.get("role") == Some("master"))
+        assert(primaryInfo.get("connected_slaves") == Some("1"))
+
+        val replicaInfo = Await.result(replica.infoMap())
+        assert(replicaInfo.get("role") == Some("slave"))
+      }
+    }
+  }
+}

--- a/finagle-redis/src/it/scala/com/twitter/finagle/redis/commands/cluster/ClusterClientReshardingIntegrationSuite.scala
+++ b/finagle-redis/src/it/scala/com/twitter/finagle/redis/commands/cluster/ClusterClientReshardingIntegrationSuite.scala
@@ -1,0 +1,49 @@
+package com.twitter.finagle.redis.integration
+
+import com.twitter.conversions.time._
+import com.twitter.finagle.redis.{ClusterClient, ClusterClientTest, ServerError}
+import com.twitter.finagle.redis.tags.{ClientTest, RedisTest}
+import com.twitter.finagle.redis.util.{BufToString, RedisCluster}
+import com.twitter.finagle.util.DefaultTimer
+import com.twitter.io.Buf
+import com.twitter.logging.Logger
+import com.twitter.util.{Await, Awaitable, Future, Time}
+import org.junit.Ignore
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@Ignore
+@RunWith(classOf[JUnitRunner])
+final class ClusterClientReshardingIntegrationSuite extends ClusterClientTest {
+
+  // Generate hash keys/slots for testing:
+  // while true; do r=`openssl rand -hex 4`;
+  // s=`echo "cluster keyslot $r" | redis-cli | cut -f2`; echo "$s,$r"; done
+
+  val primaryCount: Int = 2
+
+  // Resharding is depending on a correctly started/configured cluster
+  test("Cluster is configured and started correctly", RedisTest, ClientTest) {
+    startCluster()
+  }
+
+
+  test("Correctly hand over a slot to another primary using SETSLOT", RedisTest, ClientTest) {
+    withClusterClients(0, 1) { case Seq(a, b) =>
+      val key = Buf.Utf8("6ff70029")
+      val value = Buf.Utf8("foo")
+
+      Await.result(a.set(key, value))
+
+      // hand over slot 42 from a to b
+      Await.result(reshard(a, b, Seq(42)))
+
+      // B is responsible for slot 42
+      waitUntilAsserted("A is responsible for slot 0-41, 43-16383 and B for 42") {
+        assertSlots(a, Seq((0, 41), (43, LastHashSlot)))
+        assertSlots(b, Seq((42, 42)))
+      }
+    }
+  }
+}
+

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/ClusterClient.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/ClusterClient.scala
@@ -1,0 +1,27 @@
+package com.twitter.finagle.redis
+
+import com.twitter.finagle.redis.protocol._
+import com.twitter.finagle.ServiceFactory
+
+private[redis] object ClusterClient {
+  /**
+   * Construct a client client from a single host.
+   * @param host a String of host:port combination.
+   */
+  def apply(host: String): ClusterClient = {
+    ClusterClient(com.twitter.finagle.Redis.newClient(host))
+  }
+
+  /**
+   * Construct a cluster client from a single Service.
+   */
+  def apply(raw: ServiceFactory[Command, Reply]): ClusterClient =
+    new ClusterClient(raw)
+}
+
+private[redis] class ClusterClient(factory: ServiceFactory[Command, Reply])
+    extends BaseClient(factory)
+    with BasicServerCommands
+    with KeyCommands
+    with StringCommands
+    with ClusterCommands

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/ClusterCommands.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/ClusterCommands.scala
@@ -1,0 +1,230 @@
+package com.twitter.finagle.redis
+
+import com.twitter.finagle.redis.protocol.StatusReply
+import com.twitter.io.{Buf, ByteReader}
+import com.twitter.util.Future
+import com.twitter.finagle.redis.protocol._
+import com.twitter.finagle.redis.util.{BufToString, ReplyFormat, StringToBuf}
+import java.net.InetSocketAddress
+import java.nio.charset.StandardCharsets.UTF_8
+
+private[redis] trait ClusterCommands { self: BaseClient with BasicServerCommands =>
+
+  private def toInfoMap(buf: Buf): Map[String, String] = {
+    def readAll(acc: Map[String, String], reader: ByteReader): Map[String, String] = {
+      reader.remainingUntil('\r') match {
+        case -1 => acc
+        case n =>
+          val newAcc = reader.readString(n, UTF_8).split(":") match {
+            case Array(key, value) => acc + (key -> value)
+            case _ => acc
+          }
+
+          // jump past the '\r\n'
+          reader.skip(2)
+          readAll(newAcc, reader)
+      }
+    }
+
+    readAll(Map(), ByteReader(buf)) 
+  }
+
+  private def toInt(entry: Reply): Int = entry match {
+    case IntegerReply(v) => v.toInt
+    case _ =>
+      val msg = ReplyFormat.toString(List(entry))
+      throw new ClusterDecodeError(s"Could not extract an Integer from $msg")
+  }
+
+  private def toString(entry: Reply): String = entry match {
+    case BulkReply(v) => BufToString(v)
+    case _ =>
+      val msg = ReplyFormat.toString(List(entry))
+      throw new ClusterDecodeError(s"Could not extract a String from $msg")
+  }
+
+
+  private def toNode(entry: Reply): ClusterNode = entry match {
+    // early versions only had name and port, new versions include an id
+    case MBulkReply(name :: port :: opts) =>
+      ClusterNode(
+        host = toString(name),
+        port = toInt(port),
+        id = opts.headOption.map(toString))
+
+    case _ =>
+      val msg = ReplyFormat.toString(List(entry))
+      throw new ClusterDecodeError(s"Could not extract a Cluster Node from $msg")
+  }
+
+
+  private def toSlots(entries: List[Reply]): Seq[Slots] =
+    entries.map {
+      case MBulkReply(start :: end :: master :: replicas) =>
+        Slots(
+          start = toInt(start),
+          end = toInt(end),
+          master = toNode(master),
+          replicas = replicas.map(toNode))
+
+      case _ =>
+        val msg = ReplyFormat.toString(entries)
+        throw new ClusterDecodeError(s"Could not extract Cluster Slots from $msg")
+    }
+
+  private def toNodes(buf: Buf): Seq[ClusterNode] = {
+    def readAll(acc: Seq[ClusterNode], reader: ByteReader): Seq[ClusterNode] = {
+      reader.remainingUntil('\n') match {
+        case -1 => acc
+        case n =>
+          val newAcc = reader.readString(n, UTF_8).split(" ").toList match {
+            case nodeId :: hostPort :: flags :: master :: pingSent :: pongRecv :: epoch :: linkState :: slots =>
+              val Array(host, portClusterPort) = hostPort.split(":")
+              // support for 4.0 which has a different format: <host>:<port>@<cluster bus port>
+              val port = portClusterPort.split("@").head
+              acc :+ ClusterNode(host, port.toInt, id = Some(nodeId), flags = flags.split(",").toSeq)
+            case _ => acc
+          }
+
+          // jump past the '\n'
+          reader.skip(1)
+          readAll(newAcc, reader)
+      }
+    }
+
+    readAll(Seq(), ByteReader(buf))
+  }
+
+  /**
+   * Add a list of slots this server is responsible for
+   * @param slots
+   * @return unit
+   */
+  def addSlots(slots: Seq[Int]): Future[Unit] =
+    doRequest(AddSlots(slots)) {
+      case StatusReply(_) => Future.Unit
+    }
+
+  /**
+   * Set the state for this slot
+   * @param command The new slot state
+   * @param slot
+   * @param destinationId the target node id
+   * @return unit
+   */
+  def setSlot(state: SetSlotState, slot: Int, destinationId: Option[String]): Future[Unit] =
+    doRequest(SetSlot(state, slot, destinationId)) {
+      case StatusReply(_) => Future.Unit
+    }
+
+  /**
+   * Set this slot to be migrating
+   * @param slot
+   * @param destinationId the target node id
+   * @return unit
+   */
+  def setSlotMigrating(slot: Int, destinationId: String): Future[Unit] =
+    setSlot(SetSlotState.Migrating, slot, Some(destinationId))
+
+  /**
+   * Set this slot to be importing
+   * @param slot
+   * @param destinationId the source node id
+   * @return unit
+   */
+  def setSlotImporting(slot: Int, sourceId: String): Future[Unit] =
+    setSlot(SetSlotState.Importing, slot, Some(sourceId))
+
+  /**
+   * Set the slot to be associated with a node
+   * @param slot
+   * @param ownerId the source node id
+   * @return unit
+   */
+  def setSlotNode(slot: Int, ownerId: String): Future[Unit] =
+    setSlot(SetSlotState.Node, slot, Some(ownerId))
+
+  /**
+   * Returns the cluster info
+   * @return A key, value map with the cluster info
+   */
+  def clusterInfo(): Future[Map[String, String]] =
+    doRequest(ClusterInfo()) {
+      case BulkReply(message) => Future.value(toInfoMap(message))
+      case EmptyBulkReply => Future.value(Map())
+    }
+
+  /**
+   * Returns a list of slots known by the server
+   * @return A list of slots
+   */
+  def slots(): Future[Seq[Slots]] =
+    doRequest(ClusterSlots()) {
+      case MBulkReply(entries) =>
+        Future.value(toSlots(entries))
+      case EmptyMBulkReply => Future.Nil
+    }
+
+  /**
+   * Returns a list of nodes known by the server
+   * @return A list of cluster nodes
+   */
+  def nodes(): Future[Seq[ClusterNode]] =
+    doRequest(Nodes()) {
+      case BulkReply(entries) => Future.value(toNodes(entries))
+      case EmptyBulkReply => Future.Nil
+    }
+
+  /**
+   * Returns a list of keys stored by a slot on this server
+   * @param slot the slot id
+   * @param count number of keys to return, default is 10
+   * @return A list of key bufs
+   */
+  def getKeysInSlot(slot: Int, count: Int = 10): Future[Seq[Buf]] =
+    doRequest(GetKeysInSlot(slot, count)) {
+      case MBulkReply(keys) => Future.value(ReplyFormat.toBuf(keys))
+      case EmptyMBulkReply => Future.Nil
+    }
+
+  /**
+   * Instructs the server to become a replica of the given node
+   * @param nodeId
+   * @return unit
+   */
+  def replicate(nodeId: String): Future[Unit] =
+    doRequest(Replicate(nodeId)) {
+      case StatusReply(_) => Future.Unit
+    }
+
+  /**
+   * Return the cluster node id of the server
+   * @return optional node id
+   */
+  def nodeId(): Future[Option[String]] =
+    node().map(_.flatMap(_.id))
+
+  /**
+   * Return the cluster node for this server
+   * @return optional node cluster node
+   */
+  def node(): Future[Option[ClusterNode]] =
+    nodes().map(_.filter(_.isMyself).headOption)
+
+  /**
+   * Returns the server info
+   * @return A key, value map with the server info
+   */
+  def infoMap(): Future[Map[String, String]] =
+    info().map(_.map(toInfoMap(_)).getOrElse(Map()))
+
+  /**
+   * Instructs this cluster server to meet another server
+   * @param addr InetSocketAddress of the server to meet
+   * @return unit
+   */
+  def meet(addr: InetSocketAddress): Future[Unit] =
+    doRequest(Meet(addr)) {
+      case StatusReply(_) => Future.Unit
+    }
+}

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/Exceptions.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/Exceptions.scala
@@ -7,3 +7,8 @@ case class ClientError(message: String) extends Exception(message)
  * An error caused by failing to cast [[com.twitter.finagle.redis.protocol.Reply]] to a target type
  */
 case class ReplyCastFailure(message: String) extends Exception(message)
+
+/**
+ * Thrown when the response from a cluster management command could not be decoded correctly.
+ */
+case class ClusterDecodeError(message: String) extends Exception(message)

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/KeyCommands.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/KeyCommands.scala
@@ -1,12 +1,14 @@
 package com.twitter.finagle.redis
 
 import java.lang.{Boolean => JBoolean, Long => JLong}
+import java.net.InetSocketAddress
 import com.twitter.finagle.redis.protocol._
 import com.twitter.finagle.redis.util.ReplyFormat
 import com.twitter.io.Buf
-import com.twitter.util.{Future, Time}
+import com.twitter.util.{Duration, Future, Time}
 
 private[redis] trait KeyCommands { self: BaseClient =>
+  import com.twitter.conversions.time._
 
   /**
    * Removes keys
@@ -74,6 +76,20 @@ private[redis] trait KeyCommands { self: BaseClient =>
       case MBulkReply(messages) => Future.value(ReplyFormat.toBuf(messages))
       case EmptyMBulkReply => Future.Nil
     }
+
+  /**
+   * Migrates all keys to the destination server
+   * @param destAddr target redis server
+   * @param keys list of keys to be migrated
+   * @param timeout timeout before failing, defaults to 5 seconds
+   * @return unit
+   */
+  def migrate(destAddr: InetSocketAddress, keys: Seq[Buf], timeout: Duration = 5.seconds): Future[Unit] = {
+    doRequest(Migrate(destAddr, keys, timeout)) {
+      case StatusReply(_) => Future.Unit
+      case ErrorReply(msg) => Future.exception(new ServerError(msg))
+    }
+  }
 
   /**
    * Move key from the currently selected database to the specified destination

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/Command.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/Command.scala
@@ -111,6 +111,7 @@ object Command {
   val SLAVEOF = Buf.Utf8("SLAVEOF")
   val CONFIG = Buf.Utf8("CONFIG")
   val SENTINEL = Buf.Utf8("SENTINEL")
+  val CLUSTER = Buf.Utf8("CLUSTER")
   val DBSIZE = Buf.Utf8("DBSIZE")
 
   // Scripts
@@ -148,6 +149,7 @@ object Command {
   val EXPIRE = Buf.Utf8("EXPIRE")
   val EXPIREAT = Buf.Utf8("EXPIREAT")
   val KEYS = Buf.Utf8("KEYS")
+  val MIGRATE = Buf.Utf8("MIGRATE")
   val MOVE = Buf.Utf8("MOVE")
   val PERSIST = Buf.Utf8("PERSIST")
   val PEXPIRE = Buf.Utf8("PEXPIRE")

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/Cluster.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/Cluster.scala
@@ -1,0 +1,58 @@
+package com.twitter.finagle.redis.protocol
+
+import java.net.InetSocketAddress
+import com.twitter.io.Buf
+
+// data structure for slots
+object ClusterNode {
+  def apply(host: String, port: Int, id: Option[String] = None, flags: Seq[String] = Seq()) =
+    new ClusterNode(new InetSocketAddress(host, port), id, flags)
+}
+
+case class ClusterNode(
+  addr: InetSocketAddress,
+  id: Option[String],
+  flags: Seq[String]) {
+  def isMyself(): Boolean =
+    flags.contains("myself")
+}
+
+case class Slots(start: Int, end: Int, master: ClusterNode, replicas: Seq[ClusterNode])
+
+case class AddSlots(slots: Seq[Int])
+  extends Cluster("ADDSLOTS", slots.map(_.toString))
+
+sealed trait SetSlotState
+
+object SetSlotState {
+  case object Migrating extends SetSlotState
+  case object Importing extends SetSlotState
+  case object Stable extends SetSlotState
+  case object Node extends SetSlotState
+}
+
+case class SetSlot(command: SetSlotState, slot: Int, nodeId: Option[String])
+  extends Cluster("SETSLOT", Seq(slot.toString, command.toString.toUpperCase) ++ nodeId)
+
+case class ClusterInfo() extends Cluster("INFO")
+
+case class ClusterSlots() extends Cluster("SLOTS")
+
+case class Replicate(nodeId: String)
+  extends Cluster("REPLICATE", Seq(nodeId))
+
+case class Meet(addr: InetSocketAddress)
+  extends Cluster("MEET", Seq(addr.getAddress.getHostAddress, addr.getPort.toString))
+
+case class GetKeysInSlot(slot: Int, count: Int)
+  extends Cluster("GETKEYSINSLOT", Seq(slot.toString, count.toString))
+
+case class Nodes() extends Cluster("NODES")
+
+abstract class Cluster(sub: String, args: Seq[String] = Seq()) extends Command {
+  def name: Buf = Command.CLUSTER
+
+  override def body: Seq[Buf] = {
+    Buf.Utf8(sub) +: args.map(Buf.Utf8.apply)
+  }
+}

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/util/TestServer.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/util/TestServer.scala
@@ -1,6 +1,6 @@
 package com.twitter.finagle.redis.util
 
-import java.net.InetSocketAddress
+import java.net.{InetSocketAddress, Socket}
 import java.io.{BufferedWriter, FileWriter, PrintWriter, File}
 import com.twitter.finagle.Redis
 import com.twitter.finagle.redis.Client
@@ -74,10 +74,12 @@ object RedisMode {
   case object Sentinel extends RedisMode
   case object Cluster extends RedisMode
 }
+
 class ExternalRedis(mode: RedisMode = RedisMode.Standalone) {
   private[this] val rand = new Random
   private[this] var process: Option[Process] = None
-  private[this] val forbiddenPorts = 6300.until(7300)
+  private[this] val forbiddenPorts = 6300.until(7300) ++ 55535.until(65535)
+  private[this] val possiblePorts = 49152.until(55535)
   var address: Option[InetSocketAddress] = None
 
   private[this] def assertRedisBinaryPresent() {
@@ -88,27 +90,57 @@ class ExternalRedis(mode: RedisMode = RedisMode.Standalone) {
   }
 
   private[this] def findAddress() {
-    var tries = 100
+    var tries = possiblePorts.size-1
     while (address.isEmpty && tries >= 0) {
-      address = Some(RandomSocket.nextAddress())
-      if (forbiddenPorts.contains(address.get.getPort)) {
-        address = None
-        tries -= 1
-        Thread.sleep(5)
+      val addr = new InetSocketAddress(possiblePorts(tries))
+      val socket = new Socket
+
+      try {
+        socket.setReuseAddress(true)
+        socket.bind(addr)
+        address = Some(addr)
+      } catch {
+        case exc: Exception =>
+          address = None
+          tries -= 1
+          Thread.sleep(5) 
+      } finally {
+        socket.close()
       }
     }
     address.getOrElse { sys.error("Couldn't get an address for the external redis instance") }
   }
 
   protected def createConfigFile(port: Int): File = {
-    val f = File.createTempFile("redis-" + rand.nextInt(1000), ".tmp")
-    f.deleteOnExit()
-    val out = new PrintWriter(new BufferedWriter(new FileWriter(f)))
-    val conf = "port %s".format(port)
+    val confFile = File.createTempFile("redis-" + rand.nextInt(1000), ".tmp")
+    val nodesFile = File.createTempFile("redis-nodes-" + rand.nextInt(1000), ".tmp")
+    val appendFile = File.createTempFile("redis-append-" + rand.nextInt(1000), ".aof")
+    val dbFile = File.createTempFile("redis-db-" + rand.nextInt(1000), ".db")
+
+    confFile.deleteOnExit()
+    nodesFile.deleteOnExit()
+    appendFile.deleteOnExit()
+    dbFile.deleteOnExit()
+
+    val out = new PrintWriter(new BufferedWriter(new FileWriter(confFile)))
+    var conf = "port %s".format(port)
+
+    if (mode == RedisMode.Cluster) {
+      conf += s"""
+cluster-enabled yes
+cluster-config-file ${nodesFile.getAbsolutePath}
+cluster-node-timeout 5000
+appendonly yes
+dir ${appendFile.getParent}
+appendfilename ${appendFile.getName}
+dbfilename ${dbFile.getName}
+"""
+    }
+
     out.write(conf)
     out.println()
     out.close()
-    f
+    confFile
   }
 
   def start() {

--- a/finagle-redis/src/test/scala/com/twitter/finagle/redis/RedisTest.scala
+++ b/finagle-redis/src/test/scala/com/twitter/finagle/redis/RedisTest.scala
@@ -384,3 +384,4 @@ trait SentinelClientTest extends RedisTest with BeforeAndAfterAll {
     try { testCode(client) } finally { client.close() }
   }
 }
+

--- a/finagle-redis/src/test/scala/com/twitter/finagle/redis/commands/key/KeyCodecSuite.scala
+++ b/finagle-redis/src/test/scala/com/twitter/finagle/redis/commands/key/KeyCodecSuite.scala
@@ -3,7 +3,8 @@ package com.twitter.finagle.redis.protocol
 import com.twitter.finagle.redis.RedisRequestTest
 import com.twitter.finagle.redis.tags.CodecTest
 import com.twitter.io.Buf
-import com.twitter.util.Time
+import com.twitter.util.{Duration, Time}
+import java.net.InetSocketAddress
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -14,6 +15,14 @@ final class KeyCodecSuite extends RedisRequestTest {
   test("DUMP", CodecTest) { checkSingleKey("DUMP", Dump.apply) }
   test("EXISTS", CodecTest) { checkSingleKey("EXISTS", Exists.apply) }
   test("KEYS", CodecTest) { checkSingleKey("KEYS", Keys.apply) }
+  test("MIGRATE", CodecTest) {
+    val a = new InetSocketAddress("127.0.0.1", 9999)
+    val k = Seq(Buf.Utf8("foo"))
+    val ks = Seq(Buf.Utf8("foo"), Buf.Utf8("bar"))
+    val d = Duration.fromMilliseconds(5000)
+    assert(encodeCommand(Migrate(a, k, d)) == Seq("MIGRATE", "127.0.0.1", "9999", "", "0", "5000", "KEYS", "foo"))
+    assert(encodeCommand(Migrate(a, ks, d)) == Seq("MIGRATE", "127.0.0.1", "9999", "", "0", "5000", "KEYS", "foo", "bar"))
+  }
   test("MOVE", CodecTest) { checkSingleKeySingleVal("MOVE", Move.apply) }
   test("PERSIST", CodecTest) { checkSingleKey("PERSIST", Persist.apply) }
   test("RENAME", CodecTest) { checkSingleKeySingleVal("RENAME", Rename.apply) }


### PR DESCRIPTION
Problem

The current finagle-redis client does not have support for the CLUSTER commands introduced in Redis 3.0.0.

Solution

This adds support for a number of new cluster commands that are necessary to setup and manage a redis cluster.

- CLUSTER ADDSLOT, assigns a storage slot to a server
- CLUSTER SETSLOT, updates the state of a slot
- CLUSTER SLOTS, returns a list of slots known to the server
- CLUSTER GETKEYSINSLOT, returns keys stored in a slot
- CLUSTER REPLICATE, changes a node to become a replica of a server
- CLUSTER MEET, introduces cluster nodes to each other
- CLUSTER NODES, returns the list of cluster nodes known to the server
- CLUSTER INFO, returns the cluster specific info
- MIGRATE, used to transfer keys to another node

Result

Using the introduced commands it is possible to setup a redis cluster for testing and live re-sharding. This is the first step in implementing the redis cluster client protocol. The next step is to handle operation redirects, i.e. when the server returns ASK or MOVED.