### PR TITLE
upgrade to latest jackson version to overcome security-critical CVEs.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,6 +55,11 @@ Runtime Behavior Changes
   Set the flag `com.twitter.finagle.netty4.trackReferenceLeaks` to `true` to enable.
   ``PHAB_ID=D297031``
 
+* finagle-toggle, finagle-stats-core, finagle-zipkin-core, finagle-exception, finagle-serversets,
+  finagle-tunable, finagle-memcached: Upgrade jackson library to version 2.9.8 to address the
+  following vulnerabilities: CVE-2018-14718, CVE-2018-14719, CVE-2018-14720, CVE-2018-14721,
+  CVE-2018-19360, CVE-2018-19361, CVE-2018-19362.
+
 Breaking API Changes
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ val netty4Http = "io.netty" % "netty-codec-http" % netty4Version
 val netty4Http2 = "io.netty" % "netty-codec-http2" % netty4Version
 val netty4StaticSsl = "io.netty" % "netty-tcnative-boringssl-static" % "2.0.19.Final"
 val opencensusVersion = "0.19.1"
-val jacksonVersion = "2.9.6"
+val jacksonVersion = "2.9.8"
 val jacksonLibs = Seq(
   "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,


### PR DESCRIPTION
The following CVEs are addressed by the version upgrade:

  - CVE-2018-14718
  - CVE-2018-14719
  - CVE-2018-14720
  - CVE-2018-14721
  - CVE-2018-19360
  - CVE-2018-19361
  - CVE-2018-19362