### PR TITLE
finagle-http: allow streaming of fixed length messages

### DIFF
--- a/finagle-base-http/src/main/scala/com/twitter/finagle/http/param/params.scala
+++ b/finagle-base-http/src/main/scala/com/twitter/finagle/http/param/params.scala
@@ -64,10 +64,10 @@ object Streaming {
     Stack.Param(Streaming(enabled = false))
 }
 
-case class AggregateIfLessThan(size: StorageUnit)
-object AggregateIfLessThan {
-  implicit val aggregateIfLessThan: Stack.Param[AggregateIfLessThan] =
-    Stack.Param(AggregateIfLessThan(StorageUnit.zero))
+case class FixedLengthStreamedAfter(size: StorageUnit)
+object FixedLengthStreamedAfter {
+  implicit val fixedLengthStreamedAfter: Stack.Param[FixedLengthStreamedAfter] =
+    Stack.Param(FixedLengthStreamedAfter(StorageUnit.zero))
 }
 
 case class Decompression(enabled: Boolean)

--- a/finagle-base-http/src/main/scala/com/twitter/finagle/http/param/params.scala
+++ b/finagle-base-http/src/main/scala/com/twitter/finagle/http/param/params.scala
@@ -64,10 +64,10 @@ object Streaming {
     Stack.Param(Streaming(enabled = false))
 }
 
-case class MinChunkSize(size: StorageUnit)
-object MinChunkSize {
-  implicit val minChunkSize: Stack.Param[MinChunkSize] =
-    Stack.Param(MinChunkSize(StorageUnit.zero))
+case class AggregateIfLessThan(size: StorageUnit)
+object AggregateIfLessThan {
+  implicit val aggregateIfLessThan: Stack.Param[AggregateIfLessThan] =
+    Stack.Param(AggregateIfLessThan(StorageUnit.zero))
 }
 
 case class Decompression(enabled: Boolean)

--- a/finagle-base-http/src/main/scala/com/twitter/finagle/http/param/params.scala
+++ b/finagle-base-http/src/main/scala/com/twitter/finagle/http/param/params.scala
@@ -64,6 +64,12 @@ object Streaming {
     Stack.Param(Streaming(enabled = false))
 }
 
+case class MinChunkSize(size: StorageUnit)
+object MinChunkSize {
+  implicit val minChunkSize: Stack.Param[MinChunkSize] =
+    Stack.Param(MinChunkSize(StorageUnit.zero))
+}
+
 case class Decompression(enabled: Boolean)
 object Decompression extends {
   implicit val decompressionParam: Stack.Param[Decompression] =

--- a/finagle-base-http/src/main/scala/com/twitter/finagle/http/param/params.scala
+++ b/finagle-base-http/src/main/scala/com/twitter/finagle/http/param/params.scala
@@ -67,7 +67,7 @@ object Streaming {
 case class FixedLengthStreamedAfter(size: StorageUnit)
 object FixedLengthStreamedAfter {
   implicit val fixedLengthStreamedAfter: Stack.Param[FixedLengthStreamedAfter] =
-    Stack.Param(FixedLengthStreamedAfter(StorageUnit.zero))
+    Stack.Param(FixedLengthStreamedAfter(5.megabytes))
 }
 
 case class Decompression(enabled: Boolean)

--- a/finagle-http/src/main/scala/com/twitter/finagle/Http.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/Http.scala
@@ -503,7 +503,7 @@ object Http extends Client[Request, Response] with HttpRichClient with Server[Re
      */
     def withStreaming(enabled: Boolean, fixedLengthStreamedAfter: StorageUnit): Server =
       this
-        .configured(http.param.Streaming(enabled))
+        .withStreaming(enabled)
         .configured(http.param.FixedLengthStreamedAfter(fixedLengthStreamedAfter))
 
     /**

--- a/finagle-http/src/main/scala/com/twitter/finagle/Http.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/Http.scala
@@ -462,13 +462,21 @@ object Http extends Client[Request, Response] with HttpRichClient with Server[Re
 
     /**
      * Streaming allows applications to work with HTTP messages that have large
-     * (or infinite) content bodies. When this set to `true`, the message content is
+     * (or infinite) content bodies. When `enabled` is set to `true`, the message content is
      * available through a [[com.twitter.io.Reader]], which gives the application a
-     * handle to the byte stream. If `false`, the entire message content is buffered
-     * into a [[com.twitter.io.Buf]].
+     * handle to the byte stream. If `minChunkSize` is set to a positive non-zero value,
+     * then messages with no `Transfer-Encoding` and with `Content-Length` up to the
+     * `minChunkSize` value will be buffered into a [[com.twitter.io.Buf]].
+     * [[Request.isChunked]] should be used to determine whether the message is streamed
+     * (`isChunked == true`) or buffered (`isChunked == false`).
+     *
+     * If `enabled` is set to `false`, the entire message content is buffered into a
+     * [[com.twitter.io.Buf]] up to a maximum allowed message size.
      */
-    def withStreaming(enabled: Boolean): Server =
-      configured(http.param.Streaming(enabled))
+    def withStreaming(enabled: Boolean, minChunkSize: StorageUnit = StorageUnit.zero): Server =
+      this
+        .configured(http.param.Streaming(enabled))
+        .configured(http.param.MinChunkSize(minChunkSize))
 
     /**
      * Enables decompression of http content bodies.

--- a/finagle-http/src/test/java/com/twitter/finagle/http/javaapi/HttpServerTest.java
+++ b/finagle-http/src/test/java/com/twitter/finagle/http/javaapi/HttpServerTest.java
@@ -11,6 +11,7 @@ import com.twitter.finagle.http.Request;
 import com.twitter.finagle.http.Response;
 import com.twitter.finagle.param.Label;
 import com.twitter.util.Future;
+import com.twitter.util.StorageUnit;
 
 public final class HttpServerTest {
 
@@ -52,6 +53,7 @@ public final class HttpServerTest {
             .withAdmissionControl().noDeadlines()
             .withAdmissionControl().darkModeDeadlines()
             .withCompressionLevel(2)
+            .withStreaming(true, StorageUnit.fromMegabytes(1))
             .configured(new Label("test").mk())
             .withDecompression(true)
             .withHttp2();

--- a/finagle-netty4-http/src/main/scala/com/twitter/finagle/netty4/http/handler/FixedLengthMessageAggregator.scala
+++ b/finagle-netty4-http/src/main/scala/com/twitter/finagle/netty4/http/handler/FixedLengthMessageAggregator.scala
@@ -8,7 +8,8 @@ import io.netty.handler.codec.http._
  * Aggregates fixed length http messages and emits [[FullHttpMessage]] downstream.
  *
  * Http message is considered fixed length if it has `Content-Length` header and
- * `Transfer-Encoding` header is not `chunked`.
+ * `Transfer-Encoding` header is not `chunked` or if we can deduce actual content
+ * length to be 0 even if `Content-Length` header is not specified (f.ex. from RFCs).
  *
  * Fixed length messages may arrive as a series of smaller pieces (hereinafter referred
  * to as chunks, but not to be confused with http chunks) from the upstream handlers

--- a/finagle-netty4-http/src/main/scala/com/twitter/finagle/netty4/http/handler/FixedLengthMessageAggregator.scala
+++ b/finagle-netty4-http/src/main/scala/com/twitter/finagle/netty4/http/handler/FixedLengthMessageAggregator.scala
@@ -9,21 +9,21 @@ import io.netty.handler.codec.http._
  *
  * Http message is considered fixed length if it has `Content-Length` header and
  * `Transfer-Encoding` header is not `chunked` or if we can deduce actual content
- * length to be 0 even if `Content-Length` header is not specified (f.ex. from RFCs).
+ * length to be 0 even if `Content-Length` header is not specified.
  *
- * Fixed length messages may arrive as a series of smaller pieces (hereinafter referred
- * to as chunks, but not to be confused with http chunks) from the upstream handlers
- * in pipeline. To eventually build a [[com.twitter.finagle.http.Request]] object with
- * content available as [[com.twitter.finagle.http.Request.content]] or
- * [[com.twitter.finagle.http.Request.contentString]] all chunks must be stored in
+ * Fixed length messages may arrive as a series of chunks (not to be confused with chunks
+ * as in `Transfer-Encoding: chunked`) from the upstream handlers in pipeline. To
+ * eventually build a [[com.twitter.finagle.http.Request]] object with content available
+ * as [[com.twitter.finagle.http.Request.content]] or
+ * [[com.twitter.finagle.http.Request.contentString]] all chunks must be stored in a
  * temporary buffer and combined together into a [[FullHttpMessage]] as soon as the last
  * chunk of the message is received.
  *
- * `maxContentLength` parameter sets the limit on message's `Content-Length`.
- * If `Content-Length` exceeds `maxContentLength`, the message bypasses this aggregator
- * and is emitted to downstream handler in pipeline unaltered.
+ * The `maxContentLength` determines when to aggregate chunks and when to bypass the
+ * message as is. Only sufficiently small messages (smaller than `maxContentLength`) are
+ * aggregated.
  *
- * Messages with `Transfer-Encoding: chunked` are always emitted unaltered.
+ * Messages with `Transfer-Encoding: chunked` are always bypassed.
  */
 private[http] class FixedLengthMessageAggregator(
   maxContentLength: StorageUnit,

--- a/finagle-netty4-http/src/main/scala/com/twitter/finagle/netty4/http/package.scala
+++ b/finagle-netty4-http/src/main/scala/com/twitter/finagle/netty4/http/package.scala
@@ -117,7 +117,7 @@ package object http {
     val decompressionEnabled = params[Decompression].enabled
     val compressionLevel = params[CompressionLevel].level
     val streaming = params[Streaming].enabled
-    val aggregateIfLessThan = params[AggregateIfLessThan].size
+    val fixedLengthStreamedAfter = params[FixedLengthStreamedAfter].size
     val log = params[Logger].log
 
     { pipeline: ChannelPipeline =>
@@ -143,14 +143,12 @@ package object http {
         if (autoContinue)
           pipeline.addLast("expectContinue", new HttpServerExpectContinueHandler)
 
-        // buffer size for messages with fixed length
-        val fixedLengthBuffer = aggregateIfLessThan.min(maxRequestSize)
-
+        val fixedLengthBufferSize = fixedLengthStreamedAfter.min(maxRequestSize)
         // no need to handle expect headers in the fixedLenAggregator since we have the task
         // specific HttpServerExpectContinueHandler above.
         pipeline.addLast(
           "fixedLenAggregator",
-          new FixedLengthMessageAggregator(fixedLengthBuffer, handleExpectContinue = false)
+          new FixedLengthMessageAggregator(fixedLengthBufferSize, handleExpectContinue = false)
         )
       } else
         pipeline.addLast(

--- a/finagle-netty4-http/src/main/scala/com/twitter/finagle/netty4/http/package.scala
+++ b/finagle-netty4-http/src/main/scala/com/twitter/finagle/netty4/http/package.scala
@@ -117,7 +117,7 @@ package object http {
     val decompressionEnabled = params[Decompression].enabled
     val compressionLevel = params[CompressionLevel].level
     val streaming = params[Streaming].enabled
-    val minChunkSize = params[MinChunkSize].size
+    val aggregateIfLessThan = params[AggregateIfLessThan].size
     val log = params[Logger].log
 
     { pipeline: ChannelPipeline =>
@@ -143,14 +143,14 @@ package object http {
         if (autoContinue)
           pipeline.addLast("expectContinue", new HttpServerExpectContinueHandler)
 
-        // do not let minChunkSize to be greater than maxRequestSize
-        val effectiveMinChunkSize = minChunkSize.min(maxRequestSize)
+        // buffer size for messages with fixed length
+        val fixedLengthBuffer = aggregateIfLessThan.min(maxRequestSize)
 
         // no need to handle expect headers in the fixedLenAggregator since we have the task
         // specific HttpServerExpectContinueHandler above.
         pipeline.addLast(
           "fixedLenAggregator",
-          new FixedLengthMessageAggregator(effectiveMinChunkSize, handleExpectContinue = false)
+          new FixedLengthMessageAggregator(fixedLengthBuffer, handleExpectContinue = false)
         )
       } else
         pipeline.addLast(

--- a/finagle-netty4-http/src/test/scala/com/twitter/finagle/netty4/http/handler/FixedLengthMessageAggregatorTest.scala
+++ b/finagle-netty4-http/src/test/scala/com/twitter/finagle/netty4/http/handler/FixedLengthMessageAggregatorTest.scala
@@ -1,6 +1,7 @@
 package com.twitter.finagle.netty4.http.handler
 
 import com.twitter.conversions.storage._
+import com.twitter.util.StorageUnit.zero
 import io.netty.buffer.Unpooled
 import io.netty.channel.embedded.EmbeddedChannel
 import io.netty.handler.codec.http._
@@ -75,6 +76,20 @@ class FixedLengthMessageAggregatorTest extends FunSuite {
     assert(reqObserved.content == content)
   }
 
+  test("fixed length messages that don't have body are aggregated by zero-length aggregator") {
+    val agg = new FixedLengthMessageAggregator(zero)
+    val channel: EmbeddedChannel = new EmbeddedChannel(new HttpRequestEncoder(), agg)
+    val head = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/")
+    HttpUtil.setContentLength(head, 0)
+
+    assert(!channel.writeInbound(head))
+    assert(channel.writeInbound(new DefaultLastHttpContent()))
+
+    val reqObserved = channel.readInbound[FullHttpRequest]()
+    assert(reqObserved.method == HttpMethod.POST)
+    assert(reqObserved.content == Unpooled.EMPTY_BUFFER)
+  }
+
   test(
     "fixed length messages which are chunked and larger than than the " +
       "specified size remain chunked"
@@ -97,6 +112,38 @@ class FixedLengthMessageAggregatorTest extends FunSuite {
     assert(bodyObserved.content == content)
   }
 
+  test("fixed length messages that have body are not aggregated by zero-length aggregator") {
+    val agg = new FixedLengthMessageAggregator(zero)
+    val channel: EmbeddedChannel = new EmbeddedChannel(new HttpRequestEncoder(), agg)
+    val content = Unpooled.wrappedBuffer(new Array[Byte](11))
+    val head = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/")
+    HttpUtil.setContentLength(head, content.readableBytes)
+
+    val body = new DefaultLastHttpContent(content)
+
+    assert(channel.writeInbound(head))
+    assert(channel.writeInbound(body))
+
+    val reqObserved = channel.readInbound[HttpRequest]()
+    assert(reqObserved.method == HttpMethod.POST)
+
+    val bodyObserved = channel.readInbound[HttpContent]()
+    assert(bodyObserved.content == content)
+  }
+
+  test("requests with no content-length and transfer-encoding are aggregated") {
+    val agg = new FixedLengthMessageAggregator(zero)
+    val channel: EmbeddedChannel = new EmbeddedChannel(new HttpRequestEncoder(), agg)
+    val head = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/")
+
+    assert(!channel.writeInbound(head)) // shouldn't pass through
+    assert(channel.writeInbound(new DefaultLastHttpContent()))
+
+    val reqObserved = channel.readInbound[FullHttpRequest]()
+    assert(reqObserved.method == HttpMethod.POST)
+    assert(reqObserved.content == Unpooled.EMPTY_BUFFER)
+  }
+
   test("responses that will not have a body are aggregated") {
     Set(
       HttpResponseStatus.NO_CONTENT,
@@ -105,7 +152,7 @@ class FixedLengthMessageAggregatorTest extends FunSuite {
       HttpResponseStatus.SWITCHING_PROTOCOLS,
       HttpResponseStatus.PROCESSING
     ).foreach { status =>
-      val agg = new FixedLengthMessageAggregator(11.byte)
+      val agg = new FixedLengthMessageAggregator(zero)
       val channel: EmbeddedChannel = new EmbeddedChannel(new HttpRequestEncoder(), agg)
       val head = new DefaultHttpResponse(HttpVersion.HTTP_1_1, status)
 


### PR DESCRIPTION
Problem

Server.withStreaming(true) only enables streaming for requests with
chunked encoding. Requests without chunked encoding are still buffered
up to max allowed request size. This is not desirable for some use cases

https://github.com/twitter/finagle/issues/538

Solution

Introduce new stack parameter FixedLengthStreamedAfter which determines
the maximum content length for the FixedLengthMessageAggregator in netty
server pipeline.

Default value for the new parameter is 5.megabytes which forces
streaming of messages with body exceeding 5 MiB (changes former
behavior).

Result

Server-side:

    val server = Http.server
      .withStreaming(true)
      .withMaxRequestSize(50.megabytes)

will stream messages with Transfer-Encoding: chunked and messages
without the header if Content-Length is larger than 5242880.
To revert to previous behavior fixedLengthStreamedAfter must be set to
the value of maxRequestSize

    val server = Http.server
      .withStreaming(true, fixedLengthStreamedAfter = 50.megabytes)
      .withMaxRequestSize(50.megabytes)

