### PR TITLE
Update netty versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ val releaseVersion = "18.3.0-SNAPSHOT"
 
 val libthriftVersion = "0.5.0-7"
 
-val netty4Version = "4.1.16.Final"
+val netty4Version = "4.1.21.Final"
 
 // zkVersion should be kept in sync with the 'util-zk' dependency version
 val zkVersion = "3.5.0-alpha"
@@ -14,7 +14,7 @@ val zkVersion = "3.5.0-alpha"
 val caffeineLib = "com.github.ben-manes.caffeine" % "caffeine" % "2.3.4"
 val hdrHistogramLib = "org.hdrhistogram" % "HdrHistogram" % "2.1.10"
 val jsr305Lib = "com.google.code.findbugs" % "jsr305" % "2.0.1"
-val netty3Lib = "io.netty" % "netty" % "3.10.1.Final"
+val netty3Lib = "io.netty" % "netty" % "3.10.6.Final"
 val netty4Libs = Seq(
   "io.netty" % "netty-handler" % netty4Version,
   "io.netty" % "netty-transport" % netty4Version,

--- a/finagle-http2/src/main/scala/io/netty/handler/codec/http2/UpgradeMultiplexCodecBuilder.scala
+++ b/finagle-http2/src/main/scala/io/netty/handler/codec/http2/UpgradeMultiplexCodecBuilder.scala
@@ -19,10 +19,14 @@ private class UpgradeMultiplexCodecBuilder(
         ctx: ChannelHandlerContext,
         stream: Http2FrameStream,
         bytes: Int
-      ): Unit = {
+      ): Boolean = {
         // opt out of flow control for the h2c upgrade--it's actually an http/1.1 message
-        if (stream.id() != 1)
+        if (stream.id() != 1) {
           consumeBytes(stream.id(), bytes)
+          true
+        } else {
+          false
+        }
       }
     }
 }


### PR DESCRIPTION
## Problem

Finagle is potentially vulnerable to CVE-2015-2156.

## Solution

Bump the `netty` versions to versions that are unaffected by the CVE.

Modify the code where there were incompatibilities with class inheritance.

Fixes #665

## Result

Finagle will no longer be affected by the CVE.
