### PR TITLE
serversets: Preserve host/ip provided in serveIface

### DIFF
--- a/finagle-serversets/src/main/java/com/twitter/finagle/common/zookeeper/ServerSets.java
+++ b/finagle-serversets/src/main/java/com/twitter/finagle/common/zookeeper/ServerSets.java
@@ -78,6 +78,6 @@ public final class ServerSets {
    * @param address the target address to create the endpoint for
    */
   public static Endpoint toEndpoint(InetSocketAddress address) {
-    return new Endpoint(address.getHostName(), address.getPort());
+    return new Endpoint(address.getHostString(), address.getPort());
   }
 }


### PR DESCRIPTION
Problem

I'm deploying Finagle ThriftMux with Zookeeper ServerSets inside Kubernetes and pod hostname is being set as the host in Zookeeper instead of the IP of the pod which is what I'm binding to when initing the ThrifMux server.

Solution

In k8s `getHostName` returns the name of the pod which is not 
accessible from other pods in the cluster. `getHostString` 
returns the IP of the pod.

Fixes #684
