### PR TITLE
update netty3 version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ val zkVersion = "3.5.0-alpha"
 val caffeineLib = "com.github.ben-manes.caffeine" % "caffeine" % "2.3.4"
 val hdrHistogramLib = "org.hdrhistogram" % "HdrHistogram" % "2.1.10"
 val jsr305Lib = "com.google.code.findbugs" % "jsr305" % "2.0.1"
-val netty3Lib = "io.netty" % "netty" % "3.10.1.Final"
+val netty3Lib = "io.netty" % "netty" % "3.10.6.Final"
 val netty4Libs = Seq(
   "io.netty" % "netty-handler" % netty4Version,
   "io.netty" % "netty-transport" % netty4Version,


### PR DESCRIPTION
Problem

Current version of netty3 has a CVE:
CVE-2015-2156
more details:
[https://snyk.io/vuln/SNYK-JAVA-IONETTY-30430](https://snyk.io/vuln/SNYK-JAVA-IONETTY-30430)

Solution

Update to latest of netty 3.10.x

Result

No more flagging dependency with vulnerability
