### PR TITLE
B3 header support

### DIFF
--- a/finagle-base-http/src/main/scala/com/twitter/finagle/http/HttpTracing.scala
+++ b/finagle-base-http/src/main/scala/com/twitter/finagle/http/HttpTracing.scala
@@ -8,6 +8,7 @@ object HttpTracing {
    * See [[headers()]] for Java compatibility.
    */
   object Header {
+    val TraceContext = "b3"
     val TraceId = "X-B3-TraceId"
     val SpanId = "X-B3-SpanId"
     val ParentSpanId = "X-B3-ParentSpanId"

--- a/finagle-base-http/src/main/scala/com/twitter/finagle/http/TraceInfo.scala
+++ b/finagle-base-http/src/main/scala/com/twitter/finagle/http/TraceInfo.scala
@@ -49,6 +49,7 @@ private object TraceInfo {
         case None =>
           ()
       }
+      request.headerMap -= "b3"
     }
 
   def letTraceIdFromRequestHeaders[R](request: Request)(f: => R): R = {

--- a/finagle-base-http/src/test/scala/com/twitter/finagle/http/TraceInfoTest.scala
+++ b/finagle-base-http/src/test/scala/com/twitter/finagle/http/TraceInfoTest.scala
@@ -84,4 +84,33 @@ class TraceInfoTest extends FunSuite {
       )
     )
   }
+
+  test("b3-header is parsed into a proper TraceId, most basic header") {
+    val req = Request(Method.Get, "/")
+    req.headerMap.put("b3", "0000000000000abc-0000000000000def")
+    TraceInfo.convertB3Trace(req)
+    assert(req.headerMap.keys == Set("X-B3-TraceId", "X-B3-SpanId"))
+  }
+
+  test("b3 header, just sampled/debug flag") {
+    val req = Request(Method.Get, "/")
+    // flags == 0
+    req.headerMap.put("b3", "0")
+    TraceInfo.convertB3Trace(req)
+    assert(req.headerMap.keys == Set("X-B3-Flags"))
+
+    // debug == d
+    req.headerMap.clear
+    req.headerMap.put("b3", "1")
+    TraceInfo.convertB3Trace(req)
+    
+    assert(req.headerMap.keys == Set("X-B3-Sampled"))
+  }
+
+  test("b3 header with all the fields") {
+    val req = Request(Method.Get, "/")
+    req.headerMap.put("b3", "0000000000000abc-0000000000000def-1-0000000000000def")
+    TraceInfo.convertB3Trace(req)
+    assert(req.headerMap.keys == Set("X-B3-SpanId", "X-B3-Sampled", "X-B3-ParentSpanId", "X-B3-TraceId"))
+  }
 }


### PR DESCRIPTION
Problem

OpenZipkin has created a new set of header to carry trace information. These headers are not compatible with the old ones and are needed to interoperate with services that use the new version of the header.

Solution

If a "b3" header exists in the request this extracts all the new information and populates finagles tracing header with the existing values.

