### PR TITLE
Allow to use SOCKS proxy for localhost

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,6 +55,9 @@ New Features
   Use `withExecutionOffloaded` configuration method (on a client or a server) to access
   new functionality. ``PHAB_ID=D325049``
 
+* finagle-core: Allow to not bypass SOCKS proxy for localhost by usingg the GlobalFlag
+  `-com.twitter.finagle.socks.socksProxyForLocalhost`
+
 * finagle-http: Added counters for request/response stream as: `stream/request/closed`,
   `stream/request/failures`, `stream/request/failures/<exception_name>`, `stream/request/opened`,
   `stream/request/pending` and `stream/response/closed`, `stream/response/failures`,

--- a/finagle-core/src/main/scala/com/twitter/finagle/client/Transporter.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/client/Transporter.scala
@@ -67,7 +67,7 @@ object Transporter {
   /**
    * $param a SocksProxy as the endpoint for a `Transporter`.
    */
-  case class SocksProxy(sa: Option[SocketAddress], credentials: Option[(String, String)]) {
+  case class SocksProxy(sa: Option[SocketAddress], credentials: Option[(String, String)], bypassLocalhost: Boolean = true) {
     def mk(): (SocksProxy, Stack.Param[SocksProxy]) =
       (this, SocksProxy)
   }
@@ -85,7 +85,7 @@ object Transporter {
         case _ => None
       }
 
-    val default: SocksProxy = SocksProxy(socksProxy, socksUsernameAndPassword)
+    val default: SocksProxy = SocksProxy(socksProxy, socksUsernameAndPassword, !socksProxyForLocalhost())
 
     override def show(p: SocksProxy): Seq[(String, () => String)] = {
       // do not show the password for security reasons

--- a/finagle-core/src/main/scala/com/twitter/finagle/socks/flags.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/socks/flags.scala
@@ -8,6 +8,9 @@ private[finagle] object socksProxyHost extends GlobalFlag("", "SOCKS proxy host"
 private[finagle] object socksProxyPort extends GlobalFlag(0, "SOCKS proxy port") {
   override val name = "socksProxyPort"
 }
+private[finagle] object socksProxyForLocalhost extends GlobalFlag(false, "Use SOCKS proxy for localhost connections, defaults to false.") {
+  override val name = "socksProxyForLocalhost"
+}
 private[finagle] object socksUsernameFlag extends GlobalFlag("", "SOCKS username") {
   override val name = "socksUsername"
 }

--- a/finagle-core/src/test/java/com/twitter/finagle/StackParamCompilationTest.java
+++ b/finagle-core/src/test/java/com/twitter/finagle/StackParamCompilationTest.java
@@ -70,7 +70,7 @@ public class StackParamCompilationTest {
           new DefaultPool.Param(0, Integer.MAX_VALUE, 0, Duration.Top(), Integer.MAX_VALUE).mk())
         .configured(new Transporter.ConnectTimeout(Duration.Top()).mk())
         .configured(
-          new Transporter.SocksProxy(Option.empty(), Option.empty()).mk())
+          new Transporter.SocksProxy(Option.empty(), Option.empty(), true).mk())
         .configured(
           new Transporter.HttpProxy(
             Option.<SocketAddress>empty(),

--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/channel/AbstractNetty4ClientChannelInitializer.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/channel/AbstractNetty4ClientChannelInitializer.scala
@@ -26,7 +26,7 @@ private[netty4] abstract class AbstractNetty4ClientChannelInitializer(params: St
   private[this] val Stats(stats) = params[Stats]
   private[this] val Transporter.HttpProxyTo(httpHostAndCredentials) =
     params[Transporter.HttpProxyTo]
-  private[this] val Transporter.SocksProxy(socksAddress, socksCredentials) =
+  private[this] val Transporter.SocksProxy(socksAddress, socksCredentials, socksBypassLocalhost) =
     params[Transporter.SocksProxy]
   private[this] val Transporter.HttpProxy(httpAddress, httpCredentials) =
     params[Transporter.HttpProxy]
@@ -99,7 +99,7 @@ private[netty4] abstract class AbstractNetty4ClientChannelInitializer(params: St
 
       pipe.addFirst(
         "socksProxyConnect",
-        new Netty4ProxyConnectHandler(proxyHandler, bypassLocalhostConnections = true)
+        new Netty4ProxyConnectHandler(proxyHandler, bypassLocalhostConnections = socksBypassLocalhost)
       )
     }
 


### PR DESCRIPTION
Problem

SOCKS proxy is bypassed when connecting to localhost and there's no way to override this behaviour. Using a SOCKS proxy when connecting to localhost can be useful to easily capture communication between local services for debugging.

Solution

Add a flags to enable SOCKS proxy for localhost.

Result

You can now force the use of SOCKS proxy for localhost with `-com.twitter.finagle.socks.socksProxyForLocalhost`. Without this flag, the behaviour of bypassing the SOCKS proxy is kept.
