### PR TITLE
finagle-netty4: allow sockets to be configured with SO_REUSEPORT

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,10 @@ New Features
     check if an exception is known to be safe to retry. Java compatibility has
     also been added. ``PHAB_ID=D202374``
 
+  * finagle-netty4: Allow sockets to be configured with the [SO_REUSEPORT](http://lwn.net/Articles/542629/) option
+    when using native epoll, which allows multiple processes to bind and accept connections
+    from the same port.
+
 Breaking API Changes
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/finagle-core/src/main/scala/com/twitter/finagle/transport/Transport.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/transport/Transport.scala
@@ -217,14 +217,24 @@ object Transport {
    *
    * @param reuseAddr enables or disables `SO_REUSEADDR` option on a
    *                  transport socket. Default is `true`.
+   *
+   * @param reusePort enables or disables `SO_REUSEPORT` option on a
+   *                  transport socket (Linux 3.9+ only). This option is only
+   *                  available when using finagle-netty4 and native epoll support
+   *                  is enabled. Default is `false`.
    */
-  case class Options(noDelay: Boolean, reuseAddr: Boolean) {
+  case class Options(noDelay: Boolean, reuseAddr: Boolean, reusePort: Boolean) {
+    def this(noDelay: Boolean, reuseAddr: Boolean) = this(noDelay, reuseAddr, reusePort = false)
+
     def mk(): (Options, Stack.Param[Options]) = (this, Options.param)
   }
 
   object Options {
     implicit val param: Stack.Param[Options] =
-      Stack.Param(Options(noDelay = true, reuseAddr = true))
+      Stack.Param(Options(noDelay = true, reuseAddr = true, reusePort = false))
+
+    def apply(noDelay: Boolean, reuseAddr: Boolean): Options =
+      this.apply(noDelay = noDelay, reuseAddr = reuseAddr, reusePort = false)
   }
 
   /**

--- a/finagle-netty3/src/main/scala/com/twitter/finagle/netty3/Netty3Listener.scala
+++ b/finagle-netty3/src/main/scala/com/twitter/finagle/netty3/Netty3Listener.scala
@@ -215,7 +215,7 @@ class Netty3Listener[In, Out](pipelineFactory: ChannelPipelineFactory, params: S
     val Listener.Backlog(backlog) = params[Listener.Backlog]
     val Transport.BufferSizes(sendBufSize, recvBufSize) = params[Transport.BufferSizes]
     val Transport.Liveness(readTimeout, writeTimeout, keepAlive) = params[Transport.Liveness]
-    val Transport.Options(noDelay, reuseAddr) = params[Transport.Options]
+    val Transport.Options(noDelay, reuseAddr, _) = params[Transport.Options]
 
     val opts = new mutable.HashMap[String, Object]()
     opts += "soLinger" -> (0: java.lang.Integer)

--- a/finagle-netty3/src/main/scala/com/twitter/finagle/netty3/Netty3Transporter.scala
+++ b/finagle-netty3/src/main/scala/com/twitter/finagle/netty3/Netty3Transporter.scala
@@ -235,7 +235,7 @@ private[netty3] class Netty3Transporter[In, Out](
     val LatencyCompensation.Compensation(compensation) = params[LatencyCompensation.Compensation]
     val Transport.BufferSizes(sendBufSize, recvBufSize) = params[Transport.BufferSizes]
     val Transport.Liveness(readerTimeout, writerTimeout, keepAlive) = params[Transport.Liveness]
-    val Transport.Options(noDelay, reuseAddr) = params[Transport.Options]
+    val Transport.Options(noDelay, reuseAddr, _) = params[Transport.Options]
 
     val opts = new mutable.HashMap[String, Object]()
     opts += "connectTimeoutMillis" ->

--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ConnectionBuilder.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ConnectionBuilder.scala
@@ -27,6 +27,7 @@ import io.netty.channel.socket.nio.NioSocketChannel
 import java.lang.{Boolean => JBool, Integer => JInt}
 import java.net.SocketAddress
 import java.nio.channels.UnresolvedAddressException
+
 import scala.util.control.NonFatal
 
 /**
@@ -59,7 +60,7 @@ private final class ConnectionBuilder(
    *       the spawned channel.
    */
   def build[T](builder: Channel => Future[T]): Future[T] = {
-    val Transport.Options(noDelay, reuseAddr) = params[Transport.Options]
+    val Transport.Options(noDelay, reuseAddr, reusePort) = params[Transport.Options]
     val LatencyCompensation.Compensation(compensation) = params[LatencyCompensation.Compensation]
     val Transporter.ConnectTimeout(connectTimeout) = params[Transporter.ConnectTimeout]
     val Transport.BufferSizes(sendBufSize, recvBufSize) = params[Transport.BufferSizes]


### PR DESCRIPTION
Problem

Would like to be able to build servers that open sockets with the `SO_REUSEPORT` option on Linux. `SO_REUSEPORT` allows multiple processes to bind and accept connections from the same address and port. 

Our particular use-case involves being able to support near zero-downtime restarts with finagle servers. We'd like to be able to start a new, simultaneously-running finagle process, listen on the same interface and port and then gracefully shutdown the old PID when the new process is healthy. 

Solution

Support for `SO_REUSEPORT` is available when using the native-epoll transport in netty4 (https://github.com/netty/netty/commit/d1d8a6b6cdfbf3946fbce0a7a0bf7657cbfade03).  Allow this option to be configured using `Transport.Options`.