### PR TITLE
finagle-redis: Add support for Stream APIs

### DIFF
--- a/finagle-redis/src/it/scala/com/twitter/finagle/redis/commands/streams/StreamsClientIntegrationSuite.scala
+++ b/finagle-redis/src/it/scala/com/twitter/finagle/redis/commands/streams/StreamsClientIntegrationSuite.scala
@@ -1,0 +1,251 @@
+package com.twitter.finagle.redis.commands.streams
+
+import com.twitter.concurrent.ThreadPoolScheduler
+import com.twitter.conversions.time._
+import com.twitter.finagle.redis.{RedisClientTest, XPendingAllReply, XPendingRangeReply}
+import com.twitter.finagle.redis.tags.{ClientTest, RedisTest}
+import com.twitter.finagle.redis.util.BufToString
+import com.twitter.io.Buf
+import com.twitter.util.{Await, CountDownLatch, Promise}
+import org.scalatest.Inside
+
+final class StreamsClientIntegrationSuite extends RedisClientTest with Inside {
+  val TIMEOUT = 5.seconds
+
+  test("Correctly perform stream create/add and read commands", RedisTest, ClientTest) {
+    withRedisClient { client =>
+      val messageId = Await.result(client.xAdd(bufFoo, None, Map(bufBoo -> bufMoo)), TIMEOUT)
+
+      val expected = Seq((messageId, Seq((bufBoo, bufMoo))))
+
+      Await.result(client.xRange(bufFoo, Buf.Utf8("-"), Buf.Utf8("+"), None), TIMEOUT) match {
+        case `expected` =>
+        case x => fail(s"Expected $expected, but got $x")
+      }
+
+      val messageId2 = Await.result(client.xAdd(bufFoo, None, Map(bufBoo -> bufBaz, bufBar -> bufBaz)), TIMEOUT)
+
+      val expected2 = expected ++ Seq((messageId2, Seq((bufBoo, bufBaz), (bufBar, bufBaz))))
+
+      Await.result(client.xRange(bufFoo, Buf.Utf8("-"), Buf.Utf8("+"), None), TIMEOUT) match {
+        case `expected2` =>
+        case x => fail(s"Expected $expected, but got $x")
+      }
+    }
+  }
+
+  test("Correctly perform stream delete commands", RedisTest, ClientTest) {
+    withRedisClient { client =>
+      val stream = Buf.Utf8("a")
+
+      val messageId = Await.result(client.xAdd(stream, None, Map(bufBoo -> bufMoo)), TIMEOUT)
+      val messageId2 = Await.result(client.xAdd(stream, None, Map(bufBoo -> bufMoo)), TIMEOUT)
+
+      val len1 = Await.result(client.xLen(stream), TIMEOUT)
+      assert(len1 == 2)
+
+      val numDeleted = Await.result(client.xDel(stream, Seq(messageId)), TIMEOUT)
+      assert(numDeleted == 1)
+
+      val len2 = Await.result(client.xLen(stream), TIMEOUT)
+      assert(len2 == 1)
+
+      val expected = Seq((messageId2, Seq((bufBoo, bufMoo))))
+      Await.result(client.xRange(stream, Buf.Utf8("-"), Buf.Utf8("+"), None), TIMEOUT) match {
+        case `expected` =>
+        case x => fail(s"Expected $expected, but got $x")
+      }
+    }
+  }
+
+  test("Correctly perform stream range commands", RedisTest, ClientTest) {
+    withRedisClient { client =>
+      val stream = Buf.Utf8("b")
+      val key = Buf.Utf8("key")
+      val alpha = ('a' to 'z').map(_.toString).map(Buf.Utf8.apply)
+
+      val ids = alpha.map(a => Await.result(client.xAdd(stream, None, Map(key -> a)), TIMEOUT))
+
+      val len = Await.result(client.xLen(stream), TIMEOUT)
+      assert(len == 26)
+
+      val expected = ids.zip(alpha).flatMap { case (id, a) => Seq(id -> Seq(key -> a)) }
+      val forward = Await.result(client.xRange(stream, Buf.Utf8("-"), Buf.Utf8("+"), None), TIMEOUT)
+
+      forward match {
+        case `expected` =>
+        case _ => fail()
+      }
+
+      val expectedRev = expected.reverse
+      val reverse = Await.result(client.xRevRange(stream, Buf.Utf8("+"), Buf.Utf8("-"), None), TIMEOUT)
+      reverse match {
+        case `expectedRev` =>
+        case _ => fail()
+      }
+    }
+  }
+
+  test("Correctly perform stream trim commands", RedisTest, ClientTest) {
+    withRedisClient { client =>
+      val stream = Buf.Utf8("trim")
+      val key = Buf.Utf8("key")
+      val alpha = ('a' to 'z').map(_.toString).map(Buf.Utf8.apply)
+
+      val ids = alpha.map(a => Await.result(client.xAdd(stream, None, Map(key -> a)), TIMEOUT))
+
+      val len = Await.result(client.xLen(stream), TIMEOUT)
+      assert(len == 26)
+
+      val trimmed = Await.result(client.xTrim(stream, 1, exact = true), TIMEOUT)
+      assert(trimmed == 25)
+
+      val len2 = Await.result(client.xLen(stream), TIMEOUT)
+      assert(len2 == 1)
+
+      val read = Await.result(client.xRange(stream, Buf.Utf8("-"), Buf.Utf8("+"), None), TIMEOUT)
+      assert(read.size == 1)
+      assert(read.head._1 == ids.last)
+    }
+  }
+
+  test("Correctly perform stream read commands", RedisTest, ClientTest) {
+    val scheduler = new ThreadPoolScheduler("redis_test_1")
+
+    try {
+      val stream = Buf.Utf8("c")
+      val start = Buf.Utf8("$") // Only read items that were pushed to the stream after we start listening
+
+      val countdownLatch = new CountDownLatch(1)
+      val blockingRead = Promise[Seq[(Buf, Seq[(Buf, Seq[(Buf, Buf)])])]]
+
+      withRedisClient { client =>
+        // Start a listener on a separate thread with client 1
+        val submit = () => scheduler.submit(new Runnable {
+          override def run(): Unit = {
+            // Block for max 10 seconds
+            blockingRead.become(client.xRead(None, Some(5000), Seq(stream), Seq(start)))
+            countdownLatch.countDown()
+            Await.result(blockingRead, TIMEOUT)
+          }
+        })
+
+        assert(!blockingRead.isDefined)
+
+        // WIth client B, wait until client A is listening and then send 2 messages to the stream
+        withRedisClient { client2 =>
+          // Start blocking on client A
+          submit()
+          countdownLatch.await()
+
+          // Send an item on the stream
+          val id = Await.result(client2.xAdd(stream, None, Map(bufFoo -> bufBar)), TIMEOUT)
+
+          val expected = Seq(
+            stream -> Seq(id -> Seq(bufFoo -> bufBar))
+          )
+
+          // Client A should have the item we just pushed
+          Await.result(blockingRead, TIMEOUT) match {
+            case `expected` =>
+            case x => fail(s"Expected $expected, but got $x")
+          }
+        }
+      }
+    } finally {
+      scheduler.shutdown()
+    }
+  }
+
+  test("Correctly send messages to read groups", RedisTest, ClientTest) {
+    withRedisClient { client =>
+      val stream = Buf.Utf8("d")
+      val group = Buf.Utf8("group-1")
+      val consumer = Buf.Utf8("consumer-1")
+      val zero = new java.lang.Long(0)
+      val one = new java.lang.Long(1)
+
+      // Must create stream before adding read group
+      Await.result(client.xAdd(stream, None, Map(bufFoo -> bufBar)), TIMEOUT)
+
+      Await.result(client.xGroupCreate(stream, group, Buf.Utf8("0")), TIMEOUT)
+
+      val read = Await.result(client.xReadGroup(group, consumer, Some(1), None, Seq(stream), Seq(Buf.Utf8("0"))), TIMEOUT)
+
+      read match {
+        case Seq((`stream`, Seq((_, Seq((`bufFoo`, `bufBar`)))))) =>
+        case _ => fail()
+      }
+
+      val pendingId = read.head._2.head._1
+
+      val pending1 = Await.result(client.xPending(stream, group), TIMEOUT)
+
+      val expected1 = XPendingAllReply(one, Some(pendingId), Some(pendingId), Seq(consumer -> Buf.Utf8("1")))
+
+      pending1 match {
+        case `expected1` =>
+        case n => fail(s"Expected $expected1 but got $n")
+      }
+
+      val pending2 = Await.result(client.xPending(stream, group, Buf.Utf8("-"), Buf.Utf8("+"), 10, None), TIMEOUT)
+      pending2 match {
+        case Seq(XPendingRangeReply(`pendingId`, `consumer`, _, `one`)) =>
+        case _ => fail()
+      }
+
+      assert(Await.result(client.xAck(stream, group, Seq(pendingId))) == 1, TIMEOUT)
+
+      Await.result(client.xPending(stream, group), TIMEOUT) match {
+        case XPendingAllReply(`zero`, _, _, Seq()) =>
+        case n => fail(s"Unexpected state $n")
+      }
+
+      Await.result(client.xPending(stream, group, Buf.Utf8("-"), Buf.Utf8("+"), 10, None), TIMEOUT) match {
+        case Seq() =>
+        case n => fail(s"Unexpected state $n")
+      }
+    }
+  }
+
+  test("Correctly claim pending messages from other consumers", RedisTest, ClientTest) {
+    withRedisClient { client =>
+      val stream = Buf.Utf8("e")
+      val group = Buf.Utf8("group-1")
+      val consumer = Buf.Utf8("consumer-1")
+      val consumer2 = Buf.Utf8("consumer-2")
+      val one = new java.lang.Long(1)
+
+      // Must create stream before adding read group
+      val id = Await.result(client.xAdd(stream, None, Map(bufFoo -> bufBar)), TIMEOUT)
+
+      Await.result(client.xGroupCreate(stream, group, Buf.Utf8("0")), TIMEOUT)
+
+      val read = Await.result(client.xReadGroup(group, consumer, Some(1), None, Seq(stream), Seq(Buf.Utf8("0"))), TIMEOUT)
+
+      read match {
+        case Seq((`stream`, Seq((_, Seq((`bufFoo`, `bufBar`)))))) =>
+        case _ => fail()
+      }
+
+      val pendingId = read.head._2.head._1
+
+      val pending1 = Await.result(client.xPending(stream, group), TIMEOUT)
+
+      val expected1 = XPendingAllReply(one, Some(pendingId), Some(pendingId), Seq(consumer -> Buf.Utf8("1")))
+
+      pending1 match {
+        case `expected1` =>
+        case n => fail(s"Expected $expected1 but got $n")
+      }
+
+      val claimed = Await.result(client.xClaim(stream, group, consumer2, 0, Seq(id), None, None, false, false), TIMEOUT)
+
+
+      claimed match {
+        case Seq((`id`, Seq((`bufFoo`, `bufBar`)))) =>
+        case _ => fail()
+      }
+    }
+  }
+}

--- a/finagle-redis/src/it/scala/com/twitter/finagle/redis/commands/streams/StreamsClientIntegrationSuite.scala
+++ b/finagle-redis/src/it/scala/com/twitter/finagle/redis/commands/streams/StreamsClientIntegrationSuite.scala
@@ -1,36 +1,27 @@
 package com.twitter.finagle.redis.commands.streams
 
 import com.twitter.concurrent.ThreadPoolScheduler
-import com.twitter.conversions.time._
-import com.twitter.finagle.redis.{RedisClientTest, XPendingAllReply, XPendingRangeReply}
 import com.twitter.finagle.redis.tags.{ClientTest, RedisTest}
-import com.twitter.finagle.redis.util.BufToString
+import com.twitter.finagle.redis._
 import com.twitter.io.Buf
-import com.twitter.util.{Await, CountDownLatch, Promise}
+import com.twitter.util._
 import org.scalatest.Inside
 
 final class StreamsClientIntegrationSuite extends RedisClientTest with Inside {
-  val TIMEOUT = 5.seconds
-
   test("Correctly perform stream create/add and read commands", RedisTest, ClientTest) {
     withRedisClient { client =>
-      val messageId = Await.result(client.xAdd(bufFoo, None, Map(bufBoo -> bufMoo)), TIMEOUT)
+      val messageId = result(client.xAdd(bufFoo, None, Map(bufBoo -> bufMoo)))
 
-      val expected = Seq((messageId, Seq((bufBoo, bufMoo))))
+      val expected = Seq(StreamEntryReply(messageId, Seq((bufBoo, bufMoo))))
+      val rangeRes = result(client.xRange(bufFoo, Buf.Utf8("-"), Buf.Utf8("+"), None))
 
-      Await.result(client.xRange(bufFoo, Buf.Utf8("-"), Buf.Utf8("+"), None), TIMEOUT) match {
-        case `expected` =>
-        case x => fail(s"Expected $expected, but got $x")
-      }
+      assert(rangeRes == expected, s"Expected $expected, but got $rangeRes")
 
-      val messageId2 = Await.result(client.xAdd(bufFoo, None, Map(bufBoo -> bufBaz, bufBar -> bufBaz)), TIMEOUT)
+      val messageId2 = result(client.xAdd(bufFoo, None, Map(bufBoo -> bufBaz, bufBar -> bufBaz)))
 
-      val expected2 = expected ++ Seq((messageId2, Seq((bufBoo, bufBaz), (bufBar, bufBaz))))
-
-      Await.result(client.xRange(bufFoo, Buf.Utf8("-"), Buf.Utf8("+"), None), TIMEOUT) match {
-        case `expected2` =>
-        case x => fail(s"Expected $expected, but got $x")
-      }
+      val expected2 = expected ++ Seq(StreamEntryReply(messageId2, Seq((bufBoo, bufBaz), (bufBar, bufBaz))))
+      val rangeRes2 = result(client.xRange(bufFoo, Buf.Utf8("-"), Buf.Utf8("+"), None))
+      assert(rangeRes2 == expected2, s"Expected $expected2, but got $rangeRes2")
     }
   }
 
@@ -38,20 +29,20 @@ final class StreamsClientIntegrationSuite extends RedisClientTest with Inside {
     withRedisClient { client =>
       val stream = Buf.Utf8("a")
 
-      val messageId = Await.result(client.xAdd(stream, None, Map(bufBoo -> bufMoo)), TIMEOUT)
-      val messageId2 = Await.result(client.xAdd(stream, None, Map(bufBoo -> bufMoo)), TIMEOUT)
+      val messageId = result(client.xAdd(stream, None, Map(bufBoo -> bufMoo)))
+      val messageId2 = result(client.xAdd(stream, None, Map(bufBoo -> bufMoo)))
 
-      val len1 = Await.result(client.xLen(stream), TIMEOUT)
+      val len1 = result(client.xLen(stream))
       assert(len1 == 2)
 
-      val numDeleted = Await.result(client.xDel(stream, Seq(messageId)), TIMEOUT)
+      val numDeleted = result(client.xDel(stream, Seq(messageId)))
       assert(numDeleted == 1)
 
-      val len2 = Await.result(client.xLen(stream), TIMEOUT)
+      val len2 = result(client.xLen(stream))
       assert(len2 == 1)
 
-      val expected = Seq((messageId2, Seq((bufBoo, bufMoo))))
-      Await.result(client.xRange(stream, Buf.Utf8("-"), Buf.Utf8("+"), None), TIMEOUT) match {
+      val expected = Seq(StreamEntryReply(messageId2, Seq((bufBoo, bufMoo))))
+      result(client.xRange(stream, Buf.Utf8("-"), Buf.Utf8("+"), None)) match {
         case `expected` =>
         case x => fail(s"Expected $expected, but got $x")
       }
@@ -64,13 +55,13 @@ final class StreamsClientIntegrationSuite extends RedisClientTest with Inside {
       val key = Buf.Utf8("key")
       val alpha = ('a' to 'z').map(_.toString).map(Buf.Utf8.apply)
 
-      val ids = alpha.map(a => Await.result(client.xAdd(stream, None, Map(key -> a)), TIMEOUT))
+      val ids = alpha.map(a => result(client.xAdd(stream, None, Map(key -> a))))
 
-      val len = Await.result(client.xLen(stream), TIMEOUT)
+      val len = result(client.xLen(stream))
       assert(len == 26)
 
-      val expected = ids.zip(alpha).flatMap { case (id, a) => Seq(id -> Seq(key -> a)) }
-      val forward = Await.result(client.xRange(stream, Buf.Utf8("-"), Buf.Utf8("+"), None), TIMEOUT)
+      val expected = ids.zip(alpha).flatMap { case (id, a) => Seq(StreamEntryReply(id, Seq(key -> a))) }
+      val forward = result(client.xRange(stream, Buf.Utf8("-"), Buf.Utf8("+"), None))
 
       forward match {
         case `expected` =>
@@ -78,7 +69,7 @@ final class StreamsClientIntegrationSuite extends RedisClientTest with Inside {
       }
 
       val expectedRev = expected.reverse
-      val reverse = Await.result(client.xRevRange(stream, Buf.Utf8("+"), Buf.Utf8("-"), None), TIMEOUT)
+      val reverse = result(client.xRevRange(stream, Buf.Utf8("+"), Buf.Utf8("-"), None))
       reverse match {
         case `expectedRev` =>
         case _ => fail()
@@ -92,20 +83,20 @@ final class StreamsClientIntegrationSuite extends RedisClientTest with Inside {
       val key = Buf.Utf8("key")
       val alpha = ('a' to 'z').map(_.toString).map(Buf.Utf8.apply)
 
-      val ids = alpha.map(a => Await.result(client.xAdd(stream, None, Map(key -> a)), TIMEOUT))
+      val ids = alpha.map(a => result(client.xAdd(stream, None, Map(key -> a))))
 
-      val len = Await.result(client.xLen(stream), TIMEOUT)
+      val len = result(client.xLen(stream))
       assert(len == 26)
 
-      val trimmed = Await.result(client.xTrim(stream, 1, exact = true), TIMEOUT)
+      val trimmed = result(client.xTrim(stream, 1, exact = true))
       assert(trimmed == 25)
 
-      val len2 = Await.result(client.xLen(stream), TIMEOUT)
+      val len2 = result(client.xLen(stream))
       assert(len2 == 1)
 
-      val read = Await.result(client.xRange(stream, Buf.Utf8("-"), Buf.Utf8("+"), None), TIMEOUT)
+      val read = result(client.xRange(stream, Buf.Utf8("-"), Buf.Utf8("+"), None))
       assert(read.size == 1)
-      assert(read.head._1 == ids.last)
+      assert(read.head.id == ids.last)
     }
   }
 
@@ -117,7 +108,7 @@ final class StreamsClientIntegrationSuite extends RedisClientTest with Inside {
       val start = Buf.Utf8("$") // Only read items that were pushed to the stream after we start listening
 
       val countdownLatch = new CountDownLatch(1)
-      val blockingRead = Promise[Seq[(Buf, Seq[(Buf, Seq[(Buf, Buf)])])]]
+      val blockingRead = Promise[Seq[XReadStreamReply]]
 
       withRedisClient { client =>
         // Start a listener on a separate thread with client 1
@@ -126,7 +117,7 @@ final class StreamsClientIntegrationSuite extends RedisClientTest with Inside {
             // Block for max 10 seconds
             blockingRead.become(client.xRead(None, Some(5000), Seq(stream), Seq(start)))
             countdownLatch.countDown()
-            Await.result(blockingRead, TIMEOUT)
+            result(blockingRead)
           }
         })
 
@@ -139,14 +130,14 @@ final class StreamsClientIntegrationSuite extends RedisClientTest with Inside {
           countdownLatch.await()
 
           // Send an item on the stream
-          val id = Await.result(client2.xAdd(stream, None, Map(bufFoo -> bufBar)), TIMEOUT)
+          val id = result(client2.xAdd(stream, None, Map(bufFoo -> bufBar)))
 
           val expected = Seq(
-            stream -> Seq(id -> Seq(bufFoo -> bufBar))
+            XReadStreamReply(stream, Seq(StreamEntryReply(id, Seq(bufFoo -> bufBar))))
           )
 
           // Client A should have the item we just pushed
-          Await.result(blockingRead, TIMEOUT) match {
+          result(blockingRead) match {
             case `expected` =>
             case x => fail(s"Expected $expected, but got $x")
           }
@@ -166,45 +157,38 @@ final class StreamsClientIntegrationSuite extends RedisClientTest with Inside {
       val one = new java.lang.Long(1)
 
       // Must create stream before adding read group
-      Await.result(client.xAdd(stream, None, Map(bufFoo -> bufBar)), TIMEOUT)
+      result(client.xAdd(stream, None, Map(bufFoo -> bufBar)))
 
-      Await.result(client.xGroupCreate(stream, group, Buf.Utf8("0")), TIMEOUT)
+      result(client.xGroupCreate(stream, group, Buf.Utf8("0")))
 
-      val read = Await.result(client.xReadGroup(group, consumer, Some(1), None, Seq(stream), Seq(Buf.Utf8("0"))), TIMEOUT)
+      val read = result(client.xReadGroup(group, consumer, Some(1), None, Seq(stream), Seq(Buf.Utf8("0"))))
 
       read match {
-        case Seq((`stream`, Seq((_, Seq((`bufFoo`, `bufBar`)))))) =>
+        case Seq(XReadStreamReply(`stream`, Seq(StreamEntryReply(_, Seq((`bufFoo`, `bufBar`)))))) =>
         case _ => fail()
       }
 
-      val pendingId = read.head._2.head._1
+      val pendingId = read.head.entries.head.id
 
-      val pending1 = Await.result(client.xPending(stream, group), TIMEOUT)
-
+      val pending1 = result(client.xPending(stream, group))
       val expected1 = XPendingAllReply(one, Some(pendingId), Some(pendingId), Seq(consumer -> Buf.Utf8("1")))
 
-      pending1 match {
-        case `expected1` =>
-        case n => fail(s"Expected $expected1 but got $n")
-      }
+      assert(pending1 == expected1, s"Expected $expected1 but got $pending1")
 
-      val pending2 = Await.result(client.xPending(stream, group, Buf.Utf8("-"), Buf.Utf8("+"), 10, None), TIMEOUT)
+      val pending2 = result(client.xPending(stream, group, Buf.Utf8("-"), Buf.Utf8("+"), 10, None))
       pending2 match {
         case Seq(XPendingRangeReply(`pendingId`, `consumer`, _, `one`)) =>
         case _ => fail()
       }
 
-      assert(Await.result(client.xAck(stream, group, Seq(pendingId))) == 1, TIMEOUT)
+      assert(result(client.xAck(stream, group, Seq(pendingId))) == 1)
 
-      Await.result(client.xPending(stream, group), TIMEOUT) match {
+      result(client.xPending(stream, group)) match {
         case XPendingAllReply(`zero`, _, _, Seq()) =>
         case n => fail(s"Unexpected state $n")
       }
 
-      Await.result(client.xPending(stream, group, Buf.Utf8("-"), Buf.Utf8("+"), 10, None), TIMEOUT) match {
-        case Seq() =>
-        case n => fail(s"Unexpected state $n")
-      }
+      assert(result(client.xPending(stream, group, Buf.Utf8("-"), Buf.Utf8("+"), 10, None)).isEmpty)
     }
   }
 
@@ -217,35 +201,27 @@ final class StreamsClientIntegrationSuite extends RedisClientTest with Inside {
       val one = new java.lang.Long(1)
 
       // Must create stream before adding read group
-      val id = Await.result(client.xAdd(stream, None, Map(bufFoo -> bufBar)), TIMEOUT)
+      val id = result(client.xAdd(stream, None, Map(bufFoo -> bufBar)))
 
-      Await.result(client.xGroupCreate(stream, group, Buf.Utf8("0")), TIMEOUT)
+      result(client.xGroupCreate(stream, group, Buf.Utf8("0")))
 
-      val read = Await.result(client.xReadGroup(group, consumer, Some(1), None, Seq(stream), Seq(Buf.Utf8("0"))), TIMEOUT)
+      val read = result(client.xReadGroup(group, consumer, Some(1), None, Seq(stream), Seq(Buf.Utf8("0"))))
 
       read match {
-        case Seq((`stream`, Seq((_, Seq((`bufFoo`, `bufBar`)))))) =>
+        case Seq(XReadStreamReply(`stream`, Seq(StreamEntryReply(_, Seq((`bufFoo`, `bufBar`)))))) =>
         case _ => fail()
       }
 
-      val pendingId = read.head._2.head._1
+      val pendingId = read.head.entries.head.id
 
-      val pending1 = Await.result(client.xPending(stream, group), TIMEOUT)
-
+      val pending1 = result(client.xPending(stream, group))
       val expected1 = XPendingAllReply(one, Some(pendingId), Some(pendingId), Seq(consumer -> Buf.Utf8("1")))
 
-      pending1 match {
-        case `expected1` =>
-        case n => fail(s"Expected $expected1 but got $n")
-      }
+      assert(pending1 == expected1, s"Expected $expected1 but got $expected1")
 
-      val claimed = Await.result(client.xClaim(stream, group, consumer2, 0, Seq(id), None, None, false, false), TIMEOUT)
+      val claimed = result(client.xClaim(stream, group, consumer2, 0, Seq(id), None, None, false, false))
 
-
-      claimed match {
-        case Seq((`id`, Seq((`bufFoo`, `bufBar`)))) =>
-        case _ => fail()
-      }
+      assert(claimed == Seq(StreamEntryReply(`id`, Seq(`bufFoo` -> `bufBar`))))
     }
   }
 }

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/Client.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/Client.scala
@@ -45,7 +45,8 @@ trait NormalCommands
     with PubSubCommands
     with ServerCommands
     with ScriptCommands
-    with ConnectionCommands { self: BaseClient =>
+    with ConnectionCommands
+    with StreamCommands { self: BaseClient =>
 }
 
 trait Transactions { self: Client =>

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/StreamCommands.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/StreamCommands.scala
@@ -1,0 +1,300 @@
+package com.twitter.finagle.redis
+
+import com.twitter.finagle.redis.protocol._
+import com.twitter.finagle.redis.util.ReplyFormat
+import com.twitter.io.Buf
+import com.twitter.util.Future
+import java.lang.{Long => JLong}
+
+private[redis] trait StreamCommands { self: BaseClient =>
+  /**
+   * Pushes the fields and values in `fv` onto the stream at `key`. If `id` is None
+   * an ID will be generated for the message, otherwise the passed `id` will be used
+   *
+   * @param key
+   * @param id
+   * @param fv
+   * @return The ID for the message
+   * @see https://redis.io/commands/xadd
+   */
+  def xAdd(key: Buf, id: Option[Buf], fv: Map[Buf, Buf]): Future[Buf] =
+    doRequest(XAdd(key, id, fv)) {
+      case BulkReply(message) => Future.value(message)
+    }
+
+  /**
+   * Trims the stream at `key` to a particular number of items indicated by `size`. If `exact`
+   * is false, Redis will trim to approximately the indicated size (which is more efficient)
+   *
+   * @param key
+   * @param size
+   * @param exact
+   * @return The number of items removed from the stream
+   * @see https://redis.io/commands/xtrim
+   */
+  def xTrim(key: Buf, size: Long, exact: Boolean): Future[JLong] =
+    doRequest(XTrim(key, size, exact)) {
+      case IntegerReply(n) => Future.value(n)
+    }
+
+  /**
+   * Removes specified entries from the stream at `key`
+   *
+   * @param key
+   * @param ids
+   * @return The number of entries deleted
+   * @see https://redis.io/commands/xdel
+   */
+  def xDel(key: Buf, ids: Seq[Buf]): Future[JLong] =
+    doRequest(XDel(key, ids)) {
+      case IntegerReply(n) => Future.value(n)
+    }
+
+  /**
+   * Returns entries from the stream at `key` in the range of `start` to `end`. If `count` is specified no more than `count`
+   * items will be returned
+   *
+   * @param key
+   * @param start
+   * @param end
+   * @param count
+   * @return A sequence of entries
+   * @see https://redis.io/commands/xrange
+   */
+  def xRange(key: Buf, start: Buf, end: Buf, count: Option[Long]): Future[Seq[(Buf, Seq[(Buf, Buf)])]] =
+    doRequest(XRange(key, start, end, count)) {
+      case NilMBulkReply | EmptyMBulkReply => Future.value(Seq.empty)
+      case MBulkReply(replies) => Future.value(handleRangeReply(replies))
+    }
+
+  /**
+   * Like XRANGE, but returns entries in reverse order
+   *
+   * @param key
+   * @param start
+   * @param end
+   * @param count
+   * @return A sequence of entries
+   * @see https://redis.io/commands/xrevrange
+   */
+  def xRevRange(key: Buf, start: Buf, end: Buf, count: Option[Long]): Future[Seq[(Buf, Seq[(Buf, Buf)])]] =
+    doRequest(XRevRange(key, start, end, count)) {
+      case NilMBulkReply | EmptyMBulkReply => Future.value(Seq.empty)
+      case MBulkReply(replies) => Future.value(handleRangeReply(replies))
+    }
+
+  /**
+   *
+   * @param key
+   * @return
+   * @see https://redis.io/commands/xlen
+   */
+  def xLen(key: Buf): Future[JLong] =
+    doRequest(XLen(key)) {
+      case IntegerReply(n) => Future.value(n)
+    }
+
+  /**
+   * Reads entries from one or many streams
+   *
+   * @param count The maximum amount of messages to return per-stream
+   * @param blockMs If no messages are available on the given streams, block for this many millis to awai entries
+   * @param keys
+   * @param ids
+   * @return
+   * @see https://redis.io/commands/xread
+   */
+  def xRead(count: Option[Long], blockMs: Option[Long], keys: Seq[Buf], ids: Seq[Buf]): Future[Seq[(Buf, Seq[(Buf, Seq[(Buf, Buf)])])]] =
+    doRequest(XRead(count, blockMs, keys, ids)) {
+      case NilMBulkReply | EmptyMBulkReply => Future.value(Seq.empty)
+      case MBulkReply(replies) => Future.value(handleReadReply(replies))
+    }
+
+  /**
+   * Reads from one or many streams within the context `group` for `consumer`.
+   *
+   * @param group
+   * @param consumer
+   * @param count The maximum amount of messages to return per-stream
+   * @param blockMs If no messages are available on the given streams, block for this many millis to awai entries
+   * @param keys
+   * @param ids
+   * @return
+   * @see https://redis.io/commands/xreadgroup
+   */
+  def xReadGroup(group: Buf, consumer: Buf, count: Option[Long], blockMs: Option[Long], keys: Seq[Buf], ids: Seq[Buf]): Future[Seq[(Buf, Seq[(Buf, Seq[(Buf, Buf)])])]] =
+    doRequest(XReadGroup(group, consumer, count, blockMs, keys, ids)) {
+      case NilMBulkReply | EmptyMBulkReply => Future.value(Seq.empty)
+      case MBulkReply(replies) => Future.value(handleReadReply(replies))
+    }
+
+  /**
+   * Creates a new consumer group named `groupName` for stream `key` starting at entry `id`
+   *
+   * @param key
+   * @param groupName
+   * @param id
+   * @return
+   * @see https://redis.io/commands/xgroup
+   */
+  def xGroupCreate(key: Buf, groupName: Buf, id: Buf): Future[Unit] =
+    doRequest(XGroupCreate(key, groupName, id)) {
+      case StatusReply(_) => Future.Unit
+    }
+
+  /**
+   *
+   * @param key
+   * @param id
+   * @return
+   * @see https://redis.io/commands/xgroup
+   */
+  def xGroupSetId(key: Buf, id: Buf): Future[Unit] =
+    doRequest(XGroupSetId(key, id)) {
+      case StatusReply(_) => Future.Unit
+    }
+
+  /**
+   *
+   * @param key
+   * @param groupName
+   * @return
+   * @see https://redis.io/commands/xgroup
+   */
+  def xGroupDestroy(key: Buf, groupName: Buf): Future[Unit] =
+    doRequest(XGroupDestroy(key, groupName)) {
+      case StatusReply(_) => Future.Unit
+    }
+
+  /**
+   *
+   * @param key
+   * @param groupName
+   * @param consumerName
+   * @return
+   * @see https://redis.io/commands/xgroup
+   */
+  def xGroupDelConsumer(key: Buf, groupName: Buf, consumerName: Buf): Future[Unit] =
+    doRequest(XGroupDelConsumer(key, groupName, consumerName)) {
+      case StatusReply(_) => Future.Unit
+    }
+
+  /**
+   * Removes entries from the pending list with `ids` from the stream at `key` within the context of `group`
+   *
+   * @param key
+   * @param group
+   * @param ids
+   * @return The number of messages acked
+   * @see https://redis.io/commands/xack
+   */
+  def xAck(key: Buf, group: Buf, ids: Seq[Buf]): Future[JLong] =
+    doRequest(XAck(key, group, ids)) {
+      case IntegerReply(n) => Future.value(n)
+    }
+
+  /**
+   * Retrieves all pending messages within the stream at `key` for `group`
+   * @param key
+   * @param group
+   * @return
+   * @see https://redis.io/commands/xpending
+   */
+  def xPending(key: Buf, group: Buf): Future[XPendingAllReply] =
+    doRequest(XPending(key, group)) {
+      case MBulkReply(IntegerReply(count) :: BulkReply(start) :: BulkReply(end) :: MBulkReply(consumerCounts) :: Nil) =>
+        val consumerAndCount = consumerCounts.collect {
+          case MBulkReply(BulkReply(consumer) :: BulkReply(consumerCount) :: Nil) => consumer -> consumerCount
+        }
+
+        Future.value(XPendingAllReply(count, Some(start), Some(end), consumerAndCount))
+
+      case MBulkReply(IntegerReply(count) :: EmptyBulkReply :: EmptyBulkReply :: NilMBulkReply :: Nil) =>
+        Future.value(XPendingAllReply(count, None, None, Seq.empty))
+    }
+
+  /**
+   * Returns all pending messages within a range, optionally for a specific consumer
+   *
+   * @param key
+   * @param group
+   * @param start
+   * @param end
+   * @param count
+   * @param consumer
+   * @return
+   * @see https://redis.io/commands/xpending
+   */
+  def xPending(key: Buf, group: Buf, start: Buf, end: Buf, count: Long, consumer: Option[Buf]): Future[Seq[XPendingRangeReply]] =
+    doRequest(XPendingRange(key, group, start, end, count, consumer)) {
+      case MBulkReply(pending) =>
+        Future.value {
+          pending.collect {
+            case MBulkReply(BulkReply(id) :: BulkReply(consumerId) :: IntegerReply(ms) :: IntegerReply(deliveries) :: Nil) =>
+              XPendingRangeReply(id, consumerId, ms, deliveries)
+          }
+        }
+
+      case NilMBulkReply | EmptyMBulkReply => Future.value(Seq.empty)
+    }
+
+  /**
+   * Changes the ownership of pending entries to `consumer` with `ids` within the stream at `key` within the context
+   * of `group`.
+   *
+   * @param key
+   * @param group
+   * @param consumer
+   * @param minIdleTime
+   * @param ids
+   * @param idle
+   * @param retryCount
+   * @param force
+   * @param justId
+   * @return If justId is true, a sequence of claimed IDs, otherwise claimed IDs and the contents of the entries
+   * @see https://redis.io/commands/xclaim
+   */
+  def xClaim(
+    key: Buf,
+    group: Buf,
+    consumer: Buf,
+    minIdleTime: Long,
+    ids: Seq[Buf],
+    idle: Option[XClaimMillisOrUnixTs],
+    retryCount: Option[Long],
+    force: Boolean,
+    justId: Boolean
+  ): Future[Seq[(Buf, Seq[(Buf, Buf)])]] = {
+    doRequest(XClaim(key, group, consumer, minIdleTime, ids, idle, retryCount, force, justId)) {
+      case MBulkReply(replies) if justId => Future.value(handleRangeReply(replies))
+      case MBulkReply(replies) => Future.value(ReplyFormat.toBuf(replies).map(_ -> Seq.empty))
+      case NilMBulkReply | EmptyMBulkReply => Future.value(Seq.empty)
+    }
+  }
+
+  private[redis] def handleReadReply(replies: List[Reply]) = {
+    replies.collect {
+      case MBulkReply(BulkReply(stream) :: MBulkReply(entries) :: Nil) => stream -> handleRangeReply(entries)
+    }
+  }
+
+  private[redis] def handleRangeReply(replies: List[Reply]) = {
+    replies.collect {
+      case MBulkReply(BulkReply(id) :: MBulkReply(fields) :: Nil) => id -> returnPairs(ReplyFormat.toBuf(fields))
+    }
+  }
+}
+
+case class XPendingAllReply(
+  count: JLong,
+  start: Option[Buf],
+  end: Option[Buf],
+  pendingByConsumer: Seq[(Buf, Buf)]
+)
+
+case class XPendingRangeReply(
+  id: Buf,
+  consumer: Buf,
+  millisSinceLastDeliver: JLong,
+  numDeliveries: JLong
+)

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/Command.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/Command.scala
@@ -204,6 +204,21 @@ object Command {
   val COUNT = Buf.Utf8("COUNT")
   val MATCH = Buf.Utf8("MATCH")
 
+  // Streams
+  val XINFO = Buf.Utf8("XINFO")
+  val XADD = Buf.Utf8("XADD")
+  val XTRIM = Buf.Utf8("XTRIM")
+  val XDEL = Buf.Utf8("XDEL")
+  val XRANGE = Buf.Utf8("XRANGE")
+  val XREVRANGE = Buf.Utf8("XREVRANGE")
+  val XLEN = Buf.Utf8("XLEN")
+  val XREAD = Buf.Utf8("XREAD")
+  val XREADGROUP = Buf.Utf8("XREADGROUP")
+  val XGROUP = Buf.Utf8("XGROUP")
+  val XACK = Buf.Utf8("XACK")
+  val XCLAIM = Buf.Utf8("XCLAIM")
+  val XPENDING = Buf.Utf8("XPENDING")
+
   /**
    * Encodes a given [[Command]] as [[Buf]].
    */

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/Streams.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/Streams.scala
@@ -1,0 +1,212 @@
+package com.twitter.finagle.redis.protocol
+
+import com.twitter.io.Buf
+
+abstract class XInfo(sub: Buf, args: Seq[Buf] = Seq()) extends Command {
+  RequireClientProtocol(args.forall(_.length > 0), "Found empty arg")
+
+  override def name: Buf = Command.XINFO
+
+  override def body: Seq[Buf] = sub +: args
+}
+
+case class XInfoConsumers(key: Buf, groupname: Buf) extends XInfo(Buf.Utf8("CONSUMERS"), Seq(key, groupname))
+
+case class XInfoGroups(key: Buf) extends XInfo(Buf.Utf8("GROUPS"), Seq(key))
+
+case class XInfoStream(key: Buf) extends XInfo(Buf.Utf8("STREAM"), Seq(key))
+
+case object XInfoHelp extends XInfo(Buf.Utf8("HELP"))
+
+object XAdd {
+  final val AutogenId = Buf.Utf8("*")
+}
+
+case class XAdd(key: Buf, id: Option[Buf], fv: Map[Buf, Buf]) extends StrictKeyCommand {
+  override def name: Buf = Command.XADD
+
+  override def body: Seq[Buf] = {
+    val fvList: Seq[Buf] = fv.flatMap {
+      case (f, v) => f :: v :: Nil
+    }(collection.breakOut)
+
+    Seq(key, id.getOrElse(XAdd.AutogenId)) ++ fvList
+  }
+
+  override protected def validate(): Unit = {
+    super.validate()
+    RequireClientProtocol(id.isEmpty || id.exists(!_.isEmpty), "ID cannot be empty")
+    RequireClientProtocol(fv.nonEmpty, "Must pass field/value pairs")
+    RequireClientProtocol(fv.forall { case (f, v) => !f.isEmpty && !v.isEmpty }, "All field value pairs must be non-empty")
+  }
+}
+
+case class XTrim(key: Buf, size: Long, exact: Boolean) extends StrictKeyCommand {
+  override def name: Buf = Command.XTRIM
+
+  override def body: Seq[Buf] = {
+    val exactPart = if (exact) None else Some(Buf.Utf8("~"))
+    val args = (Some(Buf.Utf8("MAXLEN")) :: exactPart :: Some(Buf.Utf8(size.toString)) :: Nil).flatten
+    Seq(key) ++ args
+  }
+
+  override protected def validate(): Unit = {
+    super.validate()
+    RequireClientProtocol(size >= 0, "Size must be >= 0")
+  }
+}
+
+case class XDel(key: Buf, ids: Seq[Buf]) extends StrictKeysCommand {
+  override def name: Buf = Command.XDEL
+
+  override def keys: Seq[Buf] = ids
+
+  override def body: Seq[Buf] = Seq(key) ++ ids
+}
+
+abstract class XRangeCommand(key: Buf, start: Buf, end: Buf, count: Option[Long], reversed: Boolean = false) extends StrictKeyCommand {
+  override def name: Buf = if (reversed) Command.XREVRANGE else Command.XRANGE
+
+  override def body: Seq[Buf] = {
+    val countSeq = count.map(c => Seq(Buf.Utf8("COUNT"), Buf.Utf8(c.toString))).getOrElse(Seq.empty)
+    Seq(key, start, end) ++ countSeq
+  }
+
+  override protected def validate(): Unit = {
+    super.validate()
+    RequireClientProtocol(start.length > 0, "Start cannot be empty")
+    RequireClientProtocol(end.length > 0, "End cannot be empty")
+  }
+}
+
+case class XRange(key: Buf, start: Buf, end: Buf, count: Option[Long]) extends XRangeCommand(key, start, end, count)
+
+case class XRevRange(key: Buf, start: Buf, end: Buf, count: Option[Long]) extends XRangeCommand(key, start, end, count, reversed = true)
+
+case class XLen(key: Buf) extends StrictKeyCommand {
+  override def name: Buf = Command.XLEN
+}
+
+case class XRead(count: Option[Long], blockMs: Option[Long], keys: Seq[Buf], ids: Seq[Buf]) extends Command {
+  RequireClientProtocol(keys.nonEmpty, "Empty stream keys")
+  RequireClientProtocol(ids.nonEmpty, "Empty stream Ids")
+  RequireClientProtocol(keys.size == ids.size, "Must have same number of stream keys and IDs")
+
+  override def name: Buf = Command.XREAD
+
+  override def body: Seq[Buf] = {
+    val countSeq = count.map(c => Seq("COUNT", c.toString).map(Buf.Utf8.apply)).getOrElse(Seq.empty)
+    val blockSeq = blockMs.map(b => Seq("BLOCK", b.toString).map(Buf.Utf8.apply)).getOrElse(Seq.empty)
+    countSeq ++ blockSeq ++ Seq(Buf.Utf8("STREAMS")) ++ keys ++ ids
+  }
+}
+
+case class XReadGroup(group: Buf, consumer: Buf, count: Option[Long], blockMs: Option[Long], keys: Seq[Buf], ids: Seq[Buf]) extends Command {
+  RequireClientProtocol(keys.nonEmpty, "Empty stream keys")
+  RequireClientProtocol(ids.nonEmpty, "Empty stream Ids")
+  RequireClientProtocol(keys.size == ids.size, "Must have same number of stream keys and IDs")
+
+  override def name: Buf = Command.XREADGROUP
+
+  override def body: Seq[Buf] = {
+    val countSeq = count.map(c => Seq("COUNT", c.toString).map(Buf.Utf8.apply)).getOrElse(Seq.empty)
+    val blockSeq = blockMs.map(b => Seq("BLOCK", b.toString).map(Buf.Utf8.apply)).getOrElse(Seq.empty)
+    Seq(Buf.Utf8("GROUP"), group, consumer) ++ countSeq ++ blockSeq ++ Seq(Buf.Utf8("STREAMS")) ++ keys ++ ids
+  }
+}
+
+
+abstract class XGroupCommand(sub: Buf, args: Seq[Buf] = Seq()) extends StrictKeyCommand {
+  RequireClientProtocol(args.forall(_.length > 0), "Empty key found")
+
+  override def name: Buf = Command.XGROUP
+
+  override def body: Seq[Buf] = sub +: args
+}
+
+case class XGroupCreate(key: Buf, groupName: Buf, id: Buf) extends XGroupCommand(Buf.Utf8("CREATE"), Seq(key, groupName, id))
+
+case class XGroupSetId(key: Buf, id: Buf) extends XGroupCommand(Buf.Utf8("SETID"), Seq(key, id))
+
+case class XGroupDestroy(key: Buf, groupName: Buf) extends XGroupCommand(Buf.Utf8("DESTROY"), Seq(key, groupName))
+
+case class XGroupDelConsumer(key: Buf, groupName: Buf, consumerName: Buf) extends XGroupCommand(Buf.Utf8("DELCONSUMER"), Seq(key, groupName, consumerName))
+
+case class XAck(key: Buf, group: Buf, ids: Seq[Buf]) extends StrictKeyCommand {
+  override def name: Buf = Command.XACK
+
+  override def body: Seq[Buf] = Seq(key, group) ++ ids
+
+  override protected def validate(): Unit = {
+    super.validate()
+    RequireClientProtocol(group.length > 0, "Group cannot be empty")
+    RequireClientProtocol(ids.nonEmpty, "Ids cannot be empty")
+    RequireClientProtocol(ids.forall(_.length > 0), "Found an empty ID")
+  }
+}
+
+case class XPending(key: Buf, group: Buf) extends StrictKeyCommand {
+  override def name: Buf = Command.XPENDING
+
+  override def body: Seq[Buf] = Seq(key, group)
+
+  override protected def validate(): Unit = {
+    super.validate()
+    RequireClientProtocol(group.length > 0, "Group cannot be empty")
+  }
+}
+
+case class XPendingRange(key: Buf, group: Buf, start: Buf, end: Buf, count: Long, consumer: Option[Buf]) extends StrictKeyCommand {
+  override def name: Buf = Command.XPENDING
+
+  override def body: Seq[Buf] = Seq(key, group, start, end, Buf.Utf8(count.toString)) ++ consumer.toSeq
+
+  override protected def validate(): Unit = {
+    super.validate()
+    RequireClientProtocol(group.length > 0, "Group cannot be empty!")
+    RequireClientProtocol(start.length > 0, "Start cannot be empty!")
+    RequireClientProtocol(end.length > 0, "End cannot be empty!")
+    if (consumer.isDefined) RequireClientProtocol(consumer.get.length > 0, "Consumer cannot be empty!")
+  }
+}
+
+case class XClaim(
+  key: Buf,
+  group: Buf,
+  consumer: Buf,
+  minIdleTime: Long,
+  ids: Seq[Buf],
+  idle: Option[XClaimMillisOrUnixTs],
+  retryCount: Option[Long],
+  force: Boolean,
+  justId: Boolean
+) extends StrictKeyCommand {
+  override def name: Buf = Command.XCLAIM
+
+  override def body: Seq[Buf] = {
+    val forcePart = if (force) Seq("FORCE") else Seq.empty
+    val justIdPart = if (justId) Seq("JUSTID") else Seq.empty
+    val idlePart = idle match {
+      case Some(XClaimMillis(n)) => Seq("IDLE", n.toString)
+      case Some(XClaimUnixTs(n)) => Seq("TIME", n.toString)
+      case None => Seq.empty
+    }
+    val retryCountPart = retryCount.map(r => Seq("RETRYCOUNT", r.toString)).getOrElse(Seq.empty)
+
+    val options = (idlePart ++ retryCountPart ++ forcePart ++ justIdPart).map(Buf.Utf8.apply)
+
+    Seq(key, group, consumer, Buf.Utf8(minIdleTime.toString)) ++ ids ++ options
+  }
+
+  override protected def validate(): Unit = {
+    super.validate()
+    RequireClientProtocol(group.length > 0, "Group cannot be empty!")
+    RequireClientProtocol(consumer.length > 0, "Consumer cannot be empty!")
+    RequireClientProtocol(ids.nonEmpty, "IDs cannot be empty!")
+    RequireClientProtocol(ids.forall(_.length > 0), "Found empty ID!")
+  }
+}
+
+sealed trait XClaimMillisOrUnixTs
+case class XClaimMillis(ms: Long) extends XClaimMillisOrUnixTs
+case class XClaimUnixTs(ts: Long) extends XClaimMillisOrUnixTs

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/Streams.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/protocol/commands/Streams.scala
@@ -163,10 +163,10 @@ case class XPendingRange(key: Buf, group: Buf, start: Buf, end: Buf, count: Long
 
   override protected def validate(): Unit = {
     super.validate()
-    RequireClientProtocol(group.length > 0, "Group cannot be empty!")
-    RequireClientProtocol(start.length > 0, "Start cannot be empty!")
-    RequireClientProtocol(end.length > 0, "End cannot be empty!")
-    if (consumer.isDefined) RequireClientProtocol(consumer.get.length > 0, "Consumer cannot be empty!")
+    RequireClientProtocol(group.length > 0, "Group cannot be empty")
+    RequireClientProtocol(start.length > 0, "Start cannot be empty")
+    RequireClientProtocol(end.length > 0, "End cannot be empty")
+    if (consumer.isDefined) RequireClientProtocol(consumer.get.length > 0, "Consumer cannot be empty")
   }
 }
 
@@ -200,10 +200,10 @@ case class XClaim(
 
   override protected def validate(): Unit = {
     super.validate()
-    RequireClientProtocol(group.length > 0, "Group cannot be empty!")
-    RequireClientProtocol(consumer.length > 0, "Consumer cannot be empty!")
-    RequireClientProtocol(ids.nonEmpty, "IDs cannot be empty!")
-    RequireClientProtocol(ids.forall(_.length > 0), "Found empty ID!")
+    RequireClientProtocol(group.length > 0, "Group cannot be empty")
+    RequireClientProtocol(consumer.length > 0, "Consumer cannot be empty")
+    RequireClientProtocol(ids.nonEmpty, "IDs cannot be empty")
+    RequireClientProtocol(ids.forall(_.length > 0), "Found empty ID")
   }
 }
 

--- a/finagle-redis/src/test/scala/com/twitter/finagle/redis/RedisTest.scala
+++ b/finagle-redis/src/test/scala/com/twitter/finagle/redis/RedisTest.scala
@@ -217,7 +217,7 @@ trait RedisRequestTest extends RedisTest with GeneratorDrivenPropertyChecks with
 
   def checkSingleKey(c: String, f: Buf => Command): Unit = {
     forAll { key: Buf =>
-      assert(encodeCommand(f(key)) == c +: Seq(key.asString))
+      assert(encodeCommand(f(key)) == c.split(" ").toSeq ++ Seq(key.asString))
     }
 
     intercept[ClientError](f(Buf.Empty))
@@ -226,7 +226,7 @@ trait RedisRequestTest extends RedisTest with GeneratorDrivenPropertyChecks with
   def checkMultiKey(c: String, f: Seq[Buf] => Command): Unit = {
     forAll(Gen.nonEmptyListOf(genBuf)) { keys =>
       assert(
-        encodeCommand(f(keys)) == c +: keys.map(_.asString)
+        encodeCommand(f(keys)) == c.split(" ").toSeq ++ keys.map(_.asString)
       )
     }
 
@@ -237,7 +237,7 @@ trait RedisRequestTest extends RedisTest with GeneratorDrivenPropertyChecks with
   def checkSingleKeyMultiVal(c: String, f: (Buf, Seq[Buf]) => Command): Unit = {
     forAll(genBuf, Gen.nonEmptyListOf(genBuf)) { (key, vals) =>
       assert(
-        encodeCommand(f(key, vals)) == c +: key.asString +: vals.map(_.asString)
+        encodeCommand(f(key, vals)) == c.split(" ").toSeq ++ Seq(key.asString) ++ vals.map(_.asString)
       )
     }
 
@@ -248,12 +248,25 @@ trait RedisRequestTest extends RedisTest with GeneratorDrivenPropertyChecks with
   def checkSingleKeySingleVal(c: String, f: (Buf, Buf) => Command): Unit = {
     forAll { (key: Buf, value: Buf) =>
       assert(
-        encodeCommand(f(key, value)) == c +: Seq(key.asString, value.asString)
+        encodeCommand(f(key, value)) == c.split(" ").toSeq ++ Seq(key.asString, value.asString)
       )
     }
 
     intercept[ClientError](encodeCommand(f(Buf.Empty, Buf.Empty)))
     intercept[ClientError](encodeCommand(f(Buf.Utf8("x"), Buf.Empty)))
+  }
+
+  def checkSingleKeyDoubleVal(c: String, f: (Buf, Buf, Buf) => Command): Unit = {
+    forAll { (key: Buf, value: Buf, value2: Buf) =>
+      assert(
+        encodeCommand(f(key, value, value2)) == c.split(" ").toSeq ++ Seq(key.asString, value.asString, value2.asString)
+      )
+    }
+
+    intercept[ClientError](encodeCommand(f(Buf.Empty, Buf.Empty, Buf.Empty)))
+    intercept[ClientError](encodeCommand(f(Buf.Utf8("x"), Buf.Empty, Buf.Empty)))
+    intercept[ClientError](encodeCommand(f(Buf.Empty, Buf.Utf8("x"), Buf.Empty)))
+    intercept[ClientError](encodeCommand(f(Buf.Empty, Buf.Empty, Buf.Utf8("x"))))
   }
 
   def checkSingleKeyArbitraryVal[A: Arbitrary](c: String, f: (Buf, A) => Command): Unit = {

--- a/finagle-redis/src/test/scala/com/twitter/finagle/redis/commands/streams/StreamCodecSuite.scala
+++ b/finagle-redis/src/test/scala/com/twitter/finagle/redis/commands/streams/StreamCodecSuite.scala
@@ -1,0 +1,192 @@
+package com.twitter.finagle.redis.protocol
+
+import com.twitter.finagle.redis.{ClientError, RedisRequestTest}
+import com.twitter.io.Buf
+import org.junit.runner.RunWith
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+final class StreamCodecSuite extends RedisRequestTest {
+  test("XADD") {
+    forAll { (key: Buf, a: Option[Buf], b: Map[Buf, Buf]) =>
+      lazy val command = XAdd(key, a, b)
+
+      if (a.exists(_.isEmpty) || b.isEmpty) {
+        intercept[ClientError](encodeCommand(command))
+      } else {
+        val fvStr = b.toSeq.flatMap(t => Seq(t._1, t._2)).map(_.asString)
+        assert(encodeCommand(command) == "XADD" +: (Seq(key.asString, a.map(_.asString).getOrElse("*")) ++ fvStr))
+      }
+    }
+
+    for {
+      aa <- Arbitrary.arbitrary[Option[Buf]].sample
+      bb <- Arbitrary.arbitrary[Map[Buf, Buf]].sample
+    } {
+      intercept[ClientError](encodeCommand(XAdd(Buf.Empty, aa, bb)))
+    }
+  }
+
+  test("XTRIM") {
+    forAll { (key: Buf, a: Long, b: Boolean) =>
+      lazy val command = XTrim(key, a, b)
+      if (a < 0) {
+        intercept[ClientError](command)
+      } else {
+        assert(encodeCommand(command) == "XTRIM" +: (Seq(key.asString, "MAXLEN") ++ (if (!b) Seq("~") else Seq.empty) ++ Seq(a.toString)))
+      }
+
+      for {
+        aa <- Arbitrary.arbitrary[Long].sample
+        bb <- Arbitrary.arbitrary[Boolean].sample
+      } {
+        intercept[ClientError](encodeCommand(XTrim(Buf.Empty, aa, bb)))
+      }
+    }
+  }
+
+  test("XDEL") {
+    checkSingleKeyMultiVal("XDEL", XDel.apply)
+  }
+
+  test("XRANGE") {
+    forAll { (key: Buf, start: Buf, end: Buf, count: Option[Long]) =>
+      val countPart = count.map(c => Seq("COUNT", c.toString)).getOrElse(Seq.empty)
+      assert(encodeCommand(XRange(key, start, end, count)) == "XRANGE" +: (Seq(key, start, end).map(_.asString) ++ countPart))
+    }
+  }
+
+  test("XREVRANGE") {
+    forAll { (key: Buf, start: Buf, end: Buf, count: Option[Long]) =>
+      val countPart = count.map(c => Seq("COUNT", c.toString)).getOrElse(Seq.empty)
+      assert(encodeCommand(XRevRange(key, start, end, count)) == "XREVRANGE" +: (Seq(key, start, end).map(_.asString) ++ countPart))
+    }
+  }
+
+  test("XLEN") {
+    checkSingleKey("XLEN", XLen.apply)
+  }
+
+  test("XREAD") {
+    forAll(Gen.nonEmptyListOf(genBuf), Gen.nonEmptyListOf(genBuf)) { (keys: Seq[Buf], values: Seq[Buf]) =>
+      if (keys.size != values.size) {
+        intercept[ClientError](XRead(None, None, keys, values))
+      } else {
+        assert(encodeCommand(XRead(None, None, keys, values)) == "XREAD" +: "STREAMS" +: (keys.map(_.asString) ++ values.map(_.asString)))
+      }
+    }
+
+    for {
+      c <- Arbitrary.arbitrary[Option[Long]].sample
+      ms <- Arbitrary.arbitrary[Option[Long]].sample
+      b <- Gen.nonEmptyListOf(genBuf).sample
+    } {
+      intercept[ClientError](XRead(c, ms, Seq.empty, b))
+      intercept[ClientError](XRead(c, ms, b, Seq.empty))
+    }
+  }
+
+  test("XREADGROUP") {
+    forAll(genBuf, genBuf, Gen.nonEmptyListOf(genBuf), Gen.nonEmptyListOf(genBuf)) { (group: Buf, consumer: Buf, keys: Seq[Buf], values: Seq[Buf]) =>
+      if (keys.size != values.size) {
+        intercept[ClientError](XReadGroup(group, consumer, None, None, keys, values))
+      } else {
+        val expected =  ("XREADGROUP" +: "GROUP" +: Seq(group, consumer).map(_.asString)) ++ (Seq("STREAMS") ++ (keys.map(_.asString) ++ values.map(_.asString)))
+        assert(encodeCommand(XReadGroup(group, consumer, None, None, keys, values)) == expected)
+      }
+    }
+
+    for {
+      a <- genBuf.sample
+      c <- Arbitrary.arbitrary[Option[Long]].sample
+      ms <- Arbitrary.arbitrary[Option[Long]].sample
+      b <- Gen.nonEmptyListOf(genBuf).sample
+    } {
+      intercept[ClientError](XReadGroup(a, a, c, ms, Seq.empty, b))
+      intercept[ClientError](XReadGroup(a, a, c, ms, b, Seq.empty))
+      intercept[ClientError](XReadGroup(Buf.Empty, a, c, ms, b, Seq.empty))
+      intercept[ClientError](XReadGroup(a, Buf.Empty, c, ms, b, Seq.empty))
+    }
+  }
+
+  test("XGROUP CREATE") {
+    checkSingleKeyDoubleVal("XGROUP CREATE", XGroupCreate.apply)
+  }
+
+  test("XGROUP SETID") {
+    checkSingleKeySingleVal("XGROUP SETID", XGroupSetId.apply)
+  }
+
+  test("XGROUP DESTROY") {
+    checkSingleKeySingleVal("XGROUP DESTROY", XGroupDestroy.apply)
+  }
+
+  test("XGROUP DELCONSUMER") {
+    checkSingleKeyDoubleVal("XGROUP DELCONSUMER", XGroupDelConsumer.apply)
+  }
+
+  test("XACK") {
+    checkSingleKeyDoubleVal("XACK", (a, b, c) => XAck.apply(a, b, Seq(c)))
+  }
+
+  test("XPENDING") {
+    checkSingleKeySingleVal("XPENDING", XPending.apply)
+  }
+
+  test("XPENDING range options") {
+    forAll(Gen.listOfN(4, genBuf), Gen.choose(0, Long.MaxValue)) {
+      case (List(key, group, start, end), count) =>
+        val expected = "XPENDING" +: (Seq(key, group, start, end).map(_.asString) ++ Seq(count.toString))
+        assert(encodeCommand(XPendingRange(key, group, start, end, count, None)) == expected)
+    }
+
+    forAll(Gen.listOfN(3, genBuf), Gen.choose(0, Long.MaxValue)) {
+      case (List(a, b, c), count) =>
+        intercept[ClientError](XPendingRange(a, b, c, Buf.Empty, count, None))
+        intercept[ClientError](XPendingRange(a, b, Buf.Empty, c, count, None))
+        intercept[ClientError](XPendingRange(a, Buf.Empty, b, c, count, None))
+        intercept[ClientError](XPendingRange(Buf.Empty, a, b, c, count, None))
+    }
+  }
+
+  test("XCLAIM") {
+    val genLong = Gen.choose(0, Long.MaxValue)
+    val genTime = Gen.option(Gen.oneOf(genLong.map(XClaimMillis), genLong.map(XClaimUnixTs)))
+    val genBool = Gen.oneOf(0, 1).map(_ == 1)
+    forAll(Gen.listOfN(3, genBuf), genLong, Gen.nonEmptyListOf(genBuf), Gen.option(genLong), genTime, genBool) {
+      case (List(key, group, consumer), minIdle, ids, retry, time, b) =>
+        val flags = if (b) Seq("FORCE", "JUSTID") else Seq()
+        val await = time.map {
+          case XClaimMillis(t) => Seq("IDLE", t.toString)
+          case XClaimUnixTs(t) => Seq("TIME", t.toString)
+        }.getOrElse(Seq.empty)
+        val tries = retry.map(r => Seq("RETRYCOUNT", r.toString)).getOrElse(Seq.empty)
+
+        val expected = "XCLAIM" +: (Seq(key, group, consumer).map(_.asString) ++ Seq(minIdle.toString) ++ ids.map(_.asString) ++ await ++ tries ++ flags)
+
+        assert(encodeCommand(XClaim(key, group, consumer, minIdle, ids, time, retry, b, b)) == expected)
+    }
+
+    forAll(Gen.listOfN(3, genBuf)) {
+      case List(a, b, c) =>
+        intercept[ClientError](XClaim(a, b, c, 0, Seq(), None, None, false, false))
+        intercept[ClientError](XClaim(a, b, c, 0, Seq(Buf.Empty), None, None, false, false))
+        intercept[ClientError](XClaim(a, b, Buf.Empty, 0, Seq(a), None, None, false, false))
+        intercept[ClientError](XClaim(a, Buf.Empty, b, 0, Seq(a), None, None, false, false))
+        intercept[ClientError](XClaim(Buf.Empty, a, b, 0, Seq(a), None, None, false, false))
+    }
+  }
+
+  test("XINFO CONSUMERS") {
+    checkSingleKeySingleVal("XINFO CONSUMERS", XInfoConsumers.apply)
+  }
+
+  test("XINFO GROUPS") {
+    checkSingleKey("XINFO GROUPS", XInfoGroups.apply)
+  }
+
+  test("XINFO STREAM") {
+    checkSingleKey("XINFO STREAM", XInfoStream.apply)
+  }
+}

--- a/finagle-redis/src/test/scala/com/twitter/finagle/redis/commands/streams/StreamCodecSuite.scala
+++ b/finagle-redis/src/test/scala/com/twitter/finagle/redis/commands/streams/StreamCodecSuite.scala
@@ -6,7 +6,6 @@ import org.junit.runner.RunWith
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
 final class StreamCodecSuite extends RedisRequestTest {
   test("XADD") {
     forAll { (key: Buf, a: Option[Buf], b: Map[Buf, Buf]) =>


### PR DESCRIPTION
Problem

Redis 5.0 was released recently and brought with it the new Stream
API. The finagle-redis client should support these new APIs.

Solution

Added support for the Stream API in the finagle-redis client.

Result

Users of the finagle-redis library will be able to access the new Stream
API which is now generally available on Redis >=5.0.

---
NOTE: I did not implement access to the `XINFO` APIs yet. The return types of those calls are a bit more complex than others. 