### PR TITLE
Handle empty address sets in TrafficDistributor

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/TrafficDistributor.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/TrafficDistributor.scala
@@ -283,9 +283,6 @@ private class TrafficDistributor[Req, Rep](
   // ServiceFactories that can service requests.
   private[this] val underlying: Event[ServiceFactory[Req, Rep]] =
     weightClasses.foldLeft(init) {
-      case (_, Activity.Ok(List(WeightClass(lb, _, _,sz)))) if sz == 0 =>
-        pending.updateIfEmpty(Return(lb))
-        lb
       case (_, Activity.Ok(wcs)) =>
         val dist = new Distributor(wcs, rng)
         updateGauges(wcs)

--- a/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/TrafficDistributor.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/TrafficDistributor.scala
@@ -213,22 +213,22 @@ private class TrafficDistributor[Req, Rep](
           val lb = newBalancer(Activity(emptyEndpoints))
           balancers + (0.0 -> CachedBalancer(lb, emptyEndpoints, 0))
         } else {
-        weightedGroups.foldLeft(balancers) {
-          case (cache, (weight, factories)) =>
-            val unweighted = factories.map { case WeightedFactory(f, _) => f }
-            val newCacheEntry = if (cache.contains(weight)) {
-              // an update that contains an existing weight class updates
-              // the balancers backing collection.
-              val cached = cache(weight)
-              cached.endpoints.update(Activity.Ok(unweighted))
-              cached.copy(size = unweighted.size)
-            } else {
-              val endpoints: BalancerEndpoints[Req, Rep] = Var(Activity.Ok(unweighted))
-              val lb = newBalancer(Activity(endpoints))
-              CachedBalancer(lb, endpoints, unweighted.size)
-            }
-            cache + (weight -> newCacheEntry)
-        }
+          weightedGroups.foldLeft(balancers) {
+            case (cache, (weight, factories)) =>
+              val unweighted = factories.map { case WeightedFactory(f, _) => f }
+              val newCacheEntry = if (cache.contains(weight)) {
+                // an update that contains an existing weight class updates
+                // the balancers backing collection.
+                val cached = cache(weight)
+                cached.endpoints.update(Activity.Ok(unweighted))
+                cached.copy(size = unweighted.size)
+              } else {
+                val endpoints: BalancerEndpoints[Req, Rep] = Var(Activity.Ok(unweighted))
+                val lb = newBalancer(Activity(endpoints))
+                CachedBalancer(lb, endpoints, unweighted.size)
+              }
+              cache + (weight -> newCacheEntry)
+          }
         }
 
         // weight classes that no longer exist in the update are removed from

--- a/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/TrafficDistributor.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/TrafficDistributor.scala
@@ -208,8 +208,12 @@ private class TrafficDistributor[Req, Rep](
       case (balancers, activeSet) =>
         val weightedGroups: Map[Double, Set[WeightedFactory[Req, Rep]]] =
           activeSet.groupBy(_.weight)
-
-        val merged = weightedGroups.foldLeft(balancers) {
+        val merged = if (weightedGroups.isEmpty) {
+          val emptyEndpoints: BalancerEndpoints[Req, Rep] = Var(Activity.Ok(Set.empty[EndpointFactory[Req, Rep]]))
+          val lb = newBalancer(Activity(emptyEndpoints))
+          balancers + (0.0 -> CachedBalancer(lb, emptyEndpoints, 0))
+        } else {
+        weightedGroups.foldLeft(balancers) {
           case (cache, (weight, factories)) =>
             val unweighted = factories.map { case WeightedFactory(f, _) => f }
             val newCacheEntry = if (cache.contains(weight)) {
@@ -224,6 +228,7 @@ private class TrafficDistributor[Req, Rep](
               CachedBalancer(lb, endpoints, unweighted.size)
             }
             cache + (weight -> newCacheEntry)
+        }
         }
 
         // weight classes that no longer exist in the update are removed from
@@ -278,12 +283,9 @@ private class TrafficDistributor[Req, Rep](
   // ServiceFactories that can service requests.
   private[this] val underlying: Event[ServiceFactory[Req, Rep]] =
     weightClasses.foldLeft(init) {
-      case (_, Activity.Ok(wcs)) if wcs.isEmpty =>
-        // Defer the handling of an empty destination set to `newBalancer`
-        val emptyBal = newBalancer(Activity(Var(Activity.Ok(Set.empty[EndpointFactory[Req, Rep]]))))
-        updateGauges(wcs)
-        pending.updateIfEmpty(Return(emptyBal))
-        emptyBal
+      case (_, Activity.Ok(List(WeightClass(lb, _, _,sz)))) if sz == 0 =>
+        pending.updateIfEmpty(Return(lb))
+        lb
       case (_, Activity.Ok(wcs)) =>
         val dist = new Distributor(wcs, rng)
         updateGauges(wcs)

--- a/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/TrafficDistributorTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/TrafficDistributorTest.scala
@@ -48,14 +48,20 @@ private object TrafficDistributorTest {
   private case class Balancer(endpoints: Activity[Traversable[AddressFactory]])
       extends ServiceFactory[Int, Int] {
     var offeredLoad = 0
+    var balancerIsClosed = false
+    var numOfEndpoints = 0
     def apply(conn: ClientConnection): Future[Service[Int, Int]] = {
       offeredLoad += 1
       // new hotness in load balancing
       val nodes = endpoints.sample().toSeq
+      numOfEndpoints = nodes.size
       if (nodes.isEmpty) Future.exception(new NoBrokersAvailableException)
       else nodes((math.random * nodes.size).toInt)(conn)
     }
-    def close(deadline: Time): Future[Unit] = Future.Done
+    def close(deadline: Time): Future[Unit] = {
+      balancerIsClosed = true
+      Future.Done
+    }
     override def toString: String = s"Balancer($endpoints)"
   }
 
@@ -481,9 +487,30 @@ class TrafficDistributorTest extends FunSuite {
     assert(balancers.size == 2)
 
     dest() = Activity.Ok(Set.empty[Address])
-    val bal1 = intercept[Exception] {Await.result(dist())}
+    val ex = intercept[Exception] {Await.result(dist())}
+    assert(balancers.size == 3)
+  })
+
+  test("ensure empty load balancer is closed after address set updates")(new Ctx{
+    val init: Activity.State[Set[Address]] = Activity.Pending
+    val dest = Var(init)
+    val dist = newDist(dest)
+
+    dest() = Activity.Ok(Set((1, 2.0),(2, 1.0),(3, 2.0)).map(x => WeightedAddress(Address(x._1), x._2)))
+    val bal0 = Await.result(dist())
+    assert(balancers.size == 2)
+
+    dest() = Activity.Ok(Set.empty[Address])
+    val ex = intercept[Exception] {Await.result(dist())}
     assert(balancers.size == 3)
 
-  }
-  )
+    dest() = Activity.Ok(Set((1, 1.0)).map(x => WeightedAddress(Address(x._1), x._2)))
+    val bal2 = Await.result(dist())
+
+    val emptyBalancer = balancers.find(b => b.numOfEndpoints == 0)
+    emptyBalancer match {
+      case Some(bal) => assert(bal.balancerIsClosed)
+      case _ => fail("Empty balancer does not exist")
+    }
+  })
 }

--- a/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/TrafficDistributorTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/TrafficDistributorTest.scala
@@ -487,7 +487,7 @@ class TrafficDistributorTest extends FunSuite {
     assert(balancers.size == 2)
 
     dest() = Activity.Ok(Set.empty[Address])
-    val ex = intercept[Exception] {Await.result(dist())}
+    val ex = intercept[NoBrokersAvailableException] {Await.result(dist())}
     assert(balancers.size == 3)
   })
 
@@ -501,7 +501,7 @@ class TrafficDistributorTest extends FunSuite {
     assert(balancers.size == 2)
 
     dest() = Activity.Ok(Set.empty[Address])
-    val ex = intercept[Exception] {Await.result(dist())}
+    val ex = intercept[NoBrokersAvailableException] {Await.result(dist())}
     assert(balancers.size == 3)
 
     dest() = Activity.Ok(Set((1, 1.0)).map(x => WeightedAddress(Address(x._1), x._2)))


### PR DESCRIPTION
Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>

Problem

Finagle's `TrafficDistributor` is used to build endpoints with their associated weight classes. This endpoint-to-weight class grouping is used to create load balancers used to balance requests for a particular endpoint stack. A `TrafficDistributor`'s load balancer are tracked in the global `BalancerRegistry` every time there is an address set change for a particular service. The issue is that `TrafficDistributor` has two places in its code that creates a load balancer and one of these balancers never gets destroyed when a service is closed. This causes a leak in `BalancerRegistry` This scenario is evident when a service's address set alternates periodically between an empty address set to a valid populated address set.

Solution

This PR removes code that extraneously creates an empty load balancer and adds it to the `partition` method in `TrafficDistributor`. This causes `TrafficDistributor` to manage address state in one area and avoids the object leak.
