### PR TITLE
finagle-core: SSL session verifiers return a Future value

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/ssl/client/SslClientSessionVerifier.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/ssl/client/SslClientSessionVerifier.scala
@@ -1,6 +1,7 @@
 package com.twitter.finagle.ssl.client
 
 import com.twitter.finagle.{Address, Stack}
+import com.twitter.util.Future
 import javax.net.ssl.SSLSession
 
 /**
@@ -18,7 +19,7 @@ abstract class SslClientSessionVerifier {
    * @note Throwing an exception is ok, and will be treated
    * similarly to a response of false.
    */
-  def apply(address: Address, config: SslClientConfiguration, session: SSLSession): Boolean
+  def apply(address: Address, config: SslClientConfiguration, session: SSLSession): Future[Boolean]
 }
 
 object SslClientSessionVerifier {
@@ -45,7 +46,8 @@ object SslClientSessionVerifier {
    * verifies every given session.
    */
   val AlwaysValid: SslClientSessionVerifier = new SslClientSessionVerifier {
-    def apply(address: Address, config: SslClientConfiguration, session: SSLSession): Boolean = true
+    def apply(address: Address, config: SslClientConfiguration, session: SSLSession): Future[Boolean] =
+      Future.value(true)
   }
 
 }

--- a/finagle-core/src/main/scala/com/twitter/finagle/ssl/client/SslClientSessionVerifier.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/ssl/client/SslClientSessionVerifier.scala
@@ -16,8 +16,7 @@ abstract class SslClientSessionVerifier {
    * Verifies the established `SSLSession`.
    *
    * @return true if the session is verified, false if not.
-   * @note Throwing an exception is ok, and will be treated
-   * similarly to a response of false.
+   * @note Avoid throwing an exception; use `Future.exception` to return one.
    */
   def apply(address: Address, config: SslClientConfiguration, session: SSLSession): Future[Boolean]
 }
@@ -46,8 +45,12 @@ object SslClientSessionVerifier {
    * verifies every given session.
    */
   val AlwaysValid: SslClientSessionVerifier = new SslClientSessionVerifier {
-    def apply(address: Address, config: SslClientConfiguration, session: SSLSession): Future[Boolean] =
-      Future.value(true)
+    def apply(
+      address: Address,
+      config: SslClientConfiguration,
+      session: SSLSession
+    ): Future[Boolean] =
+      Future.True
   }
 
 }

--- a/finagle-core/src/main/scala/com/twitter/finagle/ssl/server/SslServerSessionVerifier.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/ssl/server/SslServerSessionVerifier.scala
@@ -16,8 +16,7 @@ abstract class SslServerSessionVerifier {
    * Verifies the established `SSLSession`.
    *
    * @return true if the session is verified, false if not.
-   * @note Throwing an exception is ok, and will be treated
-   * similarly to a response of false.
+   * @note Avoid throwing an exception; use `Future.exception` to return one.
    */
   def apply(address: Address, config: SslServerConfiguration, session: SSLSession): Future[Boolean]
 }

--- a/finagle-core/src/main/scala/com/twitter/finagle/ssl/server/SslServerSessionVerifier.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/ssl/server/SslServerSessionVerifier.scala
@@ -46,7 +46,11 @@ object SslServerSessionVerifier {
    * verifies every given session.
    */
   val AlwaysValid: SslServerSessionVerifier = new SslServerSessionVerifier {
-    def apply(address: Address, config: SslServerConfiguration, session: SSLSession): Future[Boolean] =
+    def apply(
+      address: Address,
+      config: SslServerConfiguration,
+      session: SSLSession
+    ): Future[Boolean] =
       Future.value(true)
   }
 

--- a/finagle-core/src/main/scala/com/twitter/finagle/ssl/server/SslServerSessionVerifier.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/ssl/server/SslServerSessionVerifier.scala
@@ -1,6 +1,7 @@
 package com.twitter.finagle.ssl.server
 
 import com.twitter.finagle.{Address, Stack}
+import com.twitter.util.Future
 import javax.net.ssl.SSLSession
 
 /**
@@ -18,7 +19,7 @@ abstract class SslServerSessionVerifier {
    * @note Throwing an exception is ok, and will be treated
    * similarly to a response of false.
    */
-  def apply(address: Address, config: SslServerConfiguration, session: SSLSession): Boolean
+  def apply(address: Address, config: SslServerConfiguration, session: SSLSession): Future[Boolean]
 }
 
 object SslServerSessionVerifier {
@@ -45,7 +46,8 @@ object SslServerSessionVerifier {
    * verifies every given session.
    */
   val AlwaysValid: SslServerSessionVerifier = new SslServerSessionVerifier {
-    def apply(address: Address, config: SslServerConfiguration, session: SSLSession): Boolean = true
+    def apply(address: Address, config: SslServerConfiguration, session: SSLSession): Future[Boolean] =
+      Future.value(true)
   }
 
 }

--- a/finagle-core/src/test/scala/com/twitter/finagle/builder/ClientBuilderTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/builder/ClientBuilderTest.scala
@@ -149,7 +149,8 @@ class ClientBuilderTest
     def apply(address: Address, config: SslClientConfiguration): Engine = engine
   }
   private val sessionVerifier = new SslClientSessionVerifier {
-    def apply(address: Address, config: SslClientConfiguration, session: SSLSession): Boolean = true
+    def apply(address: Address, config: SslClientConfiguration, session: SSLSession): Future[Boolean] =
+      Future.value(true)
   }
 
   test("ClientBuilder sets SSL/TLS configuration") {

--- a/finagle-core/src/test/scala/com/twitter/finagle/builder/ClientBuilderTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/builder/ClientBuilderTest.scala
@@ -149,8 +149,12 @@ class ClientBuilderTest
     def apply(address: Address, config: SslClientConfiguration): Engine = engine
   }
   private val sessionVerifier = new SslClientSessionVerifier {
-    def apply(address: Address, config: SslClientConfiguration, session: SSLSession): Future[Boolean] =
-      Future.value(true)
+    def apply(
+      address: Address,
+      config: SslClientConfiguration,
+      session: SSLSession
+    ): Future[Boolean] =
+      Future.True
   }
 
   test("ClientBuilder sets SSL/TLS configuration") {

--- a/finagle-core/src/test/scala/com/twitter/finagle/builder/ServerBuilderTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/builder/ServerBuilderTest.scala
@@ -61,8 +61,12 @@ class ServerBuilderTest
     def apply(config: SslServerConfiguration): Engine = engine
   }
   private val sessionVerifier = new SslServerSessionVerifier {
-    def apply(address: Address, config: SslServerConfiguration, session: SSLSession): Future[Boolean] =
-      Future.value(true)
+    def apply(
+      address: Address,
+      config: SslServerConfiguration,
+      session: SSLSession
+    ): Future[Boolean] =
+      Future.True
   }
 
   test("ServerBuilder sets SSL/TLS configuration") {

--- a/finagle-core/src/test/scala/com/twitter/finagle/builder/ServerBuilderTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/builder/ServerBuilderTest.scala
@@ -61,7 +61,8 @@ class ServerBuilderTest
     def apply(config: SslServerConfiguration): Engine = engine
   }
   private val sessionVerifier = new SslServerSessionVerifier {
-    def apply(address: Address, config: SslServerConfiguration, session: SSLSession): Boolean = true
+    def apply(address: Address, config: SslServerConfiguration, session: SSLSession): Future[Boolean] =
+      Future.value(true)
   }
 
   test("ServerBuilder sets SSL/TLS configuration") {

--- a/finagle-core/src/test/scala/com/twitter/finagle/param/ClientTransportParamsTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/param/ClientTransportParamsTest.scala
@@ -3,12 +3,9 @@ package com.twitter.finagle.param
 import com.twitter.finagle.Address
 import com.twitter.finagle.client.utils.StringClient
 import com.twitter.finagle.ssl.Engine
-import com.twitter.finagle.ssl.client.{
-  SslClientConfiguration,
-  SslClientEngineFactory,
-  SslClientSessionVerifier
-}
+import com.twitter.finagle.ssl.client.{SslClientConfiguration, SslClientEngineFactory, SslClientSessionVerifier}
 import com.twitter.finagle.transport.Transport
+import com.twitter.util.Future
 import javax.net.ssl.SSLSession
 import org.scalatest.FunSuite
 import org.scalatest.mockito.MockitoSugar
@@ -21,7 +18,8 @@ class ClientTransportParamsTest extends FunSuite with MockitoSugar {
     def apply(address: Address, config: SslClientConfiguration): Engine = engine
   }
   private val sessionVerifier = new SslClientSessionVerifier {
-    def apply(address: Address, config: SslClientConfiguration, session: SSLSession): Boolean = true
+    def apply(address: Address, config: SslClientConfiguration, session: SSLSession): Future[Boolean] =
+      Future.value(true)
   }
 
   test("withTransport.tls sets SSL/TLS configuration") {

--- a/finagle-core/src/test/scala/com/twitter/finagle/param/ClientTransportParamsTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/param/ClientTransportParamsTest.scala
@@ -22,8 +22,12 @@ class ClientTransportParamsTest extends FunSuite with MockitoSugar {
     def apply(address: Address, config: SslClientConfiguration): Engine = engine
   }
   private val sessionVerifier = new SslClientSessionVerifier {
-    def apply(address: Address, config: SslClientConfiguration, session: SSLSession): Future[Boolean] =
-      Future.value(true)
+    def apply(
+      address: Address,
+      config: SslClientConfiguration,
+      session: SSLSession
+    ): Future[Boolean] =
+      Future.True
   }
 
   test("withTransport.tls sets SSL/TLS configuration") {

--- a/finagle-core/src/test/scala/com/twitter/finagle/param/ClientTransportParamsTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/param/ClientTransportParamsTest.scala
@@ -3,7 +3,11 @@ package com.twitter.finagle.param
 import com.twitter.finagle.Address
 import com.twitter.finagle.client.utils.StringClient
 import com.twitter.finagle.ssl.Engine
-import com.twitter.finagle.ssl.client.{SslClientConfiguration, SslClientEngineFactory, SslClientSessionVerifier}
+import com.twitter.finagle.ssl.client.{
+  SslClientConfiguration,
+  SslClientEngineFactory,
+  SslClientSessionVerifier
+}
 import com.twitter.finagle.transport.Transport
 import com.twitter.util.Future
 import javax.net.ssl.SSLSession

--- a/finagle-core/src/test/scala/com/twitter/finagle/param/ServerTransportParamsTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/param/ServerTransportParamsTest.scala
@@ -22,8 +22,12 @@ class ServerTransportParamsTest extends FunSuite with MockitoSugar {
     def apply(config: SslServerConfiguration): Engine = engine
   }
   private val sessionVerifier = new SslServerSessionVerifier {
-    def apply(address: Address, config: SslServerConfiguration, session: SSLSession): Future[Boolean] =
-      Future.value(true)
+    def apply(
+      address: Address,
+      config: SslServerConfiguration,
+      session: SSLSession
+    ): Future[Boolean] =
+      Future.True
   }
 
   test("withTransport.tls sets SSL/TLS configuration") {

--- a/finagle-core/src/test/scala/com/twitter/finagle/param/ServerTransportParamsTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/param/ServerTransportParamsTest.scala
@@ -3,7 +3,11 @@ package com.twitter.finagle.param
 import com.twitter.finagle.Address
 import com.twitter.finagle.server.utils.StringServer
 import com.twitter.finagle.ssl.Engine
-import com.twitter.finagle.ssl.server.{SslServerConfiguration, SslServerEngineFactory, SslServerSessionVerifier}
+import com.twitter.finagle.ssl.server.{
+  SslServerConfiguration,
+  SslServerEngineFactory,
+  SslServerSessionVerifier
+}
 import com.twitter.finagle.transport.Transport
 import com.twitter.util.Future
 import javax.net.ssl.SSLSession

--- a/finagle-core/src/test/scala/com/twitter/finagle/param/ServerTransportParamsTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/param/ServerTransportParamsTest.scala
@@ -3,12 +3,9 @@ package com.twitter.finagle.param
 import com.twitter.finagle.Address
 import com.twitter.finagle.server.utils.StringServer
 import com.twitter.finagle.ssl.Engine
-import com.twitter.finagle.ssl.server.{
-  SslServerConfiguration,
-  SslServerEngineFactory,
-  SslServerSessionVerifier
-}
+import com.twitter.finagle.ssl.server.{SslServerConfiguration, SslServerEngineFactory, SslServerSessionVerifier}
 import com.twitter.finagle.transport.Transport
+import com.twitter.util.Future
 import javax.net.ssl.SSLSession
 import org.scalatest.FunSuite
 import org.scalatest.mockito.MockitoSugar
@@ -21,7 +18,8 @@ class ServerTransportParamsTest extends FunSuite with MockitoSugar {
     def apply(config: SslServerConfiguration): Engine = engine
   }
   private val sessionVerifier = new SslServerSessionVerifier {
-    def apply(address: Address, config: SslServerConfiguration, session: SSLSession): Boolean = true
+    def apply(address: Address, config: SslServerConfiguration, session: SSLSession): Future[Boolean] =
+      Future.value(true)
   }
 
   test("withTransport.tls sets SSL/TLS configuration") {

--- a/finagle-netty3/src/main/scala/com/twitter/finagle/netty3/ssl/client/SslClientConnectHandler.scala
+++ b/finagle-netty3/src/main/scala/com/twitter/finagle/netty3/ssl/client/SslClientConnectHandler.scala
@@ -1,11 +1,15 @@
 package com.twitter.finagle.netty3.ssl.client
 
-import com.twitter.finagle.{Address, ChannelClosedException, InconsistentStateException, SslVerificationFailedException}
+import com.twitter.finagle.{
+  Address,
+  ChannelClosedException,
+  InconsistentStateException,
+  SslVerificationFailedException
+}
 import com.twitter.finagle.ssl.client.{SslClientConfiguration, SslClientSessionVerifier}
+import com.twitter.util.{Return, Throw}
 import java.net.SocketAddress
 import java.util.concurrent.atomic.AtomicReference
-
-import com.twitter.util.{Return, Throw}
 import org.jboss.netty.channel._
 import org.jboss.netty.handler.ssl.SslHandler
 

--- a/finagle-netty3/src/main/scala/com/twitter/finagle/netty3/ssl/server/SslServerConnectHandler.scala
+++ b/finagle-netty3/src/main/scala/com/twitter/finagle/netty3/ssl/server/SslServerConnectHandler.scala
@@ -3,6 +3,8 @@ package com.twitter.finagle.netty3.ssl.server
 import com.twitter.finagle.Address
 import com.twitter.finagle.ssl.server.{SslServerConfiguration, SslServerSessionVerifier}
 import java.net.InetSocketAddress
+
+import com.twitter.util.{Return, Throw}
 import javax.net.ssl.SSLException
 import org.jboss.netty.channel._
 import org.jboss.netty.handler.ssl.SslHandler
@@ -36,17 +38,16 @@ private[netty3] class SslServerConnectHandler(
             else Address(ctx.getChannel.getRemoteAddress.asInstanceOf[InetSocketAddress])
 
           if (f.isSuccess) {
-            sessionVerifier(remoteAddress, config, sslHandler.getEngine.getSession)
-              .onSuccess { verifierResult =>
+            sessionVerifier(remoteAddress, config, sslHandler.getEngine.getSession).respond {
+              case Return(verifierResult) =>
                 if (verifierResult) {
                   SslServerConnectHandler.super.channelConnected(ctx, e)
                 } else {
                   Channels.close(ctx.getChannel)
                 }
-              }
-              .onFailure { _ =>
+              case Throw(_) =>
                 Channels.close(ctx.getChannel)
-              }
+            }
           } else {
             Channels.close(ctx.getChannel)
           }

--- a/finagle-netty3/src/main/scala/com/twitter/finagle/netty3/ssl/server/SslServerConnectHandler.scala
+++ b/finagle-netty3/src/main/scala/com/twitter/finagle/netty3/ssl/server/SslServerConnectHandler.scala
@@ -2,9 +2,8 @@ package com.twitter.finagle.netty3.ssl.server
 
 import com.twitter.finagle.Address
 import com.twitter.finagle.ssl.server.{SslServerConfiguration, SslServerSessionVerifier}
-import java.net.InetSocketAddress
-
 import com.twitter.util.{Return, Throw}
+import java.net.InetSocketAddress
 import javax.net.ssl.SSLException
 import org.jboss.netty.channel._
 import org.jboss.netty.handler.ssl.SslHandler

--- a/finagle-netty3/src/test/scala/com/twitter/finagle/netty3/ssl/client/SslClientConnectHandlerTest.scala
+++ b/finagle-netty3/src/test/scala/com/twitter/finagle/netty3/ssl/client/SslClientConnectHandlerTest.scala
@@ -2,10 +2,9 @@ package com.twitter.finagle.netty3.ssl.client
 
 import com.twitter.finagle.{Address, SslVerificationFailedException}
 import com.twitter.finagle.ssl.client.{SslClientConfiguration, SslClientSessionVerifier}
+import com.twitter.util.Future
 import java.net.SocketAddress
 import java.security.cert.Certificate
-
-import com.twitter.util.Future
 import javax.net.ssl.{SSLEngine, SSLSession}
 import org.jboss.netty.channel._
 import org.jboss.netty.handler.ssl.SslHandler

--- a/finagle-netty3/src/test/scala/com/twitter/finagle/netty3/ssl/client/SslClientConnectHandlerTest.scala
+++ b/finagle-netty3/src/test/scala/com/twitter/finagle/netty3/ssl/client/SslClientConnectHandlerTest.scala
@@ -41,7 +41,7 @@ class SslClientConnectHandlerTest extends FunSuite with MockitoSugar {
     val address = mock[Address]
     val config = mock[SslClientConfiguration]
     val sessionVerifier = mock[SslClientSessionVerifier]
-    when(sessionVerifier.apply(any[Address], any[SslClientConfiguration], any[SSLSession])) thenReturn Future.value(true)
+    when(sessionVerifier.apply(any[Address], any[SslClientConfiguration], any[SSLSession])) thenReturn Future.True
 
     val connectFuture = Channels.future(channel, true)
     val connectRequested =
@@ -169,7 +169,7 @@ class SslClientConnectHandlerTest extends FunSuite with MockitoSugar {
     val h = new helper2
     import h._
 
-    when(sessionVerifier(any[Address], any[SslClientConfiguration], any[SSLSession])) thenReturn Future.value(false)
+    when(sessionVerifier(any[Address], any[SslClientConfiguration], any[SSLSession])) thenReturn Future.False
     handshakeFuture.setSuccess()
     assert(connectFuture.isDone)
     assert(connectFuture.getCause.isInstanceOf[SslVerificationFailedException])

--- a/finagle-netty3/src/test/scala/com/twitter/finagle/netty3/ssl/server/SslServerConnectHandlerTest.scala
+++ b/finagle-netty3/src/test/scala/com/twitter/finagle/netty3/ssl/server/SslServerConnectHandlerTest.scala
@@ -62,7 +62,7 @@ class SslServerConnectHandlerTest extends FunSuite with MockitoSugar {
     val h = new SslServerConnectHandlerHelper
     import h._
 
-    when(verifier.apply(Address.failing, config, sslSession)) thenReturn Future.value(true)
+    when(verifier.apply(Address.failing, config, sslSession)) thenReturn Future.True
 
     verify(sslHandler, times(1)).handshake()
     verify(ctx, times(0)).sendUpstream(any[ChannelEvent])
@@ -74,7 +74,7 @@ class SslServerConnectHandlerTest extends FunSuite with MockitoSugar {
     val h = new SslServerConnectHandlerHelper
     import h._
 
-    when(verifier.apply(Address.failing, config, sslSession)) thenReturn Future.value(false)
+    when(verifier.apply(Address.failing, config, sslSession)) thenReturn Future.False
 
     verify(sslHandler, times(1)).handshake()
     verify(ctx, times(0)).sendUpstream(any[ChannelEvent])

--- a/finagle-netty3/src/test/scala/com/twitter/finagle/netty3/ssl/server/SslServerConnectHandlerTest.scala
+++ b/finagle-netty3/src/test/scala/com/twitter/finagle/netty3/ssl/server/SslServerConnectHandlerTest.scala
@@ -2,10 +2,9 @@ package com.twitter.finagle.netty3.ssl.server
 
 import com.twitter.finagle.Address
 import com.twitter.finagle.ssl.server.{SslServerConfiguration, SslServerSessionVerifier}
+import com.twitter.util.Future
 import java.net.SocketAddress
 import java.security.cert.Certificate
-
-import com.twitter.util.Future
 import javax.net.ssl.{SSLEngine, SSLSession}
 import org.jboss.netty.channel._
 import org.jboss.netty.handler.ssl.SslHandler

--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/client/SslClientVerificationHandler.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/client/SslClientVerificationHandler.scala
@@ -39,7 +39,10 @@ private[netty4] class SslClientVerificationHandler(
     failPendingWrites(t)
   }
 
-  private[this] def verifySession(session: SSLSession, ctx: ChannelHandlerContext): Future[Boolean] = {
+  private[this] def verifySession(
+    session: SSLSession,
+    ctx: ChannelHandlerContext
+  ): Future[Boolean] = {
     sessionVerifier(address, config, session).respond {
       case Return(verifierResult) =>
         if (!verifierResult) {

--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/server/SslServerVerificationHandler.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ssl/server/SslServerVerificationHandler.scala
@@ -22,7 +22,10 @@ private[netty4] class SslServerVerificationHandler(
 
   private[this] val onHandshakeComplete = Promise[Unit]()
 
-  private[this] def verifySession(session: SSLSession, ctx: ChannelHandlerContext): Future[Boolean] = {
+  private[this] def verifySession(
+    session: SSLSession,
+    ctx: ChannelHandlerContext
+  ): Future[Boolean] = {
     sessionVerifier(remoteAddress, config, session).respond {
       case Return(verifierResult) =>
         if (verifierResult) {

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/Netty4SslAddressTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/Netty4SslAddressTest.scala
@@ -18,10 +18,12 @@ class Netty4SslAddressTest extends FunSuite {
   }
 
   private[this] val hasAddressSessionVerifier = new SslServerSessionVerifier {
-    def apply(address: Address, config: SslServerConfiguration, session: SSLSession): Boolean =
-      address match {
-        case Address.Inet(isa, _) => !isa.isUnresolved
-        case _ => false
+    def apply(address: Address, config: SslServerConfiguration, session: SSLSession): Future[Boolean] =
+      Future.value {
+        address match {
+          case Address.Inet(isa, _) => !isa.isUnresolved
+          case _ => false
+        }
       }
   }
 

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/Netty4SslAddressTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/Netty4SslAddressTest.scala
@@ -18,12 +18,14 @@ class Netty4SslAddressTest extends FunSuite {
   }
 
   private[this] val hasAddressSessionVerifier = new SslServerSessionVerifier {
-    def apply(address: Address, config: SslServerConfiguration, session: SSLSession): Future[Boolean] =
-      Future.value {
-        address match {
-          case Address.Inet(isa, _) => !isa.isUnresolved
-          case _ => false
-        }
+    def apply(
+      address: Address,
+      config: SslServerConfiguration,
+      session: SSLSession
+    ): Future[Boolean] =
+      address match {
+        case Address.Inet(isa, _) if !isa.isUnresolved => Future.True
+        case _ => Future.False
       }
   }
 

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/Netty4SslTestComponents.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/Netty4SslTestComponents.scala
@@ -9,8 +9,9 @@ import com.twitter.finagle.ssl.{ClientAuth, KeyCredentials, TrustCredentials}
 import com.twitter.finagle.stats.{NullStatsReceiver, StatsReceiver}
 import com.twitter.finagle.{Address, ListeningServer, Service}
 import com.twitter.io.TempFile
-import com.twitter.util.Try
+import com.twitter.util.{Future, Try}
 import java.net.InetSocketAddress
+
 import javax.net.ssl.SSLSession
 
 object Netty4SslTestComponents {
@@ -31,13 +32,13 @@ object Netty4SslTestComponents {
   // deleteOnExit is handled by TempFile
 
   val NeverValidServerSide = new SslServerSessionVerifier {
-    def apply(address: Address, config: SslServerConfiguration, session: SSLSession): Boolean =
-      false
+    def apply(address: Address, config: SslServerConfiguration, session: SSLSession): Future[Boolean] =
+      Future.value(false)
   }
 
   val NeverValidClientSide = new SslClientSessionVerifier {
-    def apply(address: Address, config: SslClientConfiguration, session: SSLSession): Boolean =
-      false
+    def apply(address: Address, config: SslClientConfiguration, session: SSLSession): Future[Boolean] =
+      Future.value(false)
   }
 
   def getPort(server: ListeningServer): Int =

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/Netty4SslTestComponents.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/Netty4SslTestComponents.scala
@@ -31,13 +31,21 @@ object Netty4SslTestComponents {
   // deleteOnExit is handled by TempFile
 
   val NeverValidServerSide = new SslServerSessionVerifier {
-    def apply(address: Address, config: SslServerConfiguration, session: SSLSession): Future[Boolean] =
-      Future.value(false)
+    def apply(
+      address: Address,
+      config: SslServerConfiguration,
+      session: SSLSession
+    ): Future[Boolean] =
+      Future.False
   }
 
   val NeverValidClientSide = new SslClientSessionVerifier {
-    def apply(address: Address, config: SslClientConfiguration, session: SSLSession): Future[Boolean] =
-      Future.value(false)
+    def apply(
+      address: Address,
+      config: SslClientConfiguration,
+      session: SSLSession
+    ): Future[Boolean] =
+      Future.False
   }
 
   def getPort(server: ListeningServer): Int =

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/Netty4SslTestComponents.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/Netty4SslTestComponents.scala
@@ -11,7 +11,6 @@ import com.twitter.finagle.{Address, ListeningServer, Service}
 import com.twitter.io.TempFile
 import com.twitter.util.{Future, Try}
 import java.net.InetSocketAddress
-
 import javax.net.ssl.SSLSession
 
 object Netty4SslTestComponents {

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/client/SslClientVerificationHandlerTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/client/SslClientVerificationHandlerTest.scala
@@ -23,7 +23,11 @@ class SslClientVerificationHandlerTest extends FunSuite with MockitoSugar with O
   val config = SslClientConfiguration()
 
   class TestVerifier(result: => Future[Boolean]) extends SslClientSessionVerifier {
-    def apply(address: Address, config: SslClientConfiguration, session: SSLSession): Future[Boolean] =
+    def apply(
+      address: Address,
+      config: SslClientConfiguration,
+      session: SSLSession
+    ): Future[Boolean] =
       result
   }
 

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/client/SslClientVerificationHandlerTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/client/SslClientVerificationHandlerTest.scala
@@ -2,13 +2,12 @@ package com.twitter.finagle.netty4.ssl.client
 
 import com.twitter.finagle.{Address, SslVerificationFailedException}
 import com.twitter.finagle.ssl.client.{SslClientConfiguration, SslClientSessionVerifier}
+import com.twitter.util.Future
 import io.netty.channel.Channel
 import io.netty.channel.embedded.EmbeddedChannel
 import io.netty.handler.ssl.SslHandler
 import io.netty.util.concurrent.DefaultPromise
 import java.net.InetSocketAddress
-
-import com.twitter.util.Future
 import javax.net.ssl.{SSLEngine, SSLSession}
 import org.junit.runner.RunWith
 import org.mockito.Mockito._

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/client/SslClientVerificationHandlerTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/client/SslClientVerificationHandlerTest.scala
@@ -75,7 +75,7 @@ class SslClientVerificationHandlerTest extends FunSuite with MockitoSugar with O
           sslHandler,
           address,
           config,
-          new TestVerifier(Future.value(false))
+          new TestVerifier(Future.False)
         )
       )
     val connectPromise = channel.connect(fakeAddress)
@@ -173,7 +173,7 @@ class SslClientVerificationHandlerTest extends FunSuite with MockitoSugar with O
           sslHandler,
           address,
           config,
-          new TestVerifier(Future.value(false))
+          new TestVerifier(Future.False)
         )
       )
 

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/client/SslClientVerificationHandlerTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/client/SslClientVerificationHandlerTest.scala
@@ -7,6 +7,8 @@ import io.netty.channel.embedded.EmbeddedChannel
 import io.netty.handler.ssl.SslHandler
 import io.netty.util.concurrent.DefaultPromise
 import java.net.InetSocketAddress
+
+import com.twitter.util.Future
 import javax.net.ssl.{SSLEngine, SSLSession}
 import org.junit.runner.RunWith
 import org.mockito.Mockito._
@@ -21,8 +23,8 @@ class SslClientVerificationHandlerTest extends FunSuite with MockitoSugar with O
   val address = Address.Inet(fakeAddress, Map.empty)
   val config = SslClientConfiguration()
 
-  class TestVerifier(result: => Boolean) extends SslClientSessionVerifier {
-    def apply(address: Address, config: SslClientConfiguration, session: SSLSession): Boolean =
+  class TestVerifier(result: => Future[Boolean]) extends SslClientSessionVerifier {
+    def apply(address: Address, config: SslClientConfiguration, session: SSLSession): Future[Boolean] =
       result
   }
 
@@ -70,7 +72,7 @@ class SslClientVerificationHandlerTest extends FunSuite with MockitoSugar with O
           sslHandler,
           address,
           config,
-          new TestVerifier(false)
+          new TestVerifier(Future.value(false))
         )
       )
     val connectPromise = channel.connect(fakeAddress)
@@ -97,7 +99,7 @@ class SslClientVerificationHandlerTest extends FunSuite with MockitoSugar with O
           sslHandler,
           address,
           config,
-          new TestVerifier(throw e)
+          new TestVerifier(Future.exception(e))
         )
       )
     val connectPromise = channel.connect(fakeAddress)
@@ -168,7 +170,7 @@ class SslClientVerificationHandlerTest extends FunSuite with MockitoSugar with O
           sslHandler,
           address,
           config,
-          new TestVerifier(false)
+          new TestVerifier(Future.value(false))
         )
       )
 

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/server/SslServerVerificationHandlerTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/server/SslServerVerificationHandlerTest.scala
@@ -2,6 +2,7 @@ package com.twitter.finagle.netty4.ssl.server
 
 import com.twitter.finagle.Address
 import com.twitter.finagle.ssl.server.{SslServerConfiguration, SslServerSessionVerifier}
+import com.twitter.util.Future
 import io.netty.channel.Channel
 import io.netty.channel.embedded.EmbeddedChannel
 import io.netty.handler.ssl.SslHandler
@@ -13,8 +14,8 @@ import org.scalatest.mockito.MockitoSugar
 
 class SslServerVerificationHandlerTest extends FunSuite with MockitoSugar with OneInstancePerTest {
 
-  class TestVerifier(result: => Boolean) extends SslServerSessionVerifier {
-    def apply(address: Address, config: SslServerConfiguration, session: SSLSession): Boolean =
+  class TestVerifier(result: => Future[Boolean]) extends SslServerSessionVerifier {
+    def apply(address: Address, config: SslServerConfiguration, session: SSLSession): Future[Boolean] =
       result
   }
 
@@ -34,7 +35,7 @@ class SslServerVerificationHandlerTest extends FunSuite with MockitoSugar with O
         sslHandler,
         Address.failing,
         sslConfig,
-        new TestVerifier(true)
+        new TestVerifier(Future.value(true))
       )
     )
 
@@ -59,7 +60,7 @@ class SslServerVerificationHandlerTest extends FunSuite with MockitoSugar with O
         sslHandler,
         Address.failing,
         sslConfig,
-        new TestVerifier(false)
+        new TestVerifier(Future.value(false))
       )
     )
 
@@ -78,7 +79,7 @@ class SslServerVerificationHandlerTest extends FunSuite with MockitoSugar with O
         sslHandler,
         Address.failing,
         sslConfig,
-        new TestVerifier(throw new Exception("failed verification"))
+        new TestVerifier(Future.exception(new Exception("failed verification")))
       )
     )
 
@@ -97,7 +98,7 @@ class SslServerVerificationHandlerTest extends FunSuite with MockitoSugar with O
         sslHandler,
         Address.failing,
         sslConfig,
-        new TestVerifier(false)
+        new TestVerifier(Future.value(false))
       )
     )
 

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/server/SslServerVerificationHandlerTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/server/SslServerVerificationHandlerTest.scala
@@ -39,7 +39,7 @@ class SslServerVerificationHandlerTest extends FunSuite with MockitoSugar with O
         sslHandler,
         Address.failing,
         sslConfig,
-        new TestVerifier(Future.value(true))
+        new TestVerifier(Future.True)
       )
     )
 
@@ -64,7 +64,7 @@ class SslServerVerificationHandlerTest extends FunSuite with MockitoSugar with O
         sslHandler,
         Address.failing,
         sslConfig,
-        new TestVerifier(Future.value(false))
+        new TestVerifier(Future.False)
       )
     )
 
@@ -102,7 +102,7 @@ class SslServerVerificationHandlerTest extends FunSuite with MockitoSugar with O
         sslHandler,
         Address.failing,
         sslConfig,
-        new TestVerifier(Future.value(false))
+        new TestVerifier(Future.False)
       )
     )
 

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/server/SslServerVerificationHandlerTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/server/SslServerVerificationHandlerTest.scala
@@ -15,7 +15,11 @@ import org.scalatest.mockito.MockitoSugar
 class SslServerVerificationHandlerTest extends FunSuite with MockitoSugar with OneInstancePerTest {
 
   class TestVerifier(result: => Future[Boolean]) extends SslServerSessionVerifier {
-    def apply(address: Address, config: SslServerConfiguration, session: SSLSession): Future[Boolean] =
+    def apply(
+      address: Address,
+      config: SslServerConfiguration,
+      session: SSLSession
+    ): Future[Boolean] =
       result
   }
 

--- a/finagle-thriftmux/src/test/scala/com/twitter/finagle/thriftmux/ssl/ThriftSmuxSslTestComponents.scala
+++ b/finagle-thriftmux/src/test/scala/com/twitter/finagle/thriftmux/ssl/ThriftSmuxSslTestComponents.scala
@@ -36,13 +36,13 @@ object ThriftSmuxSslTestComponents {
   // deleteOnExit is handled by TempFile
 
   val NeverValidServerSide = new SslServerSessionVerifier {
-    def apply(address: Address, config: SslServerConfiguration, session: SSLSession): Boolean =
-      false
+    def apply(address: Address, config: SslServerConfiguration, session: SSLSession): Future[Boolean] =
+      Future.value(false)
   }
 
   val NeverValidClientSide = new SslClientSessionVerifier {
-    def apply(address: Address, config: SslClientConfiguration, session: SSLSession): Boolean =
-      false
+    def apply(address: Address, config: SslClientConfiguration, session: SSLSession): Future[Boolean] =
+      Future.value(false)
   }
 
   def getPort(server: ListeningServer): Int =

--- a/finagle-thriftmux/src/test/scala/com/twitter/finagle/thriftmux/ssl/ThriftSmuxSslTestComponents.scala
+++ b/finagle-thriftmux/src/test/scala/com/twitter/finagle/thriftmux/ssl/ThriftSmuxSslTestComponents.scala
@@ -36,13 +36,21 @@ object ThriftSmuxSslTestComponents {
   // deleteOnExit is handled by TempFile
 
   val NeverValidServerSide = new SslServerSessionVerifier {
-    def apply(address: Address, config: SslServerConfiguration, session: SSLSession): Future[Boolean] =
-      Future.value(false)
+    def apply(
+      address: Address,
+      config: SslServerConfiguration,
+      session: SSLSession
+    ): Future[Boolean] =
+      Future.False
   }
 
   val NeverValidClientSide = new SslClientSessionVerifier {
-    def apply(address: Address, config: SslClientConfiguration, session: SSLSession): Future[Boolean] =
-      Future.value(false)
+    def apply(
+      address: Address,
+      config: SslClientConfiguration,
+      session: SSLSession
+    ): Future[Boolean] =
+      Future.False
   }
 
   def getPort(server: ListeningServer): Int =


### PR DESCRIPTION
Problem

See #745 for a description of the problem.

Solution

Changed the return type of `SslServerSessionVerifier.apply` and `SslClientSessionVerifier.apply` to `Future[Boolean]`.
