### PR TITLE
Use https instead of http in urls

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,5 @@
 .. Author notes: this file is formatted with restructured text
-  (http://docutils.sourceforge.net/docs/user/rst/quickstart.html)
+  (https://docutils.sourceforge.net/docs/user/rst/quickstart.html)
   as it is included in Finagle's user's guide.
 
 Note that ``PHAB_ID=#`` and ``RB_ID=#`` correspond to associated messages in commits.

--- a/CONFIG.ini
+++ b/CONFIG.ini
@@ -7,5 +7,5 @@ project_name = finagle
 project_type = library
 docs_dir = doc/src/sphinx
 contact_email = finaglers@twitter.com
-go_link = http://go/finagle
+go_link = https://go/finagle
 tags = finagle,rpc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,7 +236,7 @@ requests that improve the existing Scaladocs!
 [4]: https://www.sphinx-doc.org/en/master/
 [5]: https://github.com/sbt/sbt-site
 [6]: https://www.sphinx-doc.org/en/master/usage/installation.html
-[7]: http://docutils.sourceforge.net/rst.html
+[7]: https://docutils.sourceforge.net/rst.html
 [8]: https://docs.scala-lang.org/style/scaladoc.html
 [9]: https://github.com/twitter/finagle/blob/master/finagle-core/src/test/java/com/twitter/finagle/AddrCompilationTest.java
 [es]: https://twitter.github.io/effectivescala/

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/doc/src/sphinx/FAQ.rst
+++ b/doc/src/sphinx/FAQ.rst
@@ -67,7 +67,7 @@ You can disable this behavior by using the :API:`MaskCancelFilter <com/twitter/f
   import com.twitter.finagle.http.
 
   val service: Service[http.Request, http.Response] =
-    Http.client.newService("http://twitter.com")
+    Http.client.newService("https://twitter.com")
   val masked = new MaskCancelFilter[http.Request, http.Response]
 
   val maskedService = masked.andThen(service)

--- a/finagle-http/src/test/java/com/twitter/finagle/http/HttpMuxerCompilationTest.java
+++ b/finagle-http/src/test/java/com/twitter/finagle/http/HttpMuxerCompilationTest.java
@@ -12,7 +12,7 @@ public class HttpMuxerCompilationTest {
   /** a comment */
   @Test
   public void testHttpMuxer() {
-    HttpMuxers.apply(Request.apply("http://192.168.0.1/"));
+    HttpMuxers.apply(Request.apply("https://192.168.0.1/"));
 
     HttpMuxers.patterns();
 

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/AbstractMultipartDecoderTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/AbstractMultipartDecoderTest.scala
@@ -18,7 +18,7 @@ abstract class AbstractMultipartDecoderTest(decoder: MultipartDecoder) extends F
    */
   private[this] def newRequest(buf: Buf): Request =
     RequestBuilder()
-      .url("http://example.com")
+      .url("https://example.com")
       .add(FileElement("groups", buf, Some("image/gif"), Some("dealwithit.gif")))
       .add(SimpleElement("type", "text"))
       .buildFormPost(multipart = true)

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/RequestBuilderTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/RequestBuilderTest.scala
@@ -5,9 +5,9 @@ import java.net.URL
 import org.scalatest.FunSuite
 
 class RequestBuilderTest extends FunSuite {
-  val URL0 = new URL("http://joe:blow@www.google.com:77/xxx?foo=bar#xxx")
+  val URL0 = new URL("https://joe:blow@www.google.com:77/xxx?foo=bar#xxx")
   val URL1 = new URL("https://www.google.com/")
-  val URL2 = new URL("http://joe%40host.com:blow@www.google.com:77/xxx?foo=bar#xxx")
+  val URL2 = new URL("https://joe%40host.com:blow@www.google.com:77/xxx?foo=bar#xxx")
   val URL3 = new URL("https://foo_bar_prod.www.address.com")
 
   val BODY0 = Buf.Utf8("blah")
@@ -106,17 +106,17 @@ v33
   }
 
   test("replace the empty path with /") {
-    val req0 = RequestBuilder().url(new URL("http://a.com")).buildGet
-    val req1 = RequestBuilder().url(new URL("http://a.com?xxx")).buildGet
+    val req0 = RequestBuilder().url(new URL("https://a.com")).buildGet
+    val req1 = RequestBuilder().url(new URL("https://a.com?xxx")).buildGet
 
     req0.uri == "/"
     req1.uri == "/?xxx"
   }
 
   test("not include the fragment in the resource") {
-    val u0 = new URL("http://a.com#xxx")
-    val u1 = new URL("http://a.com/#xxx")
-    val u2 = new URL("http://a.com/?abc=def#xxx")
+    val u0 = new URL("https://a.com#xxx")
+    val u1 = new URL("https://a.com/#xxx")
+    val u2 = new URL("https://a.com/?abc=def#xxx")
 
     val get0 = RequestBuilder().url(u0).buildGet
     val get1 = RequestBuilder().url(u1).buildGet
@@ -152,9 +152,9 @@ v33
   }
 
   test("not include the empty query string") {
-    val u0 = new URL("http://a.com?")
-    val u1 = new URL("http://a.com/?")
-    val u2 = new URL("http://a.com/?#xxx")
+    val u0 = new URL("https://a.com?")
+    val u1 = new URL("https://a.com/?")
+    val u2 = new URL("https://a.com/?#xxx")
 
     val get0 = RequestBuilder().url(u0).buildGet
     val get1 = RequestBuilder().url(u1).buildGet

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/ServerSideDecodingTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/ServerSideDecodingTest.scala
@@ -79,7 +79,7 @@ class ServerSideDecodingTest extends FunSuite with GeneratorDrivenPropertyChecks
     // URL at which all requests should be made
     val url: String = {
       val addr = server.boundAddress.asInstanceOf[InetSocketAddress]
-      s"http://${addr.getHostName}:${addr.getPort}/"
+      s"https://${addr.getHostName}:${addr.getPort}/"
     }
 
     forAll { (content: String, encoder: Encoder) ⇒

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/SpnegoAuthenticatorTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/SpnegoAuthenticatorTest.scala
@@ -20,7 +20,7 @@ import org.scalatest.mockito.MockitoSugar
 class SpnegoAuthenticatorTest extends FunSuite with MockitoSugar {
   import SpnegoAuthenticator._
 
-  def builder = RequestBuilder().url("http://0.0.0.0/arbitrary")
+  def builder = RequestBuilder().url("https://0.0.0.0/arbitrary")
   def anyAuthenticated = any[Authenticated[Request]]
 
   test("no header") {

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/TraceInitializationTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/TraceInitializationTest.scala
@@ -15,7 +15,7 @@ private object Svc extends Service[Request, Response] {
 
 @RunWith(classOf[JUnitRunner])
 class TraceInitializationTest extends FunSuite {
-  def req = RequestBuilder().url("http://foo/this/is/a/uri/path").buildGet()
+  def req = RequestBuilder().url("https://foo/this/is/a/uri/path").buildGet()
 
   def assertAnnotationsInOrder(records: Seq[Record], annos: Seq[Annotation]): Unit = {
     assert(records.collect { case Record(_, _, ann, _) if annos.contains(ann) => ann } == annos)

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/filter/LoggingFilterTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/filter/LoggingFilterTest.scala
@@ -22,7 +22,7 @@ class LoggingFilterTest extends FunSuite {
     val request = Request("/search.json")
     request.method = Method.Get
     request.xForwardedFor = "10.0.0.1"
-    request.referer = "http://www.example.com/"
+    request.referer = "https://www.example.com/"
     request.userAgent = "User Agent"
     request.version = Version.Http11
 

--- a/finagle-http2/src/test/scala/com/twitter/finagle/http2/Http2ListenerTest.scala
+++ b/finagle-http2/src/test/scala/com/twitter/finagle/http2/Http2ListenerTest.scala
@@ -54,7 +54,7 @@ class Http2ListenerTest extends FunSuite {
   import Http2ListenerTest._
 
   test("Http2Listener should upgrade neatly")(new Ctx {
-    await(write("""GET http:/// HTTP/1.1
+    await(write("""GET https:/// HTTP/1.1
       |x-http2-stream-id: 1
       |upgrade: h2c
       |HTTP2-Settings: AAEAABAAAAIAAAABAAN_____AAQAAP__AAUAAEAAAAZ_____
@@ -77,7 +77,7 @@ class Http2ListenerTest extends FunSuite {
 
   test("Http2Listener should not upgrade with an invalid URI")(new Ctx {
 
-    await(write(s"""GET http:///DSC02175拷貝.jpg HTTP/1.1
+    await(write(s"""GET https:///DSC02175拷貝.jpg HTTP/1.1
                   |x-http2-stream-id: 1
                   |upgrade: h2c
                   |HTTP2-Settings: AAEAABAAAAIAAAABAAN_____AAQAAP__AAUAAEAAAAZ_____

--- a/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/MockClientTest.scala
+++ b/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/MockClientTest.scala
@@ -16,7 +16,7 @@ class MockClientTest extends FunSuite {
 
   val TimeOut = 15.seconds
 
-  // http://t.co/momentofzen.jpg
+  // https://t.co/momentofzen.jpg
   private[this] val zen: Time = Time.epoch + 1288834974657L.milliseconds // Twepoch
 
   private def run[T](awaitable: Awaitable[T]): T = Await.result(awaitable, TimeOut)

--- a/site/index.html
+++ b/site/index.html
@@ -130,7 +130,7 @@
       <li><a href="https://github.com/finagle/finagle-irc">Finagle IRC</a> - an implementation of the IRC protocol on Finagle</li>
       <li><a href="https://github.com/finagle/finagle-websocket">WebSockets implementation for Finagle</a></li>
       <li><a href="https://github.com/evnm/fintop">Fintop</a> - a top-like utility for monitoring Finagle services</li>
-      <li><a href="http://fintrospect.io/">Fintrospect</a> - adds an intelligent HTTP routing layer to Finagle. It provides a simple way to implement contracts for both server and client-side HTTP services</li>
+      <li><a href="https://fintrospect.io/">Fintrospect</a> - adds an intelligent HTTP routing layer to Finagle. It provides a simple way to implement contracts for both server and client-side HTTP services</li>
       <li><a href="https://wvlet.org/airframe/docs/airframe-http.html">Airframe HTTP</a> - a library for building REST APIs over Finagle</li>
     </ul>
   </div>


### PR DESCRIPTION
This PR changes every instance of an http url to its https version for security reasons.