### PR TITLE
finagle-redis: Fix discard transaction bug

### DIFF
--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/Client.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/Client.scala
@@ -191,7 +191,7 @@ class TransactionalClient(factory: ServiceFactory[Command, Reply])
     }
 
   def discard(): Future[Unit] =
-    doRequest(Multi) {
+    doRequest(Discard) {
       case StatusReply(message) =>
         _multi = false
         _watch = false


### PR DESCRIPTION
Problem

Send `MULTI` command when discard transaction.

Solution

Change command `MULTI` to `DISCARD`.

Result

Successfully transaction discarded.
