### PR TITLE
finagle: update travis-ci config to use xmlstarlet package install an…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ matrix:
 
 # These directories are cached to S3 at the end of the build
 cache:
+  apt: true
   directories:
    - $HOME/.ivy2/cache
    - $HOME/.ivy2/local/com.twitter
@@ -90,11 +91,10 @@ notifications:
     on_failure: change
     on_success: change
 
-before_install:
-  - sudo apt-get install -y xmlstarlet
 addons:
   apt:
-    update: true
+    packages:
+      - xmlstarlet
 
 before_script:
   - unset SBT_OPTS # default $SBT_OPTS is irrelevant to sbt launcher

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,6 @@ matrix:
 
 # These directories are cached to S3 at the end of the build
 cache:
-  apt: true
   directories:
    - $HOME/.ivy2/cache
    - $HOME/.ivy2/local/com.twitter
@@ -90,11 +89,6 @@ notifications:
     secure: PfUgPphNmKcZLIjTjd46IHBzqB0vkzK8clCqdsUr5taJRHhMSgRg8ks81sUhCmu+hTl3FG+jEzGgqMUvcisS+OziP/8QR/C41f5jdaETfkBE53DZIWVXZ80QRabphRTCbRUfibC39WWrhhLgWCIqzvTM8qsO/43JuQOGLQbuqcs=
     on_failure: change
     on_success: change
-
-addons:
-  apt:
-    packages:
-      - xmlstarlet
 
 before_script:
   - unset SBT_OPTS # default $SBT_OPTS is irrelevant to sbt launcher

--- a/netty-snapshot-env.sh
+++ b/netty-snapshot-env.sh
@@ -32,8 +32,8 @@ if [ "$USE_SNAPSHOT" = "true" ]; then
   curl -s --connect-timeout 5 --max-time 10 --retry 5 --retry-max-time 60 https://raw.githubusercontent.com/netty/netty/4.1/pom.xml > $FILE
   echo "Parsing Netty version info..."
   FINAGLE_USE_NETTY_4_SNAPSHOT=true
-  FINAGLE_NETTY_4_VERSION=$(xmlstarlet sel -N mvn='http://maven.apache.org/POM/4.0.0' -t -m '/mvn:project/mvn:version' -v . -n < $FILE)
-  FINAGLE_NETTY_4_TCNATIVE_VERSION=$(xmlstarlet sel -N mvn='http://maven.apache.org/POM/4.0.0' -t -m '/mvn:project/mvn:properties/mvn:tcnative.version' -v . -n < $FILE)
+  FINAGLE_NETTY_4_VERSION=$(grep -m 2 "<version>" $FILE | grep SNAPSHOT | awk -F'[<>]' '/version/{print $3}')
+  FINAGLE_NETTY_4_TCNATIVE_VERSION=$(grep -m 1 "<tcnative.version>" $FILE | awk -F'[<>]' '/version/{print $3}')
   rm $FILE
 
   export FINAGLE_USE_NETTY_4_SNAPSHOT


### PR DESCRIPTION
Problem

Travis CI is being flaky when attempting apt-get update

Solution

Use Travis CI's package management, cache apt.

Result

Maybe less flaky failures due to Travis.
