### PR TITLE
finagle: allow testing against Netty SNAPSHOT in build.sbt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ git:
   quiet: true
 
 env:
+  - USE_NETTY_SNAPSHOT=false
+  - USE_NETTY_SNAPSHOT=true
   global:
     - JAVA_OPTS="-DSKIP_FLAKY=1 -DSKIP_FLAKY_TRAVIS=1 -Dsbt.log.noformat=true"
   matrix:
@@ -33,6 +35,11 @@ env:
     - PROJECT=finagle-tunable
     - PROJECT=finagle-zipkin-core
     - PROJECT=finagle-zipkin-scribe
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: USE_NETTY_SNAPSHOT=true
 
 # These directories are cached to S3 at the end of the build
 cache:
@@ -60,6 +67,12 @@ notifications:
     on_failure: change
     on_success: change
 
+before_install:
+  - sudo apt-get install -y xmlstarlet
+addons:
+  apt:
+    update: true
+
 before_script:
   - unset SBT_OPTS # default $SBT_OPTS is irrelevant to sbt launcher
   # note: this is not ideal to run before every job in the matrix but is the only way that works consistently
@@ -69,6 +82,7 @@ before_script:
   - ./sbt ++$TRAVIS_SCALA_VERSION finagle-memcached/test:compile
 
 script:
+  - source ./netty-snapshot-env.sh $USE_NETTY_SNAPSHOT
   - travis_retry ./sbt ++$TRAVIS_SCALA_VERSION coverage "$PROJECT/test" coverageReport
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ matrix:
     - env: PROJECT=finagle-http USE_NETTY_SNAPSHOT=true
     - env: PROJECT=finagle-http2 USE_NETTY_SNAPSHOT=true
     - env: PROJECT=finagle-integration USE_NETTY_SNAPSHOT=true
+    - env: PROJECT=finagle-mux USE_NETTY_SNAPSHOT=true
     - env: PROJECT=finagle-mysql USE_NETTY_SNAPSHOT=true
     - env: PROJECT=finagle-netty4 USE_NETTY_SNAPSHOT=true
     - env: PROJECT=finagle-netty4-http USE_NETTY_SNAPSHOT=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,25 +11,19 @@ env:
   global:
     - JAVA_OPTS="-DSKIP_FLAKY=1 -DSKIP_FLAKY_TRAVIS=1 -Dsbt.log.noformat=true"
   matrix:
+    # We specify all of the finagle projects and explicitly assign the USE_NETTY_SNAPSHOT property
+    # to 'false', as the 'netty-snapshot-env.sh' requires a 'true' or 'false' argument.
     - PROJECT=finagle-core USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-core USE_NETTY_SNAPSHOT=true
     - PROJECT=finagle-exception  USE_NETTY_SNAPSHOT=false
     - PROJECT=finagle-exp USE_NETTY_SNAPSHOT=false
     - PROJECT=finagle-grpc-context USE_NETTY_SNAPSHOT=false
     - PROJECT=finagle-http USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-http USE_NETTY_SNAPSHOT=true
     - PROJECT=finagle-http2 USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-http2 USE_NETTY_SNAPSHOT=true
     - PROJECT=finagle-integration USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-integration USE_NETTY_SNAPSHOT=true
     - PROJECT=finagle-mux USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-mux USE_NETTY_SNAPSHOT=true
     - PROJECT=finagle-mysql USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-mysql USE_NETTY_SNAPSHOT=true
     - PROJECT=finagle-netty4 USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-netty4 USE_NETTY_SNAPSHOT=true
     - PROJECT=finagle-netty4-http USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-netty4-http USE_NETTY_SNAPSHOT=true
     - PROJECT=finagle-opencensus-tracing USE_NETTY_SNAPSHOT=false
     - PROJECT=finagle-redis USE_NETTY_SNAPSHOT=false
     - PROJECT=finagle-serversets USE_NETTY_SNAPSHOT=false
@@ -37,15 +31,31 @@ env:
     - PROJECT=finagle-stats-core USE_NETTY_SNAPSHOT=false
     - PROJECT=finagle-thrift USE_NETTY_SNAPSHOT=false
     - PROJECT=finagle-thriftmux USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-thriftmux USE_NETTY_SNAPSHOT=true
     - PROJECT=finagle-toggle USE_NETTY_SNAPSHOT=false
     - PROJECT=finagle-tunable USE_NETTY_SNAPSHOT=false
     - PROJECT=finagle-zipkin-core USE_NETTY_SNAPSHOT=false
     - PROJECT=finagle-zipkin-scribe USE_NETTY_SNAPSHOT=false
+    # Here we specify the projects that we want to build and test against the most recent
+    # Netty SNAPSHOT build. We do this to determine if we are introducing changes that will break
+    # against the latest Netty development branch (or if Netty has introduced a breaking change to
+    # the Finagle code). We choose specific projects to target that are more likely to be impacted
+    # by Netty changes to prevent having to build & test for every project.
+    - PROJECT=finagle-core USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-http USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-http2 USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-integration USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-mux USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-mysql USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-netty4 USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-netty4-http USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-thriftmux USE_NETTY_SNAPSHOT=true
 
 matrix:
+  # Allows for assigning a build result if the non-'allow_failures' targets are complete
   fast_finish: true
   allow_failures:
+    # Anything that tests against a Netty SNAPSHOT build should not be considered when failing
+    # the overall build result. The env vars here must match EXACTLY to the env matrix properties.
     - env: PROJECT=finagle-core USE_NETTY_SNAPSHOT=true
     - env: PROJECT=finagle-http USE_NETTY_SNAPSHOT=true
     - env: PROJECT=finagle-http2 USE_NETTY_SNAPSHOT=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ before_script:
   - ./sbt ++$TRAVIS_SCALA_VERSION finagle-memcached/test:compile
 
 script:
-  - if [[ ! -z "${FINAGLE_USE_NETTY_4_SNAPSHOT}" ]]; then source ./netty-snapshot-env.sh $USE_NETTY_SNAPSHOT; fi
+  - if [[ ! -z "${USE_NETTY_SNAPSHOT}" ]]; then source ./netty-snapshot-env.sh $USE_NETTY_SNAPSHOT; fi
   - travis_retry ./sbt ++$TRAVIS_SCALA_VERSION coverage "$PROJECT/test" coverageReport
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,37 +11,39 @@ env:
   global:
     - JAVA_OPTS="-DSKIP_FLAKY=1 -DSKIP_FLAKY_TRAVIS=1 -Dsbt.log.noformat=true"
   matrix:
-    - PROJECT=finagle-core
-    - PROJECT=finagle-core
-    - PROJECT=finagle-exception
-    - PROJECT=finagle-exp
-    - PROJECT=finagle-grpc-context
-    - PROJECT=finagle-http
-    - PROJECT=finagle-http2
-    - PROJECT=finagle-integration
-    - PROJECT=finagle-mux
-    - PROJECT=finagle-mysql
-    - PROJECT=finagle-netty4
-    - PROJECT=finagle-netty4-http
-    - PROJECT=finagle-opencensus-tracing
-    - PROJECT=finagle-redis
-    - PROJECT=finagle-serversets
-    - PROJECT=finagle-stats
-    - PROJECT=finagle-stats-core
-    - PROJECT=finagle-thrift
-    - PROJECT=finagle-thriftmux
-    - PROJECT=finagle-toggle
-    - PROJECT=finagle-tunable
-    - PROJECT=finagle-zipkin-core
-    - PROJECT=finagle-zipkin-scribe
+    - PROJECT=finagle-core USE_NETTY_SNAPSHOT=false
+    - PROJECT=finagle-core USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-exception  USE_NETTY_SNAPSHOT=false
+    - PROJECT=finagle-exp USE_NETTY_SNAPSHOT=false
+    - PROJECT=finagle-grpc-context USE_NETTY_SNAPSHOT=false
+    - PROJECT=finagle-http USE_NETTY_SNAPSHOT=false
+    - PROJECT=finagle-http USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-http2 USE_NETTY_SNAPSHOT=false
+    - PROJECT=finagle-http2 USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-integration USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-mux USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-mysql USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-netty4 USE_NETTY_SNAPSHOT=false
+    - PROJECT=finagle-netty4 USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-netty4-http USE_NETTY_SNAPSHOT=false
+    - PROJECT=finagle-netty4-http USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-opencensus-tracing USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-redis USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-serversets USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-stats USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-stats-core USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-thrift USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-thriftmux USE_NETTY_SNAPSHOT=false
+    - PROJECT=finagle-thriftmux USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-toggle USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-tunable USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-zipkin-core USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-zipkin-scribe USE_NETTY_SNAPSHOT=true
 
 matrix:
   fast_finish: true
   allow_failures:
     - env: USE_NETTY_SNAPSHOT=true
-  include:
-    - env: USE_NETTY_SNAPSHOT=true
-    - env: USE_NETTY_SNAPSHOT=false
 
 # These directories are cached to S3 at the end of the build
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,10 @@ git:
   quiet: true
 
 env:
-  - USE_NETTY_SNAPSHOT=false
-  - USE_NETTY_SNAPSHOT=true
   global:
     - JAVA_OPTS="-DSKIP_FLAKY=1 -DSKIP_FLAKY_TRAVIS=1 -Dsbt.log.noformat=true"
   matrix:
+    - PROJECT=finagle-core
     - PROJECT=finagle-core
     - PROJECT=finagle-exception
     - PROJECT=finagle-exp
@@ -40,6 +39,9 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: USE_NETTY_SNAPSHOT=true
+  include:
+    - env: USE_NETTY_SNAPSHOT=true
+    - env: USE_NETTY_SNAPSHOT=false
 
 # These directories are cached to S3 at the end of the build
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,30 +11,28 @@ env:
   global:
     - JAVA_OPTS="-DSKIP_FLAKY=1 -DSKIP_FLAKY_TRAVIS=1 -Dsbt.log.noformat=true"
   matrix:
-    # We specify all of the finagle projects and explicitly assign the USE_NETTY_SNAPSHOT property
-    # to 'false', as the 'netty-snapshot-env.sh' requires a 'true' or 'false' argument.
-    - PROJECT=finagle-core USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-exception  USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-exp USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-grpc-context USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-http USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-http2 USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-integration USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-mux USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-mysql USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-netty4 USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-netty4-http USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-opencensus-tracing USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-redis USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-serversets USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-stats USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-stats-core USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-thrift USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-thriftmux USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-toggle USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-tunable USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-zipkin-core USE_NETTY_SNAPSHOT=false
-    - PROJECT=finagle-zipkin-scribe USE_NETTY_SNAPSHOT=false
+    - PROJECT=finagle-core
+    - PROJECT=finagle-exception
+    - PROJECT=finagle-exp
+    - PROJECT=finagle-grpc-context
+    - PROJECT=finagle-http
+    - PROJECT=finagle-http2
+    - PROJECT=finagle-integration
+    - PROJECT=finagle-mux
+    - PROJECT=finagle-mysql
+    - PROJECT=finagle-netty4
+    - PROJECT=finagle-netty4-http
+    - PROJECT=finagle-opencensus-tracing
+    - PROJECT=finagle-redis
+    - PROJECT=finagle-serversets
+    - PROJECT=finagle-stats
+    - PROJECT=finagle-stats-core
+    - PROJECT=finagle-thrift
+    - PROJECT=finagle-thriftmux
+    - PROJECT=finagle-toggle
+    - PROJECT=finagle-tunable
+    - PROJECT=finagle-zipkin-core
+    - PROJECT=finagle-zipkin-scribe
     # Here we specify the projects that we want to build and test against the most recent
     # Netty SNAPSHOT build. We do this to determine if we are introducing changes that will break
     # against the latest Netty development branch (or if Netty has introduced a breaking change to
@@ -107,7 +105,7 @@ before_script:
   - ./sbt ++$TRAVIS_SCALA_VERSION finagle-memcached/test:compile
 
 script:
-  - source ./netty-snapshot-env.sh $USE_NETTY_SNAPSHOT
+  - if [[ ! -z "${FINAGLE_USE_NETTY_4_SNAPSHOT}" ]]; then source ./netty-snapshot-env.sh $USE_NETTY_SNAPSHOT; fi
   - travis_retry ./sbt ++$TRAVIS_SCALA_VERSION coverage "$PROJECT/test" coverageReport
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,30 +20,40 @@ env:
     - PROJECT=finagle-http USE_NETTY_SNAPSHOT=true
     - PROJECT=finagle-http2 USE_NETTY_SNAPSHOT=false
     - PROJECT=finagle-http2 USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-integration USE_NETTY_SNAPSHOT=false
     - PROJECT=finagle-integration USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-mux USE_NETTY_SNAPSHOT=false
     - PROJECT=finagle-mux USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-mysql USE_NETTY_SNAPSHOT=false
     - PROJECT=finagle-mysql USE_NETTY_SNAPSHOT=true
     - PROJECT=finagle-netty4 USE_NETTY_SNAPSHOT=false
     - PROJECT=finagle-netty4 USE_NETTY_SNAPSHOT=true
     - PROJECT=finagle-netty4-http USE_NETTY_SNAPSHOT=false
     - PROJECT=finagle-netty4-http USE_NETTY_SNAPSHOT=true
-    - PROJECT=finagle-opencensus-tracing USE_NETTY_SNAPSHOT=true
-    - PROJECT=finagle-redis USE_NETTY_SNAPSHOT=true
-    - PROJECT=finagle-serversets USE_NETTY_SNAPSHOT=true
-    - PROJECT=finagle-stats USE_NETTY_SNAPSHOT=true
-    - PROJECT=finagle-stats-core USE_NETTY_SNAPSHOT=true
-    - PROJECT=finagle-thrift USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-opencensus-tracing USE_NETTY_SNAPSHOT=false
+    - PROJECT=finagle-redis USE_NETTY_SNAPSHOT=false
+    - PROJECT=finagle-serversets USE_NETTY_SNAPSHOT=false
+    - PROJECT=finagle-stats USE_NETTY_SNAPSHOT=false
+    - PROJECT=finagle-stats-core USE_NETTY_SNAPSHOT=false
+    - PROJECT=finagle-thrift USE_NETTY_SNAPSHOT=false
     - PROJECT=finagle-thriftmux USE_NETTY_SNAPSHOT=false
     - PROJECT=finagle-thriftmux USE_NETTY_SNAPSHOT=true
-    - PROJECT=finagle-toggle USE_NETTY_SNAPSHOT=true
-    - PROJECT=finagle-tunable USE_NETTY_SNAPSHOT=true
-    - PROJECT=finagle-zipkin-core USE_NETTY_SNAPSHOT=true
-    - PROJECT=finagle-zipkin-scribe USE_NETTY_SNAPSHOT=true
+    - PROJECT=finagle-toggle USE_NETTY_SNAPSHOT=false
+    - PROJECT=finagle-tunable USE_NETTY_SNAPSHOT=false
+    - PROJECT=finagle-zipkin-core USE_NETTY_SNAPSHOT=false
+    - PROJECT=finagle-zipkin-scribe USE_NETTY_SNAPSHOT=false
 
 matrix:
   fast_finish: true
   allow_failures:
-    - env: USE_NETTY_SNAPSHOT=true
+    - env: PROJECT=finagle-core USE_NETTY_SNAPSHOT=true
+    - env: PROJECT=finagle-http USE_NETTY_SNAPSHOT=true
+    - env: PROJECT=finagle-http2 USE_NETTY_SNAPSHOT=true
+    - env: PROJECT=finagle-integration USE_NETTY_SNAPSHOT=true
+    - env: PROJECT=finagle-mysql USE_NETTY_SNAPSHOT=true
+    - env: PROJECT=finagle-netty4 USE_NETTY_SNAPSHOT=true
+    - env: PROJECT=finagle-netty4-http USE_NETTY_SNAPSHOT=true
+    - env: PROJECT=finagle-thriftmux USE_NETTY_SNAPSHOT=true
 
 # These directories are cached to S3 at the end of the build
 cache:

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,38 @@ val releaseVersion = "19.8.0-SNAPSHOT"
 
 val libthriftVersion = "0.10.0"
 
-val netty4Version = "4.1.35.Final"
+val defaultNetty4Version = "4.1.35.Final"
+val defaultNetty4StaticSslVersion = "2.0.25.Final"
+
+val useNettySnapshot: Boolean = sys.env.get("FINAGLE_USE_NETTY_4_SNAPSHOT") match {
+  case Some(useSnapshot) => useSnapshot.toBoolean
+  case _ => false
+}
+
+// we only want to allow for resolving dependencies from the snapshots repo IF we're using a
+// Netty SNAPSHOT build.
+val extraSnapshotResolvers =
+  if(useNettySnapshot) {
+    Seq(Resolver.sonatypeRepo("snapshots"))
+  } else {
+    Seq.empty
+  }
+
+val netty4Version: String =
+  if(useNettySnapshot) {
+    sys.env("FINAGLE_NETTY_4_VERSION")
+  } else {
+    defaultNetty4Version
+  }
+
+val netty4StaticSslVersion: String =
+  if(useNettySnapshot) {
+    sys.env("FINAGLE_NETTY_4_TCNATIVE_VERSION")
+  } else {
+    defaultNetty4StaticSslVersion
+  }
+
+val nettyVersionInfo = settingKey[String]("A setting reference for printing the netty version info")
 
 // zkVersion should be kept in sync with the 'util-zk' dependency version
 val zkVersion = "3.5.0-alpha"
@@ -32,9 +63,9 @@ val netty4LibsTest = Seq(
 )
 val netty4Http = "io.netty" % "netty-codec-http" % netty4Version
 val netty4Http2 = "io.netty" % "netty-codec-http2" % netty4Version
-val netty4StaticSsl = "io.netty" % "netty-tcnative-boringssl-static" % "2.0.25.Final"
+val netty4StaticSsl = "io.netty" % "netty-tcnative-boringssl-static" % netty4StaticSslVersion
 val opencensusVersion = "0.19.1"
-val jacksonVersion = "2.9.9"
+val jacksonVersion = "2.9.8"
 val jacksonLibs = Seq(
   "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
@@ -95,6 +126,8 @@ val sharedSettings = Seq(
 
   // -a: print stack traces for failing asserts
   testOptions += Tests.Argument(TestFrameworks.JUnit, "-a"),
+
+  resolvers ++= extraSnapshotResolvers,
 
   // This effectively disables packageDoc, which craps out
   // on generating docs for generated thrift due to the use
@@ -207,6 +240,13 @@ lazy val finagle = Project(
 ).enablePlugins(
   ScalaUnidocPlugin
 ).settings(
+  nettyVersionInfo := {
+    val log = sLog.value
+    log.info(s"Using Netty SNAPSHOT build mode: ${ useNettySnapshot }")
+    log.info(s"Netty version: ${ netty4Version }")
+    log.info(s"Netty tcnative version ${ netty4StaticSslVersion }")
+    ""
+  },
   sharedSettings ++
   noPublishSettings ++
   Seq(
@@ -601,10 +641,7 @@ lazy val finagleExp = Project(
   libraryDependencies ++= Seq(
     "com.netflix.concurrency-limits" % "concurrency-limits-core" % "0.3.0"
   )
-).dependsOn(
-  finagleCore % "compile->compile;test->test",
-  finagleThrift
-)
+).dependsOn(finagleCore, finagleThrift)
 
 lazy val finagleGrpcContext = Project(
   id = "finagle-grpc-context",

--- a/build.sbt
+++ b/build.sbt
@@ -17,21 +17,21 @@ val useNettySnapshot: Boolean = sys.env.get("FINAGLE_USE_NETTY_4_SNAPSHOT") matc
 // we only want to allow for resolving dependencies from the snapshots repo IF we're using a
 // Netty SNAPSHOT build.
 val extraSnapshotResolvers =
-  if(useNettySnapshot) {
+  if (useNettySnapshot) {
     Seq(Resolver.sonatypeRepo("snapshots"))
   } else {
     Seq.empty
   }
 
 val netty4Version: String =
-  if(useNettySnapshot) {
+  if (useNettySnapshot) {
     sys.env("FINAGLE_NETTY_4_VERSION")
   } else {
     defaultNetty4Version
   }
 
 val netty4StaticSslVersion: String =
-  if(useNettySnapshot) {
+  if (useNettySnapshot) {
     sys.env("FINAGLE_NETTY_4_TCNATIVE_VERSION")
   } else {
     defaultNetty4StaticSslVersion
@@ -65,7 +65,7 @@ val netty4Http = "io.netty" % "netty-codec-http" % netty4Version
 val netty4Http2 = "io.netty" % "netty-codec-http2" % netty4Version
 val netty4StaticSsl = "io.netty" % "netty-tcnative-boringssl-static" % netty4StaticSslVersion
 val opencensusVersion = "0.19.1"
-val jacksonVersion = "2.9.8"
+val jacksonVersion = "2.9.9"
 val jacksonLibs = Seq(
   "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
@@ -641,7 +641,10 @@ lazy val finagleExp = Project(
   libraryDependencies ++= Seq(
     "com.netflix.concurrency-limits" % "concurrency-limits-core" % "0.3.0"
   )
-).dependsOn(finagleCore, finagleThrift)
+).dependsOn(
+  finagleCore % "compile->compile;test->test",
+  finagleThrift
+)
 
 lazy val finagleGrpcContext = Project(
   id = "finagle-grpc-context",

--- a/netty-snapshot-env.sh
+++ b/netty-snapshot-env.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+if [ $# -ne 1 ]; then
+  echo 'usage: source '$0' {true|false}' 1>&2
+  echo '  true            Netty SNAPSHOT version info can be sourced into environment variables for Finagle sbt build'
+  echo '  false           Netty SNAPSHOT version info will be unset from environment variables'
+  exit 1
+fi
+
+USE_SNAPSHOT=$1
+
+print_env () {
+  echo "FINAGLE_USE_NETTY_4_SNAPSHOT=$FINAGLE_USE_NETTY_4_SNAPSHOT"
+  echo "FINAGLE_NETTY_4_VERSION=$FINAGLE_NETTY_4_VERSION"
+  echo "FINAGLE_NETTY_4_TCNATIVE_VERSION=$FINAGLE_NETTY_4_TCNATIVE_VERSION"
+}
+
+if [ "$USE_SNAPSHOT" = "true" ]; then
+  echo "Setting Finagle Netty Snapshot environment variables"
+  echo "Loading latest Netty info..."
+  FILE=netty4-snapshot-pom.xml
+  curl -s https://raw.githubusercontent.com/netty/netty/4.1/pom.xml > $FILE
+  echo "Parsing Netty version info..."
+  FINAGLE_USE_NETTY_4_SNAPSHOT=true
+  FINAGLE_NETTY_4_VERSION=$(xmlstarlet sel -N mvn='http://maven.apache.org/POM/4.0.0' -t -m '/mvn:project/mvn:version' -v . -n < $FILE)
+  FINAGLE_NETTY_4_TCNATIVE_VERSION=$(xmlstarlet sel -N mvn='http://maven.apache.org/POM/4.0.0' -t -m '/mvn:project/mvn:properties/mvn:tcnative.version' -v . -n < $FILE)
+  rm $FILE
+
+  export FINAGLE_USE_NETTY_4_SNAPSHOT
+  export FINAGLE_NETTY_4_VERSION
+  export FINAGLE_NETTY_4_TCNATIVE_VERSION
+
+  print_env
+else
+  echo "Unsetting Finagle Netty Snapshot environment variables"
+
+  unset FINAGLE_NETTY_4_VERSION
+  unset FINAGLE_NETTY_4_TCNATIVE_VERSION
+  unset FINAGLE_USE_NETTY_4_SNAPSHOT
+  print_env
+fi

--- a/netty-snapshot-env.sh
+++ b/netty-snapshot-env.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 if [ $# -ne 1 ]; then
-  echo 'usage: source '$0' {true|false}' 1>&2
+  USAGE_MSG=('usage: source ' $0 ' {true|false}')
+  echo ${USAGE_MSG[*]} 1>&2
   echo '  true            Netty SNAPSHOT version info can be sourced into environment variables for Finagle sbt build'
   echo '  false           Netty SNAPSHOT version info will be unset from environment variables'
   exit 1
@@ -19,7 +20,7 @@ if [ "$USE_SNAPSHOT" = "true" ]; then
   echo "Setting Finagle Netty Snapshot environment variables"
   echo "Loading latest Netty info..."
   FILE=netty4-snapshot-pom.xml
-  curl -s https://raw.githubusercontent.com/netty/netty/4.1/pom.xml > $FILE
+  curl -s --connect-timeout 5 --max-time 10 --retry 5 --retry-max-time 60 https://raw.githubusercontent.com/netty/netty/4.1/pom.xml > $FILE
   echo "Parsing Netty version info..."
   FINAGLE_USE_NETTY_4_SNAPSHOT=true
   FINAGLE_NETTY_4_VERSION=$(xmlstarlet sel -N mvn='http://maven.apache.org/POM/4.0.0' -t -m '/mvn:project/mvn:version' -v . -n < $FILE)
@@ -32,7 +33,7 @@ if [ "$USE_SNAPSHOT" = "true" ]; then
 
   print_env
 else
-  echo "Unsetting Finagle Netty Snapshot environment variables"
+  echo "Using released Netty version. Unsetting Finagle Netty Snapshot environment variables"
 
   unset FINAGLE_NETTY_4_VERSION
   unset FINAGLE_NETTY_4_TCNATIVE_VERSION

--- a/netty-snapshot-env.sh
+++ b/netty-snapshot-env.sh
@@ -1,20 +1,29 @@
 #!/bin/bash
 
-if [ $# -ne 1 ]; then
-  USAGE_MSG=('usage: source ' $0 ' {true|false}')
-  echo ${USAGE_MSG[*]} 1>&2
-  echo '  true            Netty SNAPSHOT version info can be sourced into environment variables for Finagle sbt build'
-  echo '  false           Netty SNAPSHOT version info will be unset from environment variables'
-  exit 1
-fi
-
-USE_SNAPSHOT=$1
-
 print_env () {
   echo "FINAGLE_USE_NETTY_4_SNAPSHOT=$FINAGLE_USE_NETTY_4_SNAPSHOT"
   echo "FINAGLE_NETTY_4_VERSION=$FINAGLE_NETTY_4_VERSION"
   echo "FINAGLE_NETTY_4_TCNATIVE_VERSION=$FINAGLE_NETTY_4_TCNATIVE_VERSION"
 }
+
+unset_env() {
+  unset FINAGLE_NETTY_4_VERSION
+  unset FINAGLE_NETTY_4_TCNATIVE_VERSION
+  unset FINAGLE_USE_NETTY_4_SNAPSHOT
+  print_env
+}
+
+if [ $# -ne 1 ]; then
+  USAGE_MSG=('usage: source ' $0 ' <true|false>')
+  echo "${USAGE_MSG[*]}" 1>&2
+  echo '  true            Netty SNAPSHOT version info can be sourced into environment variables for Finagle sbt build'
+  echo '  false           Netty SNAPSHOT version info will be unset from environment variables'
+  echo -e '\n\nDefault usage is "false", ensuring environment variables are unset:'
+  unset_env
+  exit 0
+fi
+
+USE_SNAPSHOT=$1
 
 if [ "$USE_SNAPSHOT" = "true" ]; then
   echo "Setting Finagle Netty Snapshot environment variables"
@@ -34,9 +43,5 @@ if [ "$USE_SNAPSHOT" = "true" ]; then
   print_env
 else
   echo "Using released Netty version. Unsetting Finagle Netty Snapshot environment variables"
-
-  unset FINAGLE_NETTY_4_VERSION
-  unset FINAGLE_NETTY_4_TCNATIVE_VERSION
-  unset FINAGLE_USE_NETTY_4_SNAPSHOT
-  print_env
+  unset_env
 fi


### PR DESCRIPTION
Problem

We have a manual process of validating Netty versions post-release. This
results in discovering breakages late in the cycle and can delay moving
to the next release.

Solution

Modify the build.sbt file to allow for providing properties to change
the Netty build version. If the build is a SNAPSHOT build, the snapshot
repo will be added to the resolvers.