### PR TITLE
change ResponseConformanceFilter log level from info to debug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Note that ``PHAB_ID=#`` and ``RB_ID=#`` correspond to associated messages in com
 
 Unreleased
 ----------
+* finagle-base-http: logging levels in `c.t.f.h.c.ResponseConformanceFilter` have
+  been change from `info` to `debug`
 
 Deprecations
 ~~~~~~~~~~~~

--- a/finagle-base-http/src/main/scala/com/twitter/finagle/http/codec/ResponseConformanceFilter.scala
+++ b/finagle-base-http/src/main/scala/com/twitter/finagle/http/codec/ResponseConformanceFilter.scala
@@ -72,7 +72,7 @@ private[codec] object ResponseConformanceFilter extends SimpleFilter[Request, Re
     val contentLength = rep.length
     if (contentLength > 0) {
       rep.clearContent()
-      logger.info(
+      logger.debug(
         "Response with a status code of %d must not have a body-message but it has " +
           "a %d-byte payload, thus the content has been removed.",
         rep.statusCode,
@@ -84,7 +84,7 @@ private[codec] object ResponseConformanceFilter extends SimpleFilter[Request, Re
       if (rep.contentLength.isDefined) {
         val contentLength = rep.contentLengthOrElse(-1)
         rep.headerMap.remove(Fields.ContentLength)
-        logger.info(
+        logger.debug(
           "Response with a status code of %d must not have a Content-Length header field " +
             "thus the field has been removed. Content-Length: %d",
           rep.statusCode,
@@ -172,7 +172,7 @@ private[codec] object ResponseConformanceFilter extends SimpleFilter[Request, Re
     }
 
     if (!response.content.isEmpty) {
-      logger.info(
+      logger.debug(
         "Received response to HEAD request (%s) that contained a static body of length %d. " +
           "Discarding body. If this is desired behavior, consider adding HeadFilter to your service",
         request.toString,


### PR DESCRIPTION
Problem

The ResponseConformanceFilter is responsible for ensuring that requests and responses messages that flow through a Finagle service are HTTP compliant. There are cases where the filter enforces certain request/response rules and every time that happens the Filter logs information at the info level. There may be certain situations where a server sends HTTP non-compliant responses by design i.e. sending 204 with bodies. A server that receives requests at a high QPS that result in these kinds of responses end up logging a lot of messages like `"Response with a status code of 204 must not have a body-message but it has a 10-byte payload, thus the content has been removed."` at an `INFO` level.

Solution

Modify all logging statements to `logger.debug` so that these messages are only visible at the `DEBUG` level since it seems more appropriate for these messages to be set at that level. 
