### PR TITLE
finagle-mysql: Make DateValue.unapply charset agnostic

### DIFF
--- a/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Value.scala
+++ b/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Value.scala
@@ -264,8 +264,8 @@ object DateValue extends Injectable[Date] with Extractable[Date] {
    * Value extractor for java.sql.Date
    */
   def unapply(v: Value): Option[Date] = v match {
-    case RawValue(Type.Date, MysqlCharset.Binary, false, bytes) =>
-      val str = new String(bytes, MysqlCharset(MysqlCharset.Binary))
+    case RawValue(Type.Date, charset, false, bytes) =>
+      val str = new String(bytes, MysqlCharset(charset))
       if (str == Zero.toString) Some(Zero)
       else Some(Date.valueOf(str))
 


### PR DESCRIPTION
Problem

Some MySQL-speaking databases send DateValue's with UTF-8 charsets, which results in failing pattern matches. It doesn't seem like there needs to be a restriction on what charset `DateValue.unapply` accepts when `Value.isBinary` is unset.

Solution

Use v.charset for String creation