### PR TITLE
[Testing] add jdk11 to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ scala:
 
 jdk:
   - oraclejdk8
+  - oraclejdk11
 
 notifications:
   slack:

--- a/sbt
+++ b/sbt
@@ -28,7 +28,6 @@ java -ea                          \
   -Djava.net.preferIPv4Stack=true \
   -XX:+AggressiveOpts             \
   -XX:+UseParallelGC              \
-  -XX:+UseConcMarkSweepGC         \
   -XX:+CMSParallelRemarkEnabled   \
   -XX:+CMSClassUnloadingEnabled   \
   -XX:ReservedCodeCacheSize=128m  \

--- a/sbt
+++ b/sbt
@@ -27,7 +27,7 @@ java -ea                          \
   $JAVA_OPTS                      \
   -Djava.net.preferIPv4Stack=true \
   -XX:+AggressiveOpts             \
-  -XX:+UseParNewGC                \
+  -XX:+UseParallelGC              \
   -XX:+UseConcMarkSweepGC         \
   -XX:+CMSParallelRemarkEnabled   \
   -XX:+CMSClassUnloadingEnabled   \


### PR DESCRIPTION
Problem

We should catch compatibility issues with JDK11 sooner rather than later.

Solution

Turn on testing with JDK11 in Travis CI.

Result

Builds will likely fail, but it is helpful to know what problems we might
encounter migrating to JDK11.