### PR TITLE
Expose the poll interval in the apply methods

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/InetResolver.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/InetResolver.scala
@@ -55,14 +55,16 @@ object InetResolver {
   def apply(unscopedStatsReceiver: StatsReceiver): Resolver =
     apply(unscopedStatsReceiver, FuturePool.unboundedPool)
 
-  def apply(unscopedStatsReceiver: StatsReceiver, resolvePool: FuturePool): Resolver = {
+  def apply(unscopedStatsReceiver: StatsReceiver, resolvePool: FuturePool): Resolver =
+    apply(unscopedStatsReceiver, Some(5.seconds), resolvePool)
+
+  def apply(unscopedStatsReceiver: StatsReceiver, pollIntervalOpt: Option[Duration], resolvePool: FuturePool) = {
     val statsReceiver = unscopedStatsReceiver.scope("inet").scope("dns")
     new InetResolver(
       new DnsResolver(statsReceiver, resolvePool),
       statsReceiver,
-      Some(5.seconds),
-      resolvePool
-    )
+      pollIntervalOpt,
+      resolvePool)
   }
 }
 


### PR DESCRIPTION
Problem

Users trying to use the InetResolver cannot specify the DNS poll interval.

Solution

Add an apply constructor method with the DNS poll interval added.

Result

Users can now specify the DNS poll interval when using their own instance of the InetResolver.

