### PR TITLE
Use current dtabs in NoBrokersAvailableException

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/Exceptions.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/Exceptions.scala
@@ -134,10 +134,18 @@ class GlobalRequestTimeoutException(timeout: Duration)
  *
  * [1] https://twitter.github.io/finagle/guide/Names.html
  */
-class NoBrokersAvailableException(val name: String, val baseDtab: Dtab, val localDtab: Dtab)
+class NoBrokersAvailableException(val name: String, val baseDtabFn: () => Dtab, val localDtabFn: () => Dtab)
     extends RequestException
     with SourcedException {
-  def this(name: String = "unknown") = this(name, Dtab.empty, Dtab.empty)
+
+  // backwards compatibility constructor
+  def this(name: String, baseDtab: Dtab, localDtab: Dtab) =
+    this(name, () => baseDtab, () => localDtab)
+
+  def this(name: String = "unknown") = this(name, () => Dtab.base, () => Dtab.local)
+
+  def baseDtab: Dtab = baseDtabFn()
+  def localDtab: Dtab = localDtabFn()
 
   override def exceptionMessage: String =
     s"No hosts are available for $name, Dtab.base=[${baseDtab.show}], Dtab.local=[${localDtab.show}]"

--- a/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/LoadBalancerFactoryTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/LoadBalancerFactoryTest.scala
@@ -9,6 +9,8 @@ import com.twitter.finagle.server.utils.StringServer
 import com.twitter.finagle.stats.{InMemoryHostStatsReceiver, InMemoryStatsReceiver}
 import com.twitter.util.{Activity, Await, Future, Time, Var}
 import java.net.{InetAddress, InetSocketAddress}
+
+import com.twitter.finagle.loadbalancer.LoadBalancerFactory.ErrorLabel
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.FunSuite
 
@@ -100,8 +102,17 @@ class LoadBalancerFactoryTest extends FunSuite with Eventually with IntegrationP
     }.toStack(next)
 
     val dest = LoadBalancerFactory.Dest(Var(Addr.Neg))
-    val factory = stack.make(Stack.Params.empty + dest)
-    intercept[NoBrokersAvailableException](Await.result(factory()))
+    val label = "mystack"
+    val factory = stack.make(Stack.Params.empty + dest + ErrorLabel(label))
+
+    Dtab.unwind {
+      val newDtab = Dtab.read("/foo => /bar")
+      Dtab.local = newDtab
+      val noBrokers = intercept[NoBrokersAvailableException](Await.result(factory()))
+      assert(noBrokers.name == "mystack")
+      assert(noBrokers.localDtab == newDtab)
+    }
+
   }
 
   test("when no nodes are Open and configured to fail fast") {


### PR DESCRIPTION
Problem
In some cases the Dtab information shows as empty in the NoBrokersAvailableException, even if there was a Dtab (base and/or local) set. This might be confusing when debugging resolver issues.

Solution

If no Dtab was given to the NoBrokersAvailableException, look up the Dtab when constructing the exceptionMessage.

Result

Actual effective Dtab is shown in NoBrokersAvaialbleException, fixes #716 
