### PR TITLE
Add a link to airframe-http, as a companion project of Finagle

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -131,6 +131,7 @@
       <li><a href="https://github.com/finagle/finagle-websocket">WebSockets implementation for Finagle</a></li>
       <li><a href="https://github.com/evnm/fintop">Fintop</a> - a top-like utility for monitoring Finagle services</li>
       <li><a href="http://fintrospect.io/">Fintrospect</a> - adds an intelligent HTTP routing layer to Finagle. It provides a simple way to implement contracts for both server and client-side HTTP services</li>
+      <li><a href="https://wvlet.org/airframe/docs/airframe-http.html">Airframe HTTP</a> - a library for building REST APIs over Finagle</li>
     </ul>
   </div>
   </body>


### PR DESCRIPTION
I've created a new project airframe-http to provide a handy way to build REST APIs on top of Finagle. Please add a link to airframe-http.

For more details, see our blog post: 
- Airframe HTTP: Building Low-Friction Web Services Over Finagle https://medium.com/@taroleo/airframe-http-a-minimalist-approach-for-building-web-services-in-scala-743ba41af7f
