### PR TITLE
finagle-serversets: initialize zkHealth to Unknown

### DIFF
--- a/finagle-serversets/src/main/scala/com/twitter/finagle/serverset2/HealthStabilizer.scala
+++ b/finagle-serversets/src/main/scala/com/twitter/finagle/serverset2/HealthStabilizer.scala
@@ -30,7 +30,7 @@ private[serverset2] object HealthStabilizer {
     statsReceiver: StatsReceiver
   ): Var[ClientHealth] = {
 
-    Var.async[ClientHealth](ClientHealth.Healthy) { u =>
+    Var.async[ClientHealth](ClientHealth.Unknown) { u =>
       val stateChanges = va.changes.dedup.select(probationEpoch.event).foldLeft[Status](Unknown) {
         // always take the first update as our status
         case (Unknown, Left(ClientHealth.Healthy)) => Healthy
@@ -68,6 +68,7 @@ private[serverset2] object HealthStabilizer {
           // re-map to the underlying health status
           case Healthy | Probation(_) => ClientHealth.Healthy
           case Unhealthy => ClientHealth.Unhealthy
+          case Unknown => ClientHealth.Unknown
         }
         .dedup
         .register(Witness(u))

--- a/finagle-serversets/src/test/scala/com/twitter/finagle/serverset2/ServiceDiscovererTest.scala
+++ b/finagle-serversets/src/test/scala/com/twitter/finagle/serverset2/ServiceDiscovererTest.scala
@@ -354,10 +354,11 @@ class ServiceDiscovererTest
         stabilizedHealth
       })
 
-      // should start as healthy until updated otherwise
-      assert(stabilizedHealth.get == ClientHealth.Healthy)
+      // should start as unknown until updated otherwise
+      assert(stabilizedHealth.get == ClientHealth.Unknown)
 
       val (session1, state1) = newZkSession()
+      state1.notify(WatchState.SessionState(SessionState.SyncConnected))
       zkSession.notify(session1)
       assert(stabilizedHealth.get == ClientHealth.Healthy)
 
@@ -389,10 +390,11 @@ class ServiceDiscovererTest
       health
     })
 
-    // should start as healthy until updated otherwise
-    assert(health.get == ClientHealth.Healthy)
+    // should start as unknown until updated otherwise
+    assert(health.get == ClientHealth.Unknown)
 
     val (session1, state1) = newZkSession()
+    state1.notify(WatchState.SessionState(SessionState.SyncConnected))
     zkSession.notify(session1)
     assert(health.get == ClientHealth.Healthy)
 


### PR DESCRIPTION
Problem

On start up, the zkHealth reports "Healthy" when the client is not able to connect to zookeeper. On debugging, I noticed that the ClientHealth was being initialized to Healthy.

Solution

The ClientHealth should be initialized to Unknown, and it will become Healthy only when it connects to zookeeper (which internally means the session changing to SyncConnected)

Result

If the client isn't able to connect to zookeeper on startup, it will report its health as Unknown.
