### PR TITLE
WIP: finagle-http2: reinstate Http2ListenerTest

### DIFF
--- a/finagle-http2/src/main/scala/com/twitter/finagle/http2/Http2Listener.scala
+++ b/finagle-http2/src/main/scala/com/twitter/finagle/http2/Http2Listener.scala
@@ -35,16 +35,15 @@ private[finagle] object Http2Listener {
         )
       else new Http2CleartextServerInitializer(_: ChannelInitializer[Channel], params)
 
-    new Http2Listener(params, initializer, mIn, mOut)
+    new Http2Listener(params, initializer)
   }
 }
 
 private[http2] class Http2Listener[In, Out](
   params: Stack.Params,
-  setupMarshalling: ChannelInitializer[Channel] => ChannelHandler,
-  implicit val mIn: Manifest[In],
-  implicit val mOut: Manifest[Out]
-) extends Listener[In, Out, TransportContext] {
+  setupMarshalling: ChannelInitializer[Channel] => ChannelHandler
+)(implicit mIn: Manifest[In], mOut: Manifest[Out])
+  extends Listener[In, Out, TransportContext] {
 
   private[this] val channels = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE)
 


### PR DESCRIPTION
Testing Travis CI.

---
Summary:
Problem

Http2ListenerTest was ignored because it was failing in CI. But now it
seems to be failing outside of CI too.

Solution

Fix and reinstate Http2ListenerTest.

Reviewers: O8464 source:/finagle/finagle-http2/!

Subscribers: #rb_csl

JIRA Issues: CSL-7188

Differential Revision: https://phabricator.twitter.biz/D234161

Problem

Explain the context and why you're making that change.  What is the
problem you're trying to solve? In some cases there is not a problem
and this can be thought of being the motivation for your change.

Solution

Describe the modifications you've done.

Result

What will change as a result of your pull request? Note that sometimes
this section is unnecessary because it is self-explanatory based on
the solution.
