### PR TITLE
Don't calculate the hashcode of Stream in Budget

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/service/Retries.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/service/Retries.scala
@@ -60,6 +60,28 @@ object Retries {
 
     def mk(): (Budget, Stack.Param[Budget]) =
       (this, Budget)
+
+    def canEqual(other: Any): Boolean = other.isInstanceOf[Budget]
+
+    /**
+      * The equals method only compares the retryBudget field of this instance,
+      * since the requeueBackoffs Stream[Duration] is possibly infinite,
+      * resulting in an infinite computation to compare for equality.
+      */
+    override def equals(other: Any): Boolean = other match {
+      case that: Budget =>
+        (that canEqual this) &&
+          retryBudget == that.retryBudget
+      case _ => false
+    }
+
+    /**
+      * For the hashCode of this class we only take into account the hashCode of the RetryBudget field.
+      * The requeueBackoffs Stream[Duration] is possibly infinite,
+      * resulting in an infinite computation to get to the hashCode.
+      */
+    override def hashCode(): Int =
+      retryBudget.##
   }
 
   object Budget extends Stack.Param[Budget] {

--- a/finagle-core/src/test/scala/com/twitter/finagle/service/RetriesTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/service/RetriesTest.scala
@@ -423,4 +423,18 @@ class RetriesTest extends FunSuite {
 
     factory()
   }
+
+  test("hashCode and equals for Retries.Budget only checks RetryBudget, not Backoff stream") {
+    val budget = Retries.Budget(RetryBudget.Empty, Backoff.const(1.second))
+    val budgetWithDifferentBackoffStream = Retries.Budget(RetryBudget.Empty, Backoff.const(2.second))
+    val differentBudget = Retries.Budget(RetryBudget.Infinite, Backoff.const(3.second))
+
+    assert(budget.equals(budget))
+    assert(budget.equals(budgetWithDifferentBackoffStream))
+    assert(! budget.equals(differentBudget))
+
+    assert(budget.## == budget.##)
+    assert(budget.## == budgetWithDifferentBackoffStream.##)
+    assert(budget.## != differentBudget.##)
+  }
 }


### PR DESCRIPTION
# Problem

Calculating the hashcode of an instance of Retries.Budget could end up
in an infinite computation.
Since the case class gave us a default implementation including all
fields, including the requeueBackoffs field with a possibly infinite
Stream[Duration], we need to override this behaviour.

# Solution

This is done by ignoring the fact that there is a field with a Stream.
The equality of the class is implemented with
http://www.artima.com/lejava/articles/equality.html in mind.

# Result

```scala
val client2 = Http.client.withRetryBackoff(Backoff.const(10.seconds))
println(s"$client2 with hashcode ${client2.hashCode}")
```
successfully returns a hashcode, fixing the 'bug' behaviour.
Closes #669.