### PR TITLE
Avoid NoClassDefFoundError if netty-transport-native-epoll is excluded

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,9 @@ Bug Fixes
     ServicePerEndpoint. It can be set via `c.t.f.thrift.RichClientParam` or a `with`-method
     as `Thrift{Mux}.client.withPerEndpointStats`. ``PHAB_ID=D169427``
 
+  * finagle-netty4: Avoid NoClassDefFoundError if netty-transport-native-epoll is not available
+    on the classpath.
+
 18.5.0
 -------
 

--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ListeningServerBuilder.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ListeningServerBuilder.scala
@@ -47,6 +47,16 @@ private class ListeningServerBuilder(
   // netty4 params
   private[this] val param.Allocator(allocator) = params[param.Allocator]
 
+  private[ListeningServerBuilder] def mkEpollEventLoopGroup(): EventLoopGroup =
+    new EpollEventLoopGroup(
+      1 /*nThreads*/,
+      new NamedPoolThreadFactory("finagle/netty4/boss", makeDaemons = true))
+
+  private[ListeningServerBuilder] def mkNioEventLoopGroup(): EventLoopGroup =
+    new NioEventLoopGroup(
+      1 /*nThreads*/,
+      new NamedPoolThreadFactory("finagle/netty4/boss", makeDaemons = true))
+
   /**
    * Listen for connections and apply the `serveTransport` callback on
    * connected [[Transport transports]].
@@ -62,15 +72,9 @@ private class ListeningServerBuilder(
     new ListeningServer with CloseAwaitably {
       private[this] val bossLoop: EventLoopGroup =
         if (nativeEpoll.enabled)
-          new EpollEventLoopGroup(
-            1 /*nThreads*/,
-            new NamedPoolThreadFactory("finagle/netty4/boss", makeDaemons = true)
-          )
+          mkEpollEventLoopGroup()
         else
-          new NioEventLoopGroup(
-            1 /*nThreads*/,
-            new NamedPoolThreadFactory("finagle/netty4/boss", makeDaemons = true)
-          )
+          mkNioEventLoopGroup()
 
       private[this] val bootstrap = new ServerBootstrap()
       if (nativeEpoll.enabled)


### PR DESCRIPTION
Problem

Currently Finagle fails at startup when netty-transport-native-epoll is not available on the classpath.
Even on OS X, or if epoll is explicitly disabled. 
(If I have seen correctly it is even disabled by default here: https://github.com/twitter/finagle/blob/835b6c3f155c066b679294083fba638111f52a39/finagle-netty4/src/main/resources/com/twitter/toggles/configs/com.twitter.finagle.netty4.json#L3-L7)

Solution

The solution is to move the creation of the different EventLoopGroups into own methods with an explicit type signature returning just EventLoopGroup.

Result

As a result it should be possible to exclude netty-transport-native-epoll from the classpath and therefore reduce the size of the bundle.

Side note: 
I see that I didn't add any tests. Unfortunately my sbt know how is not existing, so I don't know how to set up separate tests with different dependencies.