### PR TITLE
finagle-example: fix #733

### DIFF
--- a/finagle-example/src/main/scala/com/twitter/finagle/example/thrift/ThriftClient.scala
+++ b/finagle-example/src/main/scala/com/twitter/finagle/example/thrift/ThriftClient.scala
@@ -2,14 +2,16 @@ package com.twitter.finagle.example.thrift
 
 import com.twitter.finagle.example.thriftscala.Hello
 import com.twitter.finagle.Thrift
+import com.twitter.util.Await
 
 object ThriftClient {
   def main(args: Array[String]): Unit = {
     //#thriftclientapi
-    val client = Thrift.client.newIface[Hello.FutureIface]("localhost:8080")
-    client.hi().onSuccess { response =>
+    val client = Thrift.client.build[Hello.MethodPerEndpoint]("localhost:8080")
+    val response = client.hi().onSuccess { response =>
       println("Received response: " + response)
     }
+    Await.result(response)
     //#thriftclientapi
   }
 }


### PR DESCRIPTION
Problem

The Thrift example was not working properly causing the client to exit without printing anything. Moreover deprecated methods were used.

Solution

Added `Await.result` in the client so that it waits for the future to complete before exiting.
`Thrift.client.newIFace` has been replaced with `Thrift.client.build`.
