### PR TITLE
Support javax.net.ssl.[Key|Trust]Manager in Key and Trust credentials.

### DIFF
--- a/finagle-core/src/main/java/com/twitter/finagle/ssl/KeyCredentialsConfig.java
+++ b/finagle-core/src/main/java/com/twitter/finagle/ssl/KeyCredentialsConfig.java
@@ -1,7 +1,7 @@
 package com.twitter.finagle.ssl;
 
-import javax.net.ssl.KeyManagerFactory;
 import java.io.File;
+import javax.net.ssl.KeyManagerFactory;
 
 /**
  * Java APIs for {@link KeyCredentials}.
@@ -35,10 +35,10 @@ public final class KeyCredentialsConfig {
   }
 
   /**
-   * See {@link KeyCredentials.FromKeyManager}
-   * @see KeyCredentials.FromKeyManager // Refactor to use @see instead?
+   * See {@link KeyCredentials.KeyManagerFactory}
+   * @see KeyCredentials.KeyManagerFactory
    */
-  public static KeyCredentials fromKeyManagerFactory(KeyManagerFactory keyManagerFactory) {
-    return new KeyCredentials.FromKeyManager(keyManagerFactory);
+  public static KeyCredentials keyManagerFactory(KeyManagerFactory keyManagerFactory) {
+    return new KeyCredentials.KeyManagerFactory(keyManagerFactory);
   }
 }

--- a/finagle-core/src/main/java/com/twitter/finagle/ssl/KeyCredentialsConfig.java
+++ b/finagle-core/src/main/java/com/twitter/finagle/ssl/KeyCredentialsConfig.java
@@ -36,7 +36,6 @@ public final class KeyCredentialsConfig {
 
   /**
    * See {@link KeyCredentials.KeyManagerFactory}
-   * @see KeyCredentials.KeyManagerFactory
    */
   public static KeyCredentials keyManagerFactory(KeyManagerFactory keyManagerFactory) {
     return new KeyCredentials.KeyManagerFactory(keyManagerFactory);

--- a/finagle-core/src/main/java/com/twitter/finagle/ssl/KeyCredentialsConfig.java
+++ b/finagle-core/src/main/java/com/twitter/finagle/ssl/KeyCredentialsConfig.java
@@ -1,5 +1,6 @@
 package com.twitter.finagle.ssl;
 
+import javax.net.ssl.KeyManagerFactory;
 import java.io.File;
 
 /**
@@ -33,4 +34,11 @@ public final class KeyCredentialsConfig {
     return new KeyCredentials.CertKeyAndChain(certificateFile, keyFile, caCertificateFile);
   }
 
+  /**
+   * See {@link KeyCredentials.FromKeyManager}
+   * @see KeyCredentials.FromKeyManager // Refactor to use @see instead?
+   */
+  public static KeyCredentials fromKeyManagerFactory(KeyManagerFactory keyManagerFactory) {
+    return new KeyCredentials.FromKeyManager(keyManagerFactory);
+  }
 }

--- a/finagle-core/src/main/java/com/twitter/finagle/ssl/TrustCredentialsConfig.java
+++ b/finagle-core/src/main/java/com/twitter/finagle/ssl/TrustCredentialsConfig.java
@@ -1,5 +1,6 @@
 package com.twitter.finagle.ssl;
 
+import javax.net.ssl.TrustManagerFactory;
 import java.io.File;
 
 /**
@@ -28,6 +29,13 @@ public final class TrustCredentialsConfig {
    */
   public static TrustCredentials certCollection(File file) {
     return new TrustCredentials.CertCollection(file);
+  }
+
+  /**
+   * See {@link TrustCredentials.FromTrustManagerFactory}
+   */
+  public static TrustCredentials fromTrustManagerFactory(TrustManagerFactory trustManagerFactory) {
+    return new TrustCredentials.FromTrustManagerFactory(trustManagerFactory);
   }
 
 }

--- a/finagle-core/src/main/java/com/twitter/finagle/ssl/TrustCredentialsConfig.java
+++ b/finagle-core/src/main/java/com/twitter/finagle/ssl/TrustCredentialsConfig.java
@@ -1,7 +1,7 @@
 package com.twitter.finagle.ssl;
 
-import javax.net.ssl.TrustManagerFactory;
 import java.io.File;
+import javax.net.ssl.TrustManagerFactory;
 
 /**
  * Java APIs for {@link TrustCredentials}.
@@ -32,10 +32,10 @@ public final class TrustCredentialsConfig {
   }
 
   /**
-   * See {@link TrustCredentials.FromTrustManagerFactory}
+   * See {@link TrustCredentials.TrustManagerFactory}
    */
-  public static TrustCredentials fromTrustManagerFactory(TrustManagerFactory trustManagerFactory) {
-    return new TrustCredentials.FromTrustManagerFactory(trustManagerFactory);
+  public static TrustCredentials trustManagerFactory(TrustManagerFactory trustManagerFactory) {
+    return new TrustCredentials.TrustManagerFactory(trustManagerFactory);
   }
 
 }

--- a/finagle-core/src/main/scala/com/twitter/finagle/ssl/KeyCredentials.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/ssl/KeyCredentials.scala
@@ -1,8 +1,7 @@
 package com.twitter.finagle.ssl
 
 import java.io.File
-
-import javax.net.ssl.KeyManagerFactory
+import javax.net.ssl
 
 /**
  * KeyCredentials represent the items necessary for this configured
@@ -52,8 +51,9 @@ object KeyCredentials {
       extends KeyCredentials
 
   /**
-   *
-   * @param keyManagerFactory
+   * Indicates that this [[ssl.KeyManagerFactory]] should be used by
+   * the engine factory.
+   * @param keyManagerFactory A factory able of constructing the KeyManagers
    */
-  case class FromKeyManager(keyManagerFactory: KeyManagerFactory) extends KeyCredentials
+  case class KeyManagerFactory(keyManagerFactory: ssl.KeyManagerFactory) extends KeyCredentials
 }

--- a/finagle-core/src/main/scala/com/twitter/finagle/ssl/KeyCredentials.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/ssl/KeyCredentials.scala
@@ -2,6 +2,8 @@ package com.twitter.finagle.ssl
 
 import java.io.File
 
+import javax.net.ssl.KeyManagerFactory
+
 /**
  * KeyCredentials represent the items necessary for this configured
  * TLS [[Engine]] to authenticate itself to a remote peer. This
@@ -48,4 +50,10 @@ object KeyCredentials {
    */
   case class CertKeyAndChain(certificateFile: File, keyFile: File, caCertificateFile: File)
       extends KeyCredentials
+
+  /**
+   *
+   * @param keyManagerFactory
+   */
+  case class FromKeyManager(keyManagerFactory: KeyManagerFactory) extends KeyCredentials
 }

--- a/finagle-core/src/main/scala/com/twitter/finagle/ssl/SslConfigurations.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/ssl/SslConfigurations.scala
@@ -157,7 +157,7 @@ private[ssl] object SslConfigurations {
         )
       case KeyCredentials.KeyManagerFactory(_) =>
         throw SslConfigurationException.notSupported(
-          "KeyCredentials.FromKeyManager",
+          "KeyCredentials.KeyManagerFactory",
           engineFactoryName
         )
     }

--- a/finagle-core/src/main/scala/com/twitter/finagle/ssl/SslConfigurations.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/ssl/SslConfigurations.scala
@@ -21,19 +21,19 @@ private[ssl] object SslConfigurations {
   def getKeyManagers(keyCredentials: KeyCredentials): Option[Array[KeyManager]] =
     keyCredentials match {
       case KeyCredentials.Unspecified => None
-      case KeyCredentials.CertAndKey(certFile, keyFile)     =>
+      case KeyCredentials.CertAndKey(certFile, keyFile) =>
         val factory = new Pkcs8KeyManagerFactory(certFile, keyFile)
         val tryKms = factory.getKeyManagers()
         tryKms match {
           case Return(kms) => Some(kms)
           case Throw(ex) => throw SslConfigurationException(ex)
         }
-      case _: KeyCredentials.CertKeyAndChain                =>
+      case _: KeyCredentials.CertKeyAndChain =>
         throw SslConfigurationException.notSupported(
           "KeyCredentials.CertKeyAndChain",
           "SslConfigurations"
         )
-      case KeyCredentials.FromKeyManager(keyManagerFactory) =>
+      case KeyCredentials.KeyManagerFactory(keyManagerFactory) =>
         Some(keyManagerFactory.getKeyManagers)
     }
 
@@ -60,6 +60,8 @@ private[ssl] object SslConfigurations {
           case Return(tms) => Some(tms)
           case Throw(ex) => throw SslConfigurationException(ex)
         }
+      case TrustCredentials.TrustManagerFactory(trustManagerFactory) =>
+        Some(trustManagerFactory.getTrustManagers)
     }
 
   /**
@@ -145,15 +147,15 @@ private[ssl] object SslConfigurations {
     keyCredentials: KeyCredentials
   ): Unit =
     keyCredentials match {
-      case KeyCredentials.Unspecified              => // Do Nothing
-      case KeyCredentials.CertAndKey(_, _)         =>
+      case KeyCredentials.Unspecified => // Do Nothing
+      case KeyCredentials.CertAndKey(_, _) =>
         throw SslConfigurationException.notSupported("KeyCredentials.CertAndKey", engineFactoryName)
       case KeyCredentials.CertKeyAndChain(_, _, _) =>
         throw SslConfigurationException.notSupported(
           "KeyCredentials.CertKeyAndChain",
           engineFactoryName
         )
-      case KeyCredentials.FromKeyManager(_)        =>
+      case KeyCredentials.KeyManagerFactory(_) =>
         throw SslConfigurationException.notSupported(
           "KeyCredentials.FromKeyManager",
           engineFactoryName
@@ -177,6 +179,8 @@ private[ssl] object SslConfigurations {
           "TrustCredentials.CertCollection",
           engineFactoryName
         )
+      case TrustCredentials.TrustManagerFactory(_) =>
+        throw SslConfigurationException.notSupported("TrustCredentials.TrustManagerFactory", engineFactoryName)
     }
 
   /**

--- a/finagle-core/src/main/scala/com/twitter/finagle/ssl/TrustCredentials.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/ssl/TrustCredentials.scala
@@ -1,8 +1,7 @@
 package com.twitter.finagle.ssl
 
 import java.io.File
-
-import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl
 
 /**
  * TrustCredentials represent the items necessary for this configured
@@ -32,15 +31,19 @@ object TrustCredentials {
    * The collection of certificates which should be used in
    * verifying a remote peer's credentials.
    *
-   * @file A file containing a collection of X.509 certificates
-   * in PEM format.
+   * @param file A file containing a collection of X.509 certificates
+   *             in PEM format.
    */
   case class CertCollection(file: File) extends TrustCredentials
 
 
   /**
+   * Indicates that the trust credentials from the [[ssl.TrustManagerFactory]]
+   * should be used in verifying a remote peer's credentials.
    *
-   * @param trustManagerFactory
+   * @param trustManagerFactory the factory delivering the TrustManager for
+   *                            validation
    */
-  case class FromTrustManagerFactory(trustManagerFactory: TrustManagerFactory) extends TrustCredentials
+  case class TrustManagerFactory(trustManagerFactory: ssl.TrustManagerFactory) extends TrustCredentials
+
 }

--- a/finagle-core/src/main/scala/com/twitter/finagle/ssl/TrustCredentials.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/ssl/TrustCredentials.scala
@@ -2,6 +2,8 @@ package com.twitter.finagle.ssl
 
 import java.io.File
 
+import javax.net.ssl.TrustManagerFactory
+
 /**
  * TrustCredentials represent the items necessary for this configured
  * TLS [[Engine]] to verify a remote peer's credentials.
@@ -34,4 +36,11 @@ object TrustCredentials {
    * in PEM format.
    */
   case class CertCollection(file: File) extends TrustCredentials
+
+
+  /**
+   *
+   * @param trustManagerFactory
+   */
+  case class FromTrustManagerFactory(trustManagerFactory: TrustManagerFactory) extends TrustCredentials
 }

--- a/finagle-core/src/test/scala/com/twitter/finagle/ssl/SslConfigurationsTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/ssl/SslConfigurationsTest.scala
@@ -120,6 +120,7 @@ class SslConfigurationsTest extends FunSuite {
         ex.cause.getMessage
     )
   }
+  //todo: AV
 
   test("checkTrustCredentialsNotSupported throws for CertCollection") {
     val trustCredentials = TrustCredentials.CertCollection(null)

--- a/finagle-core/src/test/scala/com/twitter/finagle/ssl/SslConfigurationsTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/ssl/SslConfigurationsTest.scala
@@ -120,7 +120,17 @@ class SslConfigurationsTest extends FunSuite {
         ex.cause.getMessage
     )
   }
-  //todo: AV
+
+  test("checkTrustCredentialsNotSupported throws for TrustManagerFactory") {
+    val trustCredentials = TrustCredentials.TrustManagerFactory(null)
+    val ex = intercept[SslConfigurationException] {
+      SslConfigurations.checkTrustCredentialsNotSupported("TestFactory", trustCredentials)
+    }
+    assert(
+      "TrustCredentials.TrustManagerFactory is not supported at this time for TestFactory" ==
+        ex.cause.getMessage
+    )
+  }
 
   test("checkTrustCredentialsNotSupported throws for CertCollection") {
     val trustCredentials = TrustCredentials.CertCollection(null)

--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/Netty4SslConfigurations.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/Netty4SslConfigurations.scala
@@ -25,6 +25,11 @@ private[finagle] object Netty4SslConfigurations {
    * @note TrustCredentials.Unspecified does not change the builder,
    * as it is not possible to set the trustManager to use the system
    * trust credentials, like with the JDK engine factories.
+   *
+   * @todo Is the note above still true?
+   *       AFAIK, we can do
+   *       `TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)``
+   *       to get the default system trust credentials.
    */
   def configureTrust(
     builder: SslContextBuilder,
@@ -37,6 +42,8 @@ private[finagle] object Netty4SslConfigurations {
         builder.trustManager(InsecureTrustManagerFactory.INSTANCE)
       case TrustCredentials.CertCollection(file) =>
         builder.trustManager(file)
+      case TrustCredentials.FromTrustManagerFactory(trustManagerFactory) =>
+        builder.trustManager(trustManagerFactory)
     }
   }
 

--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/Netty4SslConfigurations.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/Netty4SslConfigurations.scala
@@ -23,13 +23,6 @@ private[finagle] object Netty4SslConfigurations {
    * method mutates the `SslContextBuilder`, and returns it as the result.
    *
    * @note TrustCredentials.Unspecified does not change the builder,
-   * as it is not possible to set the trustManager to use the system
-   * trust credentials, like with the JDK engine factories.
-   *
-   * @todo Is the note above still true?
-   *       AFAIK, we can do
-   *       `TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)``
-   *       to get the default system trust credentials.
    */
   def configureTrust(
     builder: SslContextBuilder,
@@ -42,7 +35,7 @@ private[finagle] object Netty4SslConfigurations {
         builder.trustManager(InsecureTrustManagerFactory.INSTANCE)
       case TrustCredentials.CertCollection(file) =>
         builder.trustManager(file)
-      case TrustCredentials.FromTrustManagerFactory(trustManagerFactory) =>
+      case TrustCredentials.TrustManagerFactory(trustManagerFactory) =>
         builder.trustManager(trustManagerFactory)
     }
   }

--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/client/Netty4ClientSslConfigurations.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/client/Netty4ClientSslConfigurations.scala
@@ -59,6 +59,8 @@ private[finagle] object Netty4ClientSslConfigurations {
           cert <- new X509CertificateFile(certFile).readX509Certificate()
           chain <- new X509CertificateFile(chainFile).readX509Certificates()
         } yield builder.keyManager(key, cert +: chain: _*)
+      case KeyCredentials.FromKeyManager(keyManagerFactory) =>
+        Return(builder.keyManager(keyManagerFactory))
     }
     Netty4SslConfigurations.unwrapTryContextBuilder(withKey)
   }

--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/client/Netty4ClientSslConfigurations.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/client/Netty4ClientSslConfigurations.scala
@@ -48,7 +48,7 @@ private[finagle] object Netty4ClientSslConfigurations {
     val withKey = keyCredentials match {
       case KeyCredentials.Unspecified =>
         Return(builder) // Do Nothing
-      case KeyCredentials.CertAndKey(certFile, keyFile) =>
+      case KeyCredentials.CertAndKey(certFile, keyFile)                 =>
         for {
           key <- new PrivateKeyFile(keyFile).readPrivateKey()
           cert <- new X509CertificateFile(certFile).readX509Certificate()
@@ -59,7 +59,7 @@ private[finagle] object Netty4ClientSslConfigurations {
           cert <- new X509CertificateFile(certFile).readX509Certificate()
           chain <- new X509CertificateFile(chainFile).readX509Certificates()
         } yield builder.keyManager(key, cert +: chain: _*)
-      case KeyCredentials.FromKeyManager(keyManagerFactory) =>
+      case KeyCredentials.KeyManagerFactory(keyManagerFactory)          =>
         Return(builder.keyManager(keyManagerFactory))
     }
     Netty4SslConfigurations.unwrapTryContextBuilder(withKey)

--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/server/Netty4ServerSslConfigurations.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/server/Netty4ServerSslConfigurations.scala
@@ -50,7 +50,7 @@ private[finagle] object Netty4ServerSslConfigurations {
           "KeyCredentials.Unspecified",
           "Netty4ServerEngineFactory"
         )
-      case KeyCredentials.CertAndKey(certFile, keyFile) =>
+      case KeyCredentials.CertAndKey(certFile, keyFile)                 =>
         for {
           key <- new PrivateKeyFile(keyFile).readPrivateKey()
           cert <- new X509CertificateFile(certFile).readX509Certificate()
@@ -61,7 +61,7 @@ private[finagle] object Netty4ServerSslConfigurations {
           cert <- new X509CertificateFile(certFile).readX509Certificate()
           chain <- new X509CertificateFile(chainFile).readX509Certificates()
         } yield SslContextBuilder.forServer(key, cert +: chain: _*)
-      case KeyCredentials.FromKeyManager(keyManagerFactory) =>
+      case KeyCredentials.KeyManagerFactory(keyManagerFactory)          =>
         Return(SslContextBuilder.forServer(keyManagerFactory))
     }
     Netty4SslConfigurations.unwrapTryContextBuilder(builder)

--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/server/Netty4ServerSslConfigurations.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/server/Netty4ServerSslConfigurations.scala
@@ -42,6 +42,10 @@ private[finagle] object Netty4ServerSslConfigurations {
    * @note `KeyCredentials` must be specified, using `Unspecified` is not supported.
    * @note An `SslConfigurationException` will be thrown if there is an issue loading
    * the certificate(s) or private key.
+   *
+   * @note Will not validate the validity for certificates when configured
+   *       with [[KeyCredentials.KeyManagerFactory]] in contrast to when
+   *       configured with [[KeyCredentials.CertAndKey]] or [[KeyCredentials.CertKeyAndChain]].
    */
   private def startServerWithKey(keyCredentials: KeyCredentials): SslContextBuilder = {
     val builder = keyCredentials match {
@@ -50,7 +54,7 @@ private[finagle] object Netty4ServerSslConfigurations {
           "KeyCredentials.Unspecified",
           "Netty4ServerEngineFactory"
         )
-      case KeyCredentials.CertAndKey(certFile, keyFile)                 =>
+      case KeyCredentials.CertAndKey(certFile, keyFile) =>
         for {
           key <- new PrivateKeyFile(keyFile).readPrivateKey()
           cert <- new X509CertificateFile(certFile).readX509Certificate()
@@ -61,7 +65,7 @@ private[finagle] object Netty4ServerSslConfigurations {
           cert <- new X509CertificateFile(certFile).readX509Certificate()
           chain <- new X509CertificateFile(chainFile).readX509Certificates()
         } yield SslContextBuilder.forServer(key, cert +: chain: _*)
-      case KeyCredentials.KeyManagerFactory(keyManagerFactory)          =>
+      case KeyCredentials.KeyManagerFactory(keyManagerFactory) =>
         Return(SslContextBuilder.forServer(keyManagerFactory))
     }
     Netty4SslConfigurations.unwrapTryContextBuilder(builder)

--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/server/Netty4ServerSslConfigurations.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/server/Netty4ServerSslConfigurations.scala
@@ -1,13 +1,9 @@
 package com.twitter.finagle.netty4.ssl.server
 
 import com.twitter.finagle.netty4.ssl.Netty4SslConfigurations
-import com.twitter.finagle.ssl.{
-  ApplicationProtocols,
-  Engine,
-  KeyCredentials,
-  SslConfigurationException
-}
+import com.twitter.finagle.ssl.{ApplicationProtocols, Engine, KeyCredentials, SslConfigurationException}
 import com.twitter.finagle.ssl.server.{SslServerConfiguration, SslServerEngineFactory}
+import com.twitter.util.Return
 import com.twitter.util.security.{PrivateKeyFile, X509CertificateFile}
 import io.netty.buffer.ByteBufAllocator
 import io.netty.handler.ssl.{SslContext, SslContextBuilder}
@@ -65,6 +61,8 @@ private[finagle] object Netty4ServerSslConfigurations {
           cert <- new X509CertificateFile(certFile).readX509Certificate()
           chain <- new X509CertificateFile(chainFile).readX509Certificates()
         } yield SslContextBuilder.forServer(key, cert +: chain: _*)
+      case KeyCredentials.FromKeyManager(keyManagerFactory) =>
+        Return(SslContextBuilder.forServer(keyManagerFactory))
     }
     Netty4SslConfigurations.unwrapTryContextBuilder(builder)
   }

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/client/Netty4ClientEngineFactoryTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/client/Netty4ClientEngineFactoryTest.scala
@@ -7,7 +7,6 @@ import com.twitter.io.TempFile
 import java.io.File
 import java.net.InetSocketAddress
 import java.security.{KeyStore, Security}
-
 import javax.net.ssl.{KeyManagerFactory, TrustManagerFactory}
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
@@ -128,11 +127,11 @@ class Netty4ClientEngineFactoryTest extends FunSuite {
     assert(sslEngine != null)
   }
 
-  test("config with TrustManager succeeds") {
+  test("config with TrustManagerFactory succeeds") {
     val trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
     trustManagerFactory.init(null.asInstanceOf[KeyStore])
 
-    val trustCredentials = TrustCredentials.FromTrustManagerFactory(trustManagerFactory)
+    val trustCredentials = TrustCredentials.TrustManagerFactory(trustManagerFactory)
     val config = SslClientConfiguration(trustCredentials = trustCredentials)
     val engine = factory(address, config)
     val sslEngine = engine.self
@@ -140,11 +139,11 @@ class Netty4ClientEngineFactoryTest extends FunSuite {
     assert(sslEngine != null)
   }
 
-  test("config with KeyManager succeeds") {
+  test("config with KeyManagerFactory succeeds") {
     val keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm)
     keyManagerFactory.init(null, Array[Char]())
 
-    val keyCredentials = KeyCredentials.FromKeyManager(keyManagerFactory)
+    val keyCredentials = KeyCredentials.KeyManagerFactory(keyManagerFactory)
     val config = SslClientConfiguration(keyCredentials = keyCredentials)
     val engine = factory(address, config)
     val sslEngine = engine.self

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/client/Netty4ClientEngineFactoryTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/client/Netty4ClientEngineFactoryTest.scala
@@ -6,6 +6,9 @@ import com.twitter.finagle.ssl.client.SslClientConfiguration
 import com.twitter.io.TempFile
 import java.io.File
 import java.net.InetSocketAddress
+import java.security.{KeyStore, Security}
+
+import javax.net.ssl.{KeyManagerFactory, TrustManagerFactory}
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
@@ -119,6 +122,30 @@ class Netty4ClientEngineFactoryTest extends FunSuite {
 
     val trustCredentials = TrustCredentials.CertCollection(tempCertFile)
     val config = SslClientConfiguration(trustCredentials = trustCredentials)
+    val engine = factory(address, config)
+    val sslEngine = engine.self
+
+    assert(sslEngine != null)
+  }
+
+  test("config with TrustManager succeeds") {
+    val trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
+    trustManagerFactory.init(null.asInstanceOf[KeyStore])
+
+    val trustCredentials = TrustCredentials.FromTrustManagerFactory(trustManagerFactory)
+    val config = SslClientConfiguration(trustCredentials = trustCredentials)
+    val engine = factory(address, config)
+    val sslEngine = engine.self
+
+    assert(sslEngine != null)
+  }
+
+  test("config with KeyManager succeeds") {
+    val keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm)
+    keyManagerFactory.init(null, Array[Char]())
+
+    val keyCredentials = KeyCredentials.FromKeyManager(keyManagerFactory)
+    val config = SslClientConfiguration(keyCredentials = keyCredentials)
     val engine = factory(address, config)
     val sslEngine = engine.self
 

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/server/Netty4ServerEngineFactoryTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/server/Netty4ServerEngineFactoryTest.scala
@@ -5,8 +5,6 @@ import com.twitter.finagle.ssl.server.SslServerConfiguration
 import com.twitter.io.TempFile
 import java.io.File
 import java.security.KeyStore
-
-import com.twitter.finagle.ssl.client.SslClientConfiguration
 import javax.net.ssl.{KeyManagerFactory, TrustManagerFactory}
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
@@ -116,19 +114,32 @@ class Netty4ServerEngineFactoryTest extends FunSuite {
     }
   }
 
-  test("config with KeyManager succeeds") {
-    // ToDo: Should we also create tests / build the functionality that the keymanagers are rejected if containing expired certs
-
+  test("config with TrustManagerFactory and KeyManagerFactory succeeds") {
     val trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
     trustManagerFactory.init(null.asInstanceOf[KeyStore])
 
-    val trustCredentials = TrustCredentials.FromTrustManagerFactory(trustManagerFactory)
+    val trustCredentials = TrustCredentials.TrustManagerFactory(trustManagerFactory)
 
     val keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm)
     keyManagerFactory.init(null, Array[Char]())
 
-    val keyCredentials = KeyCredentials.FromKeyManager(keyManagerFactory)
+    val keyCredentials = KeyCredentials.KeyManagerFactory(keyManagerFactory)
+
     val config = SslServerConfiguration(trustCredentials = trustCredentials, keyCredentials = keyCredentials)
+    val engine = factory(config)
+    val sslEngine = engine.self
+
+    assert(sslEngine != null)
+  }
+
+  test("config with only KeyCredentials succeeds") {
+    // ToDo: Should we also create tests / build the functionality that the keymanagers are rejected if containing expired certs
+
+    val keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm)
+    keyManagerFactory.init(null, Array[Char]())
+
+    val keyCredentials = KeyCredentials.KeyManagerFactory(keyManagerFactory)
+    val config = SslServerConfiguration(keyCredentials = keyCredentials)
     val engine = factory(config)
     val sslEngine = engine.self
 

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/server/Netty4ServerEngineFactoryTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/server/Netty4ServerEngineFactoryTest.scala
@@ -4,6 +4,10 @@ import com.twitter.finagle.ssl._
 import com.twitter.finagle.ssl.server.SslServerConfiguration
 import com.twitter.io.TempFile
 import java.io.File
+import java.security.KeyStore
+
+import com.twitter.finagle.ssl.client.SslClientConfiguration
+import javax.net.ssl.{KeyManagerFactory, TrustManagerFactory}
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
@@ -111,6 +115,26 @@ class Netty4ServerEngineFactoryTest extends FunSuite {
       val engine = factory(config)
     }
   }
+
+  test("config with KeyManager succeeds") {
+    // ToDo: Should we also create tests / build the functionality that the keymanagers are rejected if containing expired certs
+
+    val trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
+    trustManagerFactory.init(null.asInstanceOf[KeyStore])
+
+    val trustCredentials = TrustCredentials.FromTrustManagerFactory(trustManagerFactory)
+
+    val keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm)
+    keyManagerFactory.init(null, Array[Char]())
+
+    val keyCredentials = KeyCredentials.FromKeyManager(keyManagerFactory)
+    val config = SslServerConfiguration(trustCredentials = trustCredentials, keyCredentials = keyCredentials)
+    val engine = factory(config)
+    val sslEngine = engine.self
+
+    assert(sslEngine != null)
+  }
+
 
   test("config with good cipher suites succeeds") {
     val cipherSuites = CipherSuites.Enabled(Seq("TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384"))

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/server/Netty4ServerEngineFactoryTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/server/Netty4ServerEngineFactoryTest.scala
@@ -133,8 +133,6 @@ class Netty4ServerEngineFactoryTest extends FunSuite {
   }
 
   test("config with only KeyCredentials succeeds") {
-    // ToDo: Should we also create tests / build the functionality that the keymanagers are rejected if containing expired certs
-
     val keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm)
     keyManagerFactory.init(null, Array[Char]())
 


### PR DESCRIPTION
Support `javax.net.ssl.[Key|Trust]Manager` in Key and Trust credentials.

Problem

Proper H2 support is only provided when configuring the Http client with the new `Ssl[Client|Server]Configuration` which takes `KeyCredentials` and `TrustCredentials`. Before this PR those could only be constructed from PEM files. We use .jks files to ship our credentials which are not usable with the `KeyCredentials` and `TrustCredentials`.

For more background see #650.

Solution

I've added extra case classes for both `KeyCredentials` and `TrustCredentials` and made sure they are passed through to netty.

Please feel free to (nit)pick on the names for the case classes. :)