### PR TITLE
Add time unit to connection_duration documentation

### DIFF
--- a/doc/src/sphinx/metrics/Transport.rst
+++ b/doc/src/sphinx/metrics/Transport.rst
@@ -44,7 +44,7 @@ ChannelStatsHandler
   histograms.
 
 **connection_duration** `verbosity:debug`
-  A histogram of the duration of the lifetime of a connection.
+  A histogram of the duration of the lifetime of a connection, in milliseconds.
 
 **connection_received_bytes** `verbosity:debug`
   A histogram of the number of bytes received over the lifetime of a connection.


### PR DESCRIPTION
**Problem**

Time unit is not present in the metric name neither is mentioned in the documentation.

**Solution**

Add time unit to the documentation.

**Result**

Dev won't have to check finagle's source code to know which is the unit of `connection_duration`