### PR TITLE
Update scalatest/scalacheck and address deprecations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -121,8 +121,8 @@ val sharedSettings = Seq(
   crossScalaVersions := Seq("2.11.12", "2.12.8"),
   fork in Test := true, // We have to fork to get the JavaOptions
   libraryDependencies ++= Seq(
-    "org.scalacheck" %% "scalacheck" % "1.13.4" % "test",
-    "org.scalatest" %% "scalatest" % "3.0.0" % "test",
+    "org.scalacheck" %% "scalacheck" % "1.14.0" % "test",
+    "org.scalatest" %% "scalatest" % "3.0.8" % "test",
     // See https://www.scala-sbt.org/0.13/docs/Testing.html#JUnit
     "com.novocode" % "junit-interface" % "0.11" % "test",
     "org.mockito" % "mockito-all" % "1.9.5" % "test"

--- a/finagle-base-http/src/main/scala/com/twitter/finagle/http/ProxyCredentials.scala
+++ b/finagle-base-http/src/main/scala/com/twitter/finagle/http/ProxyCredentials.scala
@@ -2,13 +2,13 @@ package com.twitter.finagle.http
 
 import com.twitter.util.Base64StringEncoder
 import java.nio.charset.StandardCharsets
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 object ProxyCredentials {
   def apply(credentials: java.util.Map[String, String]): Option[ProxyCredentials] =
-    apply(credentials.toMap)
+    apply(credentials.asScala)
 
-  def apply(credentials: Map[String, String]): Option[ProxyCredentials] = {
+  def apply(credentials: scala.collection.Map[String, String]): Option[ProxyCredentials] = {
     for {
       user <- credentials.get("http_proxy_user")
       pass <- credentials.get("http_proxy_pass")

--- a/finagle-base-http/src/main/scala/com/twitter/finagle/http/ProxyCredentials.scala
+++ b/finagle-base-http/src/main/scala/com/twitter/finagle/http/ProxyCredentials.scala
@@ -6,9 +6,9 @@ import scala.collection.JavaConverters._
 
 object ProxyCredentials {
   def apply(credentials: java.util.Map[String, String]): Option[ProxyCredentials] =
-    apply(credentials.asScala)
+    apply(credentials.asScala.toMap)
 
-  def apply(credentials: scala.collection.Map[String, String]): Option[ProxyCredentials] = {
+  def apply(credentials: Map[String, String]): Option[ProxyCredentials] = {
     for {
       user <- credentials.get("http_proxy_user")
       pass <- credentials.get("http_proxy_pass")

--- a/finagle-base-http/src/main/scala/com/twitter/finagle/http/exp/GenStreamingSerialServerDispatcher.scala
+++ b/finagle-base-http/src/main/scala/com/twitter/finagle/http/exp/GenStreamingSerialServerDispatcher.scala
@@ -74,7 +74,7 @@ private[finagle] abstract class GenStreamingSerialServerDispatcher[Req, Rep, In,
       if (state.compareAndSet(Idle, Running)) {
         val save = Local.save()
         val dispatched = try {
-          Contexts.local.let(RemoteInfo.Upstream.AddressCtx, trans.remoteAddress) {
+          Contexts.local.let(RemoteInfo.Upstream.AddressCtx, trans.context.remoteAddress) {
             val peerCertificates = trans.context.sslSessionInfo.peerCertificates
             if (peerCertificates.isEmpty) dispatch(req)
             else

--- a/finagle-base-http/src/test/scala/com/twitter/finagle/http/DefaultHeaderMapTest.scala
+++ b/finagle-base-http/src/test/scala/com/twitter/finagle/http/DefaultHeaderMapTest.scala
@@ -1,9 +1,9 @@
 package com.twitter.finagle.http
 
 import org.scalacheck.Gen
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class DefaultHeaderMapTest extends AbstractHeaderMapTest with GeneratorDrivenPropertyChecks {
+class DefaultHeaderMapTest extends AbstractHeaderMapTest with ScalaCheckDrivenPropertyChecks {
 
   import Rfc7230HeaderValidationTest._
 

--- a/finagle-base-http/src/test/scala/com/twitter/finagle/http/DelayedReleaseServiceTest.scala
+++ b/finagle-base-http/src/test/scala/com/twitter/finagle/http/DelayedReleaseServiceTest.scala
@@ -5,7 +5,7 @@ import com.twitter.util.{Await, Duration, Future}
 import org.mockito.Matchers.any
 import org.mockito.Mockito.{never, stub, verify}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class DelayedReleaseServiceTest extends FunSuite with MockitoSugar {
 

--- a/finagle-base-http/src/test/scala/com/twitter/finagle/http/QueryParamCodecTest.scala
+++ b/finagle-base-http/src/test/scala/com/twitter/finagle/http/QueryParamCodecTest.scala
@@ -7,12 +7,12 @@ import java.nio.charset.StandardCharsets
 import org.scalacheck.Gen
 import org.scalatest.FunSuite
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scala.collection.JavaConverters._
 
 class QueryParamCodecTest
     extends FunSuite
-    with GeneratorDrivenPropertyChecks
+    with ScalaCheckDrivenPropertyChecks
     with Eventually
     with IntegrationPatience {
 

--- a/finagle-base-http/src/test/scala/com/twitter/finagle/http/Rfc7230HeaderValidationTest.scala
+++ b/finagle-base-http/src/test/scala/com/twitter/finagle/http/Rfc7230HeaderValidationTest.scala
@@ -3,7 +3,7 @@ package com.twitter.finagle.http
 import com.twitter.finagle.http.Rfc7230HeaderValidation.{ObsFoldDetected, ValidationFailure}
 import org.scalacheck.Gen
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 private object Rfc7230HeaderValidationTest {
 
@@ -72,7 +72,7 @@ private object Rfc7230HeaderValidationTest {
     } yield (v + c)
 }
 
-class Rfc7230HeaderValidationTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class Rfc7230HeaderValidationTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
   import Rfc7230HeaderValidationTest._
 
   private[this] def assertFailure(expectedMsgFragment: String)(f: => Any): Unit = {

--- a/finagle-base-http/src/test/scala/com/twitter/finagle/http/codec/Http1ConnectionManagerTest.scala
+++ b/finagle-base-http/src/test/scala/com/twitter/finagle/http/codec/Http1ConnectionManagerTest.scala
@@ -10,7 +10,7 @@ import org.mockito.Mockito
 import org.mockito.Mockito.{times, verify}
 import org.mockito.stubbing.OngoingStubbing
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import scala.language.reflectiveCalls
 
 class Http1ConnectionManagerTest extends FunSuite with MockitoSugar {

--- a/finagle-base-http/src/test/scala/com/twitter/finagle/http/codec/HttpDtabTest.scala
+++ b/finagle-base-http/src/test/scala/com/twitter/finagle/http/codec/HttpDtabTest.scala
@@ -5,7 +5,7 @@ import com.twitter.finagle.{Dentry, Dtab, Failure, NameTree}
 import java.nio.charset.StandardCharsets.{US_ASCII, UTF_8}
 import java.util.Base64
 import org.scalatest.FunSuite
-import org.scalatest.junit.AssertionsForJUnit
+import org.scalatestplus.junit.AssertionsForJUnit
 
 class HttpDtabTest extends FunSuite with AssertionsForJUnit {
   val okDests = Vector("/$/inet/10.0.0.1/9000", "/foo/bar", "/")

--- a/finagle-base-http/src/test/scala/com/twitter/finagle/http/filter/DtabFilterTest.scala
+++ b/finagle-base-http/src/test/scala/com/twitter/finagle/http/filter/DtabFilterTest.scala
@@ -6,7 +6,7 @@ import com.twitter.finagle.http.{Request, Response, Status}
 import com.twitter.finagle.{Dtab, Service}
 import com.twitter.util.{Await, Future}
 import org.scalatest.FunSuite
-import org.scalatest.junit.AssertionsForJUnit
+import org.scalatestplus.junit.AssertionsForJUnit
 
 class DtabFilterTest extends FunSuite with AssertionsForJUnit {
 

--- a/finagle-core/src/main/scala/com/twitter/finagle/context/MarshalledContext.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/context/MarshalledContext.scala
@@ -131,7 +131,7 @@ final class MarshalledContext private[context] extends Context {
   // Exposed for testing
   private[context] def marshal(env: Map[Buf, Cell]): Iterable[(Buf, Buf)] = {
     env.mapValues {
-      case Real(k, v) => k.marshal(v.x)
+      case Real(k, v) => k.marshal(v.get)
       case Translucent(_, vBuf) => vBuf
     }
   }

--- a/finagle-core/src/main/scala/com/twitter/finagle/dispatch/PipeliningDispatcher.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/dispatch/PipeliningDispatcher.scala
@@ -98,7 +98,7 @@ abstract class GenPipeliningDispatcher[Req, Rep, In, Out, T](
               // we check stalled so that we log exactly once per failed pipeline
               if (!stalled) {
                 stalled = true
-                val addr = trans.remoteAddress
+                val addr = trans.context.remoteAddress
                 GenPipeliningDispatcher.log.warning(
                   s"pipelined connection stalled with ${q.size} items, talking to $addr"
                 )

--- a/finagle-core/src/main/scala/com/twitter/finagle/dispatch/ServerDispatcher.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/dispatch/ServerDispatcher.scala
@@ -68,7 +68,7 @@ abstract class GenSerialServerDispatcher[Req, Rep, In, Out](trans: Transport[In,
       val eos = new Promise[Unit]
       val save = Local.save()
       val dispatched = try {
-        Contexts.local.let(RemoteInfo.Upstream.AddressCtx, trans.remoteAddress) {
+        Contexts.local.let(RemoteInfo.Upstream.AddressCtx, trans.context.remoteAddress) {
           val peerCertificates = trans.context.sslSessionInfo.peerCertificates
           if (peerCertificates.isEmpty) dispatch(req, eos)
           else

--- a/finagle-core/src/main/scala/com/twitter/finagle/liveness/FailureDetector.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/liveness/FailureDetector.scala
@@ -158,7 +158,7 @@ object FailureDetector {
    */
   private def parseConfigFromFlags(
     ping: () => Future[Unit],
-    nanoTime: () => Long = System.nanoTime,
+    nanoTime: () => Long = System.nanoTime _,
     statsReceiver: StatsReceiver = NullStatsReceiver
   ): FailureDetector = {
     sessionFailureDetector() match {

--- a/finagle-core/src/main/scala/com/twitter/finagle/liveness/ThresholdFailureDetector.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/liveness/ThresholdFailureDetector.scala
@@ -34,7 +34,7 @@ private class ThresholdFailureDetector(
   ping: () => Future[Unit],
   minPeriod: Duration = 5.seconds,
   closeTimeout: Duration = 4.seconds,
-  nanoTime: () => Long = System.nanoTime,
+  nanoTime: () => Long = System.nanoTime _,
   statsReceiver: StatsReceiver = NullStatsReceiver,
   implicit val timer: Timer = DefaultTimer)
     extends FailureDetector {

--- a/finagle-core/src/test/scala/com/twitter/finagle/ClientConnectionProxyTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/ClientConnectionProxyTest.scala
@@ -3,7 +3,7 @@ package com.twitter.finagle
 import com.twitter.finagle.ssl.session.SslSessionInfo
 import org.mockito.Mockito.when
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class ClientConnectionProxyTest extends FunSuite with MockitoSugar {
 

--- a/finagle-core/src/test/scala/com/twitter/finagle/DtabTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/DtabTest.scala
@@ -1,7 +1,7 @@
 package com.twitter.finagle
 
 import org.scalatest.{FunSuite, Assertion}
-import org.scalatest.junit.AssertionsForJUnit
+import org.scalatestplus.junit.AssertionsForJUnit
 
 class DtabTest extends FunSuite with AssertionsForJUnit {
 

--- a/finagle-core/src/test/scala/com/twitter/finagle/FailureFlagsTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/FailureFlagsTest.scala
@@ -4,9 +4,9 @@ import com.twitter.conversions.DurationOps._
 import com.twitter.util.{Await, Future, Throw}
 import org.scalacheck.Gen
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class FailureFlagsTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class FailureFlagsTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
   import FailureFlags._
 
   private def await[T](f: Future[T]): T =

--- a/finagle-core/src/test/scala/com/twitter/finagle/FailureTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/FailureTest.scala
@@ -5,10 +5,10 @@ import com.twitter.logging.{HasLogLevel, Level}
 import com.twitter.util.{Await, Future}
 import org.scalacheck.Gen
 import org.scalatest.FunSuite
-import org.scalatest.junit.AssertionsForJUnit
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.junit.AssertionsForJUnit
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class FailureTest extends FunSuite with AssertionsForJUnit with GeneratorDrivenPropertyChecks {
+class FailureTest extends FunSuite with AssertionsForJUnit with ScalaCheckDrivenPropertyChecks {
   private val exc = Gen.oneOf[Throwable](null, new Exception("first"), new Exception("second"))
 
   private val flag = Gen.oneOf(

--- a/finagle-core/src/test/scala/com/twitter/finagle/NameTreeParsersTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/NameTreeParsersTest.scala
@@ -1,7 +1,7 @@
 package com.twitter.finagle
 
 import org.scalatest.FunSuite
-import org.scalatest.junit.AssertionsForJUnit
+import org.scalatestplus.junit.AssertionsForJUnit
 
 class NameTreeParsersTest extends FunSuite with AssertionsForJUnit {
   test("parsePath") {

--- a/finagle-core/src/test/scala/com/twitter/finagle/NamerTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/NamerTest.scala
@@ -5,7 +5,7 @@ import com.twitter.finagle.Namer.AddrWeightKey
 import com.twitter.finagle.naming.namerMaxDepth
 import com.twitter.util._
 import org.scalatest.FunSuite
-import org.scalatest.junit.AssertionsForJUnit
+import org.scalatestplus.junit.AssertionsForJUnit
 import scala.language.reflectiveCalls
 
 class NamerTest extends FunSuite with AssertionsForJUnit {

--- a/finagle-core/src/test/scala/com/twitter/finagle/PathTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/PathTest.scala
@@ -1,7 +1,7 @@
 package com.twitter.finagle
 
 import org.scalatest.FunSuite
-import org.scalatest.junit.AssertionsForJUnit
+import org.scalatestplus.junit.AssertionsForJUnit
 
 class PathTest extends FunSuite with AssertionsForJUnit {
   test("Path.show") {

--- a/finagle-core/src/test/scala/com/twitter/finagle/ServiceTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/ServiceTest.scala
@@ -8,7 +8,7 @@ import org.mockito.Mockito.{times, verify, when}
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 object ServiceTest {
 

--- a/finagle-core/src/test/scala/com/twitter/finagle/StatusTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/StatusTest.scala
@@ -5,13 +5,13 @@ import com.twitter.util.{Await, Return}
 import org.scalacheck.Gen
 import org.scalatest.FunSuite
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
-import org.scalatest.junit.AssertionsForJUnit
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.junit.AssertionsForJUnit
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 class StatusTest
     extends FunSuite
     with AssertionsForJUnit
-    with GeneratorDrivenPropertyChecks
+    with ScalaCheckDrivenPropertyChecks
     with Eventually
     with IntegrationPatience {
 

--- a/finagle-core/src/test/scala/com/twitter/finagle/builder/ClientBuilderTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/builder/ClientBuilderTest.scala
@@ -21,7 +21,7 @@ import org.mockito.Matchers._
 import org.mockito.Mockito.when
 import org.scalatest.FunSuite
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class ClientBuilderTest
     extends FunSuite

--- a/finagle-core/src/test/scala/com/twitter/finagle/builder/EndToEndTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/builder/EndToEndTest.scala
@@ -21,7 +21,7 @@ class EndToEndTest extends FunSuite {
     Time.withCurrentTimeFrozen { tc =>
       val svc = new Service[String, String] {
         def apply(request: String) = {
-          reqMade.setValue()
+          reqMade.setValue(())
           Future.never
         }
       }

--- a/finagle-core/src/test/scala/com/twitter/finagle/builder/ServerBuilderTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/builder/ServerBuilderTest.scala
@@ -16,7 +16,7 @@ import java.net.{InetAddress, InetSocketAddress}
 import javax.net.ssl.SSLSession
 import org.scalatest.FunSuite
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class ServerBuilderTest
     extends FunSuite

--- a/finagle-core/src/test/scala/com/twitter/finagle/builder/SourceTrackingMonitorTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/builder/SourceTrackingMonitorTest.scala
@@ -6,7 +6,7 @@ import java.util.logging.{Level, Logger}
 import org.mockito.Matchers.{any, eq => mockitoEq}
 import org.mockito.Mockito.{never, verify}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class SourceTrackingMonitorTest extends FunSuite with MockitoSugar {
   test("handles unrolling properly") {

--- a/finagle-core/src/test/scala/com/twitter/finagle/client/AddrMetadataExtractionTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/client/AddrMetadataExtractionTest.scala
@@ -6,8 +6,8 @@ import com.twitter.finagle.naming.BindingFactory
 import com.twitter.finagle.loadbalancer.LoadBalancerFactory
 import com.twitter.finagle.stack.nilStack
 import com.twitter.util.{Await, Future, Var}
-import org.scalatestplus.junit.AssertionsForJUnit
 import org.scalatest.FunSuite
+import org.scalatestplus.junit.AssertionsForJUnit
 
 class AddrMetadataExtractionTest extends FunSuite with AssertionsForJUnit {
   class Ctx {

--- a/finagle-core/src/test/scala/com/twitter/finagle/client/AddrMetadataExtractionTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/client/AddrMetadataExtractionTest.scala
@@ -6,7 +6,7 @@ import com.twitter.finagle.naming.BindingFactory
 import com.twitter.finagle.loadbalancer.LoadBalancerFactory
 import com.twitter.finagle.stack.nilStack
 import com.twitter.util.{Await, Future, Var}
-import org.scalatest.junit.AssertionsForJUnit
+import org.scalatestplus.junit.AssertionsForJUnit
 import org.scalatest.FunSuite
 
 class AddrMetadataExtractionTest extends FunSuite with AssertionsForJUnit {

--- a/finagle-core/src/test/scala/com/twitter/finagle/client/BackupRequestFilterTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/client/BackupRequestFilterTest.scala
@@ -12,7 +12,7 @@ import org.mockito.Matchers.any
 import org.mockito.Mockito._
 import org.scalatest.{FunSuite, Matchers, OneInstancePerTest}
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import scala.util.Random
 
 class BackupRequestFilterTest

--- a/finagle-core/src/test/scala/com/twitter/finagle/client/ClientRegistryTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/client/ClientRegistryTest.scala
@@ -10,7 +10,7 @@ import org.mockito.Matchers.anyObject
 import org.mockito.Mockito.when
 import org.scalatest.{BeforeAndAfter, FunSuite}
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 object crtnamer {
   @volatile var observationsOpened = 0

--- a/finagle-core/src/test/scala/com/twitter/finagle/client/ExceptionRemoteInfoFactoryTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/client/ExceptionRemoteInfoFactoryTest.scala
@@ -8,7 +8,7 @@ import com.twitter.finagle.tracing.Trace
 import com.twitter.util.{Await, Future, Time}
 import java.net.InetSocketAddress
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class ExceptionRemoteInfoFactoryTest extends FunSuite with MockitoSugar {
   test(

--- a/finagle-core/src/test/scala/com/twitter/finagle/client/LatencyCompensationTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/client/LatencyCompensationTest.scala
@@ -10,7 +10,7 @@ import com.twitter.finagle.server.utils.StringServer
 import com.twitter.util._
 import java.net.InetSocketAddress
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
-import org.scalatest.junit.AssertionsForJUnit
+import org.scalatestplus.junit.AssertionsForJUnit
 import org.scalatest.{BeforeAndAfterEach, FunSuite}
 
 /**

--- a/finagle-core/src/test/scala/com/twitter/finagle/client/MethodBuilderTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/client/MethodBuilderTest.scala
@@ -12,7 +12,7 @@ import com.twitter.util.tunable.Tunable
 import java.util.concurrent.atomic.AtomicInteger
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.{FunSuite, Matchers}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 private object MethodBuilderTest {
   private val neverSvc: Service[Int, Int] =

--- a/finagle-core/src/test/scala/com/twitter/finagle/client/StatsScopingTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/client/StatsScopingTest.scala
@@ -6,8 +6,8 @@ import com.twitter.finagle.param.Stats
 import com.twitter.finagle.stack.nilStack
 import com.twitter.finagle.stats.{InMemoryStatsReceiver, StatsReceiver}
 import com.twitter.util.{Await, Future}
-import org.scalatestplus.junit.AssertionsForJUnit
 import org.scalatest.FunSuite
+import org.scalatestplus.junit.AssertionsForJUnit
 
 class StatsScopingTest extends FunSuite with AssertionsForJUnit {
   class Ctx {

--- a/finagle-core/src/test/scala/com/twitter/finagle/client/StatsScopingTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/client/StatsScopingTest.scala
@@ -6,7 +6,7 @@ import com.twitter.finagle.param.Stats
 import com.twitter.finagle.stack.nilStack
 import com.twitter.finagle.stats.{InMemoryStatsReceiver, StatsReceiver}
 import com.twitter.util.{Await, Future}
-import org.scalatest.junit.AssertionsForJUnit
+import org.scalatestplus.junit.AssertionsForJUnit
 import org.scalatest.FunSuite
 
 class StatsScopingTest extends FunSuite with AssertionsForJUnit {

--- a/finagle-core/src/test/scala/com/twitter/finagle/context/AbstractContextTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/context/AbstractContextTest.scala
@@ -3,7 +3,7 @@ package com.twitter.finagle.context
 import com.twitter.conversions.DurationOps._
 import com.twitter.util.{Await, Future, Promise, Return}
 import org.scalatest.FunSuite
-import org.scalatest.junit.AssertionsForJUnit
+import org.scalatestplus.junit.AssertionsForJUnit
 
 abstract class AbstractContextTest extends FunSuite with AssertionsForJUnit {
   val ctx: Context

--- a/finagle-core/src/test/scala/com/twitter/finagle/context/DeadlineTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/context/DeadlineTest.scala
@@ -3,10 +3,10 @@ package com.twitter.finagle.context
 import com.twitter.util.{Time, Duration, Return}
 import org.scalacheck.Gen
 import org.scalatest.FunSuite
-import org.scalatest.junit.AssertionsForJUnit
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.junit.AssertionsForJUnit
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class DeadlineTest extends FunSuite with AssertionsForJUnit with GeneratorDrivenPropertyChecks {
+class DeadlineTest extends FunSuite with AssertionsForJUnit with ScalaCheckDrivenPropertyChecks {
 
   val time = for (t <- Gen.choose(0L, Long.MaxValue)) yield Time.fromNanoseconds(t)
   val dur = for (d <- Gen.choose(0L, Long.MaxValue)) yield Duration.fromNanoseconds(d)

--- a/finagle-core/src/test/scala/com/twitter/finagle/decoder/LengthFieldFramerTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/decoder/LengthFieldFramerTest.scala
@@ -2,10 +2,10 @@ package com.twitter.finagle.decoder
 
 import com.twitter.io.Buf
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scala.util.Random
 
-class LengthFieldFramerTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class LengthFieldFramerTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
 
   val MaxTestFrameSize = 32
   val MaxTestFrames = 30

--- a/finagle-core/src/test/scala/com/twitter/finagle/dispatch/PipeliningDispatcherTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/dispatch/PipeliningDispatcherTest.scala
@@ -10,7 +10,7 @@ import org.mockito.Mockito
 import org.mockito.Mockito.{never, verify, times}
 import org.mockito.stubbing.OngoingStubbing
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import scala.language.reflectiveCalls
 
 class PipeliningDispatcherTest extends FunSuite with MockitoSugar {

--- a/finagle-core/src/test/scala/com/twitter/finagle/dispatch/ServerDispatcherTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/dispatch/ServerDispatcherTest.scala
@@ -81,7 +81,7 @@ class SerialServerDispatcherTest extends FunSuite with MockitoSugar {
 
   test("Inject the transport remote address")(new Ctx {
     val mockAddr = mock[SocketAddress]
-    when(trans.remoteAddress).thenReturn(mockAddr)
+    when(trans.context.remoteAddress).thenReturn(mockAddr)
     val service = new Service[String, String] {
       override def apply(request: String): Future[String] = Future.value {
         if (Contexts.local.get(RemoteInfo.Upstream.AddressCtx) == Some(mockAddr)) "ok" else "not ok"

--- a/finagle-core/src/test/scala/com/twitter/finagle/dispatch/ServerDispatcherTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/dispatch/ServerDispatcherTest.scala
@@ -13,7 +13,7 @@ import org.mockito.Mockito
 import org.mockito.Mockito.{atLeastOnce, never, times, verify}
 import org.mockito.stubbing.OngoingStubbing
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import scala.language.reflectiveCalls
 
 class SerialServerDispatcherTest extends FunSuite with MockitoSugar {

--- a/finagle-core/src/test/scala/com/twitter/finagle/factory/ServiceFactoryCacheTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/factory/ServiceFactoryCacheTest.scala
@@ -4,7 +4,7 @@ import com.twitter.conversions.DurationOps._
 import com.twitter.finagle._
 import com.twitter.util.{Future, MockTimer, Time, Timer, Await}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class ServiceFactoryCacheTest extends FunSuite with MockitoSugar {
   trait Ctx {

--- a/finagle-core/src/test/scala/com/twitter/finagle/factory/StatsFactoryWrapperTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/factory/StatsFactoryWrapperTest.scala
@@ -6,7 +6,7 @@ import com.twitter.util.{Await, Future}
 import org.mockito.Matchers.any
 import org.mockito.Mockito.{verify, when}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class StatsFactoryWrapperTest extends FunSuite with MockitoSugar {
   val underlying = mock[ServiceFactory[Int, Int]]

--- a/finagle-core/src/test/scala/com/twitter/finagle/factory/TimeoutFactoryTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/factory/TimeoutFactoryTest.scala
@@ -6,7 +6,7 @@ import com.twitter.util.{Await, Future, Promise, MockTimer, Return, Time}
 import org.mockito.Matchers.any
 import org.mockito.Mockito.{verify, when}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import scala.language.reflectiveCalls
 
 class TimeoutFactoryTest extends FunSuite with MockitoSugar {

--- a/finagle-core/src/test/scala/com/twitter/finagle/filter/ClearContextValueFilterTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/filter/ClearContextValueFilterTest.scala
@@ -63,7 +63,7 @@ class ClearContextValueFilterTest extends FunSuite {
         .make(Stack.Params.empty)
 
       val svc: Service[Unit, Unit] = Await.result(factory(), 1.second)
-      Await.result(svc(), 1.second)
+      Await.result(svc(()), 1.second)
       assert(setContextFilterCalled.isDefined)
       assert(verifyContextClearedFilterCalled.isDefined)
     }
@@ -78,7 +78,7 @@ class ClearContextValueFilterTest extends FunSuite {
         .make(Stack.Params.empty)
 
       val svc: Service[Unit, Unit] = Await.result(factory(), 1.second)
-      Await.result(svc(), 1.second)
+      Await.result(svc(()), 1.second)
       assert(verifyContextClearedFilterCalled.isDefined)
     }
   }

--- a/finagle-core/src/test/scala/com/twitter/finagle/filter/DtabStatsFilterTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/filter/DtabStatsFilterTest.scala
@@ -1,7 +1,7 @@
 package com.twitter.finagle.filter
 
 import org.scalatest.FunSuite
-import org.scalatest.junit.AssertionsForJUnit
+import org.scalatestplus.junit.AssertionsForJUnit
 import com.twitter.finagle.stats.InMemoryStatsReceiver
 import com.twitter.finagle.{Dtab, Service}
 import com.twitter.util.{Await, Future}

--- a/finagle-core/src/test/scala/com/twitter/finagle/filter/ExceptionSourceFilterTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/filter/ExceptionSourceFilterTest.scala
@@ -7,7 +7,7 @@ import com.twitter.util.{Await, Future}
 import org.mockito.Matchers.anyInt
 import org.mockito.Mockito.when
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class ExceptionSourceFilterTest extends FunSuite with MockitoSugar {
   test("ExceptionSourceFilter should add a name to sourced exceptions") {

--- a/finagle-core/src/test/scala/com/twitter/finagle/filter/MaskCancelFilterTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/filter/MaskCancelFilterTest.scala
@@ -5,7 +5,7 @@ import com.twitter.util.{Future, Promise, Return}
 import org.mockito.Matchers.anyObject
 import org.mockito.Mockito.{when, verify}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import scala.language.reflectiveCalls
 
 class MaskCancelFilterTest extends FunSuite with MockitoSugar {

--- a/finagle-core/src/test/scala/com/twitter/finagle/filter/MkJvmFilterTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/filter/MkJvmFilterTest.scala
@@ -8,7 +8,7 @@ import com.twitter.util.{TimeControl, Promise, Time, Duration}
 import org.mockito.Matchers._
 import org.mockito.Mockito.{verify, when}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class MkJvmFilterTest extends FunSuite with MockitoSugar {
   private class JvmHelper {

--- a/finagle-core/src/test/scala/com/twitter/finagle/filter/MonitorFilterTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/filter/MonitorFilterTest.scala
@@ -12,7 +12,7 @@ import org.mockito.Matchers._
 import org.mockito.Mockito.{times, verify, when}
 import org.mockito.{Matchers, Mockito}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class MonitorFilterTest extends FunSuite with MockitoSugar {
 

--- a/finagle-core/src/test/scala/com/twitter/finagle/filter/OffloadFilterTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/filter/OffloadFilterTest.scala
@@ -17,7 +17,7 @@ class OffloadFilterTest extends FunSuite {
       val s = new OffloadFilter.Client[Unit, Unit](FuturePool(executor)).andThen(next)
       val caller = Thread.currentThread()
 
-      assert(Await.result(s().map(_ => Thread.currentThread()), 5.seconds) != caller)
+      assert(Await.result(s(()).map(_ => Thread.currentThread()), 5.seconds) != caller)
     } finally {
       executor.shutdownNow()
     }
@@ -31,7 +31,7 @@ class OffloadFilterTest extends FunSuite {
       }
       val s = new OffloadFilter.Server[Unit, Thread](FuturePool(executor)).andThen(next)
       val caller = Thread.currentThread()
-      assert(Await.result(s(), 5.seconds) != caller)
+      assert(Await.result(s(()), 5.seconds) != caller)
 
     } finally {
       executor.shutdownNow()

--- a/finagle-core/src/test/scala/com/twitter/finagle/filter/RequestMeterFilterTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/filter/RequestMeterFilterTest.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.RejectedExecutionException
 
 import org.mockito.Mockito.when
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class RequestMeterFilterTest extends FunSuite with MockitoSugar {
 

--- a/finagle-core/src/test/scala/com/twitter/finagle/filter/ServerAdmissionControlTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/filter/ServerAdmissionControlTest.scala
@@ -9,7 +9,7 @@ import com.twitter.finagle.stack.Endpoint
 import com.twitter.util.{Await, Future}
 import java.util.concurrent.atomic.AtomicInteger
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class ServerAdmissionControlTest extends FunSuite with MockitoSugar {
   class Ctx {

--- a/finagle-core/src/test/scala/com/twitter/finagle/liveness/FailureAccrualFactoryTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/liveness/FailureAccrualFactoryTest.scala
@@ -12,7 +12,7 @@ import org.mockito.stubbing.Answer
 import org.mockito.Matchers
 import org.mockito.Matchers._
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import scala.util.Random
 
 class FailureAccrualFactoryTest extends FunSuite with MockitoSugar {

--- a/finagle-core/src/test/scala/com/twitter/finagle/liveness/FailureAccrualPolicyTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/liveness/FailureAccrualPolicyTest.scala
@@ -4,7 +4,7 @@ import com.twitter.conversions.DurationOps._
 import com.twitter.util._
 import com.twitter.finagle.service._
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class FailureAccrualPolicyTest extends FunSuite with MockitoSugar {
 

--- a/finagle-core/src/test/scala/com/twitter/finagle/liveness/ThresholdFailureDetectorTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/liveness/ThresholdFailureDetectorTest.scala
@@ -33,10 +33,10 @@ class ThresholdFailureDetectorTest
 
     val timer = new MockTimer
     val d = new ThresholdFailureDetector(
-      ping,
+      ping _,
       minPeriod = 10.milliseconds,
       closeTimeout = closeTimeout,
-      nanoTime = nanoTime,
+      nanoTime = nanoTime _,
       statsReceiver = sr,
       timer = timer
     )
@@ -114,10 +114,10 @@ class ThresholdFailureDetectorTest
     }
 
     val d = new ThresholdFailureDetector(
-      ping,
+      ping _,
       minPeriod = 10.milliseconds,
       closeTimeout = Duration.Top,
-      nanoTime = nanoTime,
+      nanoTime = nanoTime _,
       timer = timer,
       statsReceiver = sr
     )

--- a/finagle-core/src/test/scala/com/twitter/finagle/liveness/ThresholdFailureDetectorTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/liveness/ThresholdFailureDetectorTest.scala
@@ -7,7 +7,7 @@ import com.twitter.util._
 import java.util.concurrent.atomic.AtomicInteger
 import org.scalatest.FunSuite
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
-import org.scalatest.junit.AssertionsForJUnit
+import org.scalatestplus.junit.AssertionsForJUnit
 
 class ThresholdFailureDetectorTest
     extends FunSuite

--- a/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/BalancerRegistryTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/BalancerRegistryTest.scala
@@ -1,7 +1,7 @@
 package com.twitter.finagle.loadbalancer
 
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class BalancerRegistryTest extends FunSuite with MockitoSugar {
 

--- a/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/BalancerTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/BalancerTest.scala
@@ -7,10 +7,10 @@ import com.twitter.util.{Await, Future, Time}
 import org.scalacheck.Gen
 import org.scalatest.FunSuite
 import org.scalatest.concurrent.Conductors
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scala.language.reflectiveCalls
 
-class BalancerTest extends FunSuite with Conductors with GeneratorDrivenPropertyChecks {
+class BalancerTest extends FunSuite with Conductors with ScalaCheckDrivenPropertyChecks {
 
   private class TestBalancer(
     protected val statsReceiver: InMemoryStatsReceiver = new InMemoryStatsReceiver)

--- a/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/aperture/ProcessCoordinateTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/aperture/ProcessCoordinateTest.scala
@@ -3,9 +3,9 @@ package com.twitter.finagle.loadbalancer.aperture
 import com.twitter.util.Closable
 import org.scalacheck.Gen
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class ProcessCoordinateTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class ProcessCoordinateTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
   import ProcessCoordinate._
 
   test("update coordinate") {

--- a/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/heap/HeapLeastLoadedTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/heap/HeapLeastLoadedTest.scala
@@ -5,8 +5,8 @@ import com.twitter.finagle._
 import com.twitter.util.{Var, ReadWriteVar, Activity, Await, Future, Time}
 import java.util.concurrent.atomic.AtomicInteger
 import org.scalatest.FunSuite
-import org.scalatest.junit.AssertionsForJUnit
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.junit.AssertionsForJUnit
+import org.scalatestplus.mockito.MockitoSugar
 import scala.util.Random
 
 class HeapLeastLoadedTest extends FunSuite with MockitoSugar with AssertionsForJUnit {

--- a/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/p2c/P2CPeakEwmaTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/p2c/P2CPeakEwmaTest.scala
@@ -15,7 +15,7 @@ class P2CPeakEwmaTest extends FunSuite with P2CSuite {
   override def newBal(
     fs: Var[Vector[P2CServiceFactory]],
     sr: StatsReceiver = NullStatsReceiver,
-    clock: (() => Long) = System.nanoTime
+    clock: (() => Long) = System.nanoTime _
   ): ServiceFactory[Unit, Int] = new P2CPeakEwma(
     Activity(fs.map(Activity.Ok(_))),
     maxEffort = 5,

--- a/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/p2c/P2CSuite.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/p2c/P2CSuite.scala
@@ -31,7 +31,7 @@ trait P2CSuite {
   def newBal(
     fs: Var[Vector[P2CServiceFactory]],
     sr: StatsReceiver = NullStatsReceiver,
-    clock: (() => Long) = System.nanoTime
+    clock: (() => Long) = System.nanoTime _
   ): ServiceFactory[Unit, Int] = new P2CLeastLoaded(
     Activity(fs.map(Activity.Ok(_))),
     maxEffort = 5,

--- a/finagle-core/src/test/scala/com/twitter/finagle/naming/BindingFactoryTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/naming/BindingFactoryTest.scala
@@ -9,7 +9,7 @@ import com.twitter.util._
 import org.mockito.ArgumentCaptor
 import org.mockito.Matchers.any
 import org.mockito.Mockito.{atLeastOnce, spy, verify, when}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfter, FunSuite}
 import scala.collection.JavaConverters._
 

--- a/finagle-core/src/test/scala/com/twitter/finagle/naming/DynNameFactoryTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/naming/DynNameFactoryTest.scala
@@ -6,7 +6,7 @@ import com.twitter.util.{Await, Activity, Future, Return, Throw}
 import org.mockito.Matchers.any
 import org.mockito.Mockito.when
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class DynNameFactoryTest extends FunSuite with MockitoSugar {
   private trait Ctx {

--- a/finagle-core/src/test/scala/com/twitter/finagle/naming/LoadedNameInterpreterTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/naming/LoadedNameInterpreterTest.scala
@@ -38,7 +38,7 @@ class LoadedNameInterpreterTest extends FunSuite with BeforeAndAfter {
       }
       Seq(interpreter)
     }
-    val interpreter = new LoadedNameInterpreter(load)
+    val interpreter = new LoadedNameInterpreter(load _)
     assert(created)
     val act = interpreter.bind(Dtab.empty, Path.read("/a"))
     val NameTree.Leaf(name) = act.sample()

--- a/finagle-core/src/test/scala/com/twitter/finagle/param/ClientTransportParamsTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/param/ClientTransportParamsTest.scala
@@ -11,7 +11,7 @@ import com.twitter.finagle.ssl.client.{
 import com.twitter.finagle.transport.Transport
 import javax.net.ssl.SSLSession
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class ClientTransportParamsTest extends FunSuite with MockitoSugar {
 

--- a/finagle-core/src/test/scala/com/twitter/finagle/param/ServerTransportParamsTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/param/ServerTransportParamsTest.scala
@@ -11,7 +11,7 @@ import com.twitter.finagle.ssl.server.{
 import com.twitter.finagle.transport.Transport
 import javax.net.ssl.SSLSession
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class ServerTransportParamsTest extends FunSuite with MockitoSugar {
 

--- a/finagle-core/src/test/scala/com/twitter/finagle/pool/BufferingPoolTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/pool/BufferingPoolTest.scala
@@ -1,7 +1,7 @@
 package com.twitter.finagle.pool
 
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.mockito.Mockito.{times, verify, when}
 import org.mockito.Matchers._
 import com.twitter.finagle.{ClientConnection, Service, ServiceFactory, Status}

--- a/finagle-core/src/test/scala/com/twitter/finagle/pool/CachingPoolTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/pool/CachingPoolTest.scala
@@ -6,7 +6,7 @@ import com.twitter.finagle.{Service, ServiceFactory, Status}
 import com.twitter.util.{Await, Duration, Future, MockTimer, Time}
 import org.mockito.Matchers.any
 import org.mockito.Mockito.{never, times, verify, when}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{FunSuite, OneInstancePerTest}
 
 class CachingPoolTest extends FunSuite with MockitoSugar with OneInstancePerTest {

--- a/finagle-core/src/test/scala/com/twitter/finagle/pool/SingletonPoolTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/pool/SingletonPoolTest.scala
@@ -7,7 +7,7 @@ import com.twitter.util.{Await, Awaitable, Future, Promise, Return, Throw, Time}
 import org.mockito.Matchers.any
 import org.mockito.Mockito.{never, times, verify, when}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 object SingletonPoolTest {
   private def await[T](t: Awaitable[T]): T = Await.result(t, 1.second)

--- a/finagle-core/src/test/scala/com/twitter/finagle/pool/WatermarkPoolTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/pool/WatermarkPoolTest.scala
@@ -7,7 +7,7 @@ import com.twitter.util.{Await, Future, Promise, Return, Throw, Time}
 import org.mockito.Matchers.any
 import org.mockito.Mockito.{never, times, verify, when}
 import org.scalatest.FunSpec
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import scala.language.reflectiveCalls
 
 class WatermarkPoolTest extends FunSpec with MockitoSugar {

--- a/finagle-core/src/test/scala/com/twitter/finagle/pushsession/PipeliningClientPushSessionTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/pushsession/PipeliningClientPushSessionTest.scala
@@ -8,7 +8,7 @@ import com.twitter.util.{Await, MockTimer, Promise, Time, TimeoutException => Ut
 import java.net.{InetSocketAddress, SocketAddress}
 import org.mockito.Mockito.never
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class PipeliningMockChannelHandle[In, Out] extends MockChannelHandle[In, Out] {
 

--- a/finagle-core/src/test/scala/com/twitter/finagle/pushsession/PipeliningClientPushSessionTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/pushsession/PipeliningClientPushSessionTest.scala
@@ -36,7 +36,7 @@ class PipeliningClientPushSessionTest extends FunSuite with MockitoSugar {
               10.seconds,
               timer
             ).toService
-          val f = session()
+          val f = session(())
           f.raise(exc)
           assert(!handle.closedCalled)
         }

--- a/finagle-core/src/test/scala/com/twitter/finagle/pushsession/PushStackServerTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/pushsession/PushStackServerTest.scala
@@ -19,7 +19,7 @@ import java.net.{InetSocketAddress, SocketAddress}
 import java.security.cert.{Certificate, X509Certificate}
 import org.mockito.Mockito.when
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class PushStackServerTest extends FunSuite with MockitoSugar {
 

--- a/finagle-core/src/test/scala/com/twitter/finagle/server/StdStackServerTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/server/StdStackServerTest.scala
@@ -10,7 +10,7 @@ import java.security.cert.{Certificate, X509Certificate}
 import org.mockito.Mockito
 import org.mockito.stubbing.OngoingStubbing
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import scala.language.reflectiveCalls
 
 class StdStackServerTest extends FunSuite with MockitoSugar {

--- a/finagle-core/src/test/scala/com/twitter/finagle/server/StdStackServerTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/server/StdStackServerTest.scala
@@ -42,7 +42,7 @@ class StdStackServerTest extends FunSuite with MockitoSugar {
           when(sslSessionInfo.peerCertificates).thenReturn(Seq(mockCert))
           when(context.sslSessionInfo).thenReturn(sslSessionInfo)
           when(trans.context).thenReturn(context)
-          when(trans.remoteAddress).thenReturn(mock[SocketAddress])
+          when(trans.context.remoteAddress).thenReturn(mock[SocketAddress])
           when(trans.onClose).thenReturn(Future.never)
           serveTransport(trans)
           NullServer

--- a/finagle-core/src/test/scala/com/twitter/finagle/server/TransportClientConnectionTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/server/TransportClientConnectionTest.scala
@@ -9,7 +9,7 @@ import org.mockito.Mockito
 import org.mockito.Mockito.{times, verify}
 import org.mockito.stubbing.OngoingStubbing
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import scala.language.reflectiveCalls
 
 class TransportClientConnectionTest extends FunSuite with MockitoSugar {

--- a/finagle-core/src/test/scala/com/twitter/finagle/service/BackoffTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/service/BackoffTest.scala
@@ -5,9 +5,9 @@ import com.twitter.finagle.util.Rng
 import com.twitter.util.Duration
 import org.scalacheck.Gen
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class BackoffTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class BackoffTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
   test("exponential") {
     val backoffs = Backoff.exponential(1.seconds, 2) take 10
     assert(backoffs.force.toSeq == (0 until 10 map { i =>

--- a/finagle-core/src/test/scala/com/twitter/finagle/service/CloseOnReleaseServiceTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/service/CloseOnReleaseServiceTest.scala
@@ -3,7 +3,7 @@ package com.twitter.finagle.service
 import org.mockito.Mockito.{verify, when, times}
 import org.mockito.Matchers._
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import com.twitter.finagle.{WriteException, Service, Status}
 import com.twitter.util.{Await, Promise, Future}
 

--- a/finagle-core/src/test/scala/com/twitter/finagle/service/DeadlineFilterTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/service/DeadlineFilterTest.scala
@@ -6,7 +6,7 @@ import com.twitter.finagle.stats.InMemoryStatsReceiver
 import com.twitter.util._
 import com.twitter.conversions.DurationOps._
 import org.scalatest.{OneInstancePerTest, FunSuite}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class DeadlineFilterTest extends FunSuite with MockitoSugar with OneInstancePerTest {
   import DeadlineFilter.DeadlineExceededException

--- a/finagle-core/src/test/scala/com/twitter/finagle/service/ExpiringServiceTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/service/ExpiringServiceTest.scala
@@ -7,7 +7,7 @@ import com.twitter.util.{Future, Time, MockTimer, Promise, Return, Duration, Tim
 import org.mockito.Matchers.any
 import org.mockito.Mockito.{never, verify, when}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class ExpiringServiceTest extends FunSuite with MockitoSugar {
 

--- a/finagle-core/src/test/scala/com/twitter/finagle/service/FailFastFactoryTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/service/FailFastFactoryTest.scala
@@ -9,7 +9,7 @@ import org.mockito.Matchers.any
 import org.mockito.Mockito.{never, times, verify, when}
 import org.scalatest.FunSuite
 import org.scalatest.concurrent.{Conductors, IntegrationPatience}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import scala.language.reflectiveCalls
 
 class FailFastFactoryTest

--- a/finagle-core/src/test/scala/com/twitter/finagle/service/OptionallyServableFilterTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/service/OptionallyServableFilterTest.scala
@@ -1,7 +1,7 @@
 package com.twitter.finagle.service
 
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import com.twitter.finagle.{NotServableException, Service}
 import org.mockito.Mockito.{times, verify, when}
 import org.mockito.Matchers._

--- a/finagle-core/src/test/scala/com/twitter/finagle/service/RateLimitingFilterTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/service/RateLimitingFilterTest.scala
@@ -1,7 +1,7 @@
 package com.twitter.finagle.service
 
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.mockito.Mockito.when
 import org.mockito.Matchers
 import org.mockito.Matchers._

--- a/finagle-core/src/test/scala/com/twitter/finagle/service/RefcountedServiceTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/service/RefcountedServiceTest.scala
@@ -2,7 +2,7 @@ package com.twitter.finagle.service
 
 import com.twitter.util._
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.mockito.Mockito.{times, verify, when}
 import org.mockito.{Matchers, Mockito}
 import org.mockito.Matchers._

--- a/finagle-core/src/test/scala/com/twitter/finagle/service/RetriesTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/service/RetriesTest.scala
@@ -307,7 +307,7 @@ class RetriesTest extends FunSuite {
         Stopwatch.timeMillis
       )
 
-    val svc = endToEndToEndSvc(stats, backReqs, mkBudget)
+    val svc = endToEndToEndSvc(stats, backReqs, mkBudget _)
 
     val numReqs = 100
     Time.withCurrentTimeFrozen { _ =>
@@ -330,7 +330,7 @@ class RetriesTest extends FunSuite {
     val backReqs = new AtomicInteger()
     def mkBudget() = RetryBudget.Infinite
 
-    val svc = endToEndToEndSvc(stats, backReqs, mkBudget)
+    val svc = endToEndToEndSvc(stats, backReqs, mkBudget _)
 
     val retries = 4
     val numReqs = 100

--- a/finagle-core/src/test/scala/com/twitter/finagle/service/RetryFilterTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/service/RetryFilterTest.scala
@@ -6,7 +6,7 @@ import com.twitter.finagle.{FailedFastException, Failure, FailureFlags, Service,
 import com.twitter.util._
 import org.mockito.Matchers.anyObject
 import org.mockito.Mockito.{times, verify, when}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfter, FunSpec}
 import scala.language.reflectiveCalls
 

--- a/finagle-core/src/test/scala/com/twitter/finagle/service/ShardingServiceTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/service/ShardingServiceTest.scala
@@ -7,7 +7,7 @@ import com.twitter.util.{Await, Future}
 import org.mockito.Matchers._
 import org.mockito.Mockito.{times, verify, when}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class ShardingServiceTest extends FunSuite with MockitoSugar {
 

--- a/finagle-core/src/test/scala/com/twitter/finagle/service/TimeoutFilterTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/service/TimeoutFilterTest.scala
@@ -9,7 +9,7 @@ import com.twitter.util._
 import com.twitter.util.tunable.Tunable
 import java.util.concurrent.atomic.AtomicReference
 import org.scalatest.{FunSuite, Matchers}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import scala.language.reflectiveCalls
 
 private object TimeoutFilterTest {

--- a/finagle-core/src/test/scala/com/twitter/finagle/ssl/IgnorantTrustManagerTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/ssl/IgnorantTrustManagerTest.scala
@@ -4,7 +4,7 @@ import java.net.Socket
 import java.security.cert.X509Certificate
 import javax.net.ssl.SSLEngine
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class IgnorantTrustManagerTest extends FunSuite with MockitoSugar {
 

--- a/finagle-core/src/test/scala/com/twitter/finagle/ssl/session/UsingSslSessionInfoTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/ssl/session/UsingSslSessionInfoTest.scala
@@ -6,7 +6,7 @@ import java.security.cert.{Certificate, X509Certificate}
 import javax.net.ssl.SSLSession
 import org.mockito.Mockito.when
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class UsingSslSessionInfoTest extends FunSuite with MockitoSugar {
 

--- a/finagle-core/src/test/scala/com/twitter/finagle/tracing/TraceTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/tracing/TraceTest.scala
@@ -6,7 +6,7 @@ import com.twitter.util.Time
 import com.twitter.util.{Return, Throw}
 import org.mockito.Matchers.any
 import org.mockito.Mockito.{never, times, verify, when, atLeast}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{OneInstancePerTest, BeforeAndAfter, FunSuite}
 import scala.util.Random
 

--- a/finagle-core/src/test/scala/com/twitter/finagle/tracing/TracerTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/tracing/TracerTest.scala
@@ -2,9 +2,9 @@ package com.twitter.finagle.tracing
 
 import org.scalacheck.Gen
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class TracerTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class TracerTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
 
   case class TestTracer(res: Option[Boolean]) extends Tracer {
     def record(record: Record): Unit = ()

--- a/finagle-core/src/test/scala/com/twitter/finagle/tracing/TracingFilterTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/tracing/TracingFilterTest.scala
@@ -6,8 +6,8 @@ import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.{spy, verify, when, atLeastOnce}
 import org.mockito.Matchers.any
 import org.scalactic.source.Position
-import org.scalatest.junit.AssertionsForJUnit
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.junit.AssertionsForJUnit
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfter, FunSuite, Tag}
 import scala.collection.JavaConverters._
 

--- a/finagle-core/src/test/scala/com/twitter/finagle/transport/TransportTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/transport/TransportTest.scala
@@ -6,10 +6,10 @@ import com.twitter.finagle.Status
 import com.twitter.io.{Buf, Pipe, Reader, ReaderDiscardedException}
 import com.twitter.util.{Await, Future, Promise, Return, Throw, Time}
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scala.language.reflectiveCalls
 
-class TransportTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class TransportTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
 
   private def awaitResult[T](f: Future[T]): T = {
     Await.result(f, 5.seconds)

--- a/finagle-core/src/test/scala/com/twitter/finagle/util/BlockingTimeTrackingThreadFactoryTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/util/BlockingTimeTrackingThreadFactoryTest.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.ThreadFactory
 import org.mockito.Matchers.any
 import org.mockito.Mockito.verify
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class BlockingTimeTrackingThreadFactoryTest extends FunSuite with MockitoSugar {
 

--- a/finagle-core/src/test/scala/com/twitter/finagle/util/DefaultMonitorTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/util/DefaultMonitorTest.scala
@@ -9,7 +9,7 @@ import com.twitter.util.{Duration, TimeoutException => UtilTimeoutException}
 import java.util.logging.Handler
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.verify
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FunSuite, Matchers}
 
 class DefaultMonitorTest extends FunSuite with Matchers with MockitoSugar with BeforeAndAfterEach {

--- a/finagle-core/src/test/scala/com/twitter/finagle/util/ExitGuardTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/util/ExitGuardTest.scala
@@ -2,8 +2,8 @@ package com.twitter.finagle.util
 
 import org.scalatest.FunSuite
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
-import org.scalatest.junit.AssertionsForJUnit
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.junit.AssertionsForJUnit
+import org.scalatestplus.mockito.MockitoSugar
 
 class ExitGuardTest
     extends FunSuite

--- a/finagle-core/src/test/scala/com/twitter/finagle/util/WindowedPercentileHistogramTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/util/WindowedPercentileHistogramTest.scala
@@ -7,14 +7,14 @@ import com.twitter.util.{MockTimer, Time}
 import org.scalacheck.Gen
 import org.scalatest.FunSuite
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scala.collection.mutable
 
 class WindowedPercentileHistogramTest
     extends FunSuite
     with Eventually
     with IntegrationPatience
-    with GeneratorDrivenPropertyChecks {
+    with ScalaCheckDrivenPropertyChecks {
 
   test("Throws IllegalArgumentException when retrieving a percentile < 0") {
     val wp = new WindowedPercentileHistogram(10, 10.seconds, new MockTimer)

--- a/finagle-exception/src/test/scala/com/twitter/finagle/exception/ReporterSpec.scala
+++ b/finagle-exception/src/test/scala/com/twitter/finagle/exception/ReporterSpec.scala
@@ -7,7 +7,7 @@ import org.mockito.ArgumentCaptor
 import org.mockito.Matchers.anyObject
 import org.mockito.Mockito._
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class DefaultReporterTest extends FunSuite with MockitoSugar {
   val logger = mock[Scribe.FutureIface]

--- a/finagle-exp/src/test/scala/com/twitter/finagle/exp/DarkTrafficFilterTest.scala
+++ b/finagle-exp/src/test/scala/com/twitter/finagle/exp/DarkTrafficFilterTest.scala
@@ -8,7 +8,7 @@ import com.twitter.util.{Await, Future, FutureCancelledException, Promise}
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class DarkTrafficFilterTest extends FunSuite with MockitoSugar {
 

--- a/finagle-exp/src/test/scala/com/twitter/finagle/exp/ThriftForwardingWarmUpFilterTest.scala
+++ b/finagle-exp/src/test/scala/com/twitter/finagle/exp/ThriftForwardingWarmUpFilterTest.scala
@@ -7,7 +7,7 @@ import com.twitter.util.{Future, Time}
 import org.scalatest.FunSuite
 import org.mockito.Matchers._
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class ThriftForwardingWarmUpFilterTest extends FunSuite with MockitoSugar {
 

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/ServerSideDecodingTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/ServerSideDecodingTest.scala
@@ -11,7 +11,7 @@ import java.net.InetSocketAddress
 import java.util.zip.{DeflaterOutputStream, GZIPOutputStream}
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 /**
  * Provides tests for server side content decoding.
@@ -21,7 +21,7 @@ import org.scalatest.prop.GeneratorDrivenPropertyChecks
  * compression is currently made problematic by netty
  * (see https://github.com/netty/netty/issues/4970).
  */
-class ServerSideDecodingTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class ServerSideDecodingTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
   // Helper class - might be overkill to have a sum type for just one test, but
   // it makes it simple to provide an Arbitrary instance for encoders and to
   // make the actual test that much more readable.

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/SpnegoAuthenticatorTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/SpnegoAuthenticatorTest.scala
@@ -12,7 +12,7 @@ import org.ietf.jgss.GSSContext
 import org.mockito.Matchers.any
 import org.mockito.Mockito.{stub, verify}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class SpnegoAuthenticatorTest extends FunSuite with MockitoSugar {
   import SpnegoAuthenticator._

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/TracingTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/TracingTest.scala
@@ -6,9 +6,9 @@ import com.twitter.finagle.tracing.{Flags, SpanId, Trace, TraceId}
 import com.twitter.util.{Await, Future}
 import org.scalacheck.Gen
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class TracingTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class TracingTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
 
   import HttpTracing.{Header, stripParameters}
 

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/path/PathTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/path/PathTest.scala
@@ -2,11 +2,11 @@ package com.twitter.finagle.http.path
 
 import com.twitter.finagle.http.{Method, ParamMap}
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalacheck.Gen
 import scala.util.Random
 
-class PathTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class PathTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
 
   def alpha(min: Int, max: Int) =
     for {

--- a/finagle-http2/src/main/scala/com/twitter/finagle/http2/exp/transport/H2ClientFilter.scala
+++ b/finagle-http2/src/main/scala/com/twitter/finagle/http2/exp/transport/H2ClientFilter.scala
@@ -36,7 +36,7 @@ private[transport] final class H2ClientFilter(params: Stack.Params)
   private[this] val failureDetector: FailureDetector = {
     val statsReceiver = params[Stats].statsReceiver
     val detectorConfig = params[FailureDetector.Param].param
-    FailureDetector(detectorConfig, ping, statsReceiver.scope("failuredetector"))
+    FailureDetector(detectorConfig, ping _, statsReceiver.scope("failuredetector"))
   }
 
   // exposed for testing

--- a/finagle-http2/src/main/scala/com/twitter/finagle/http2/transport/AdapterProxyChannelHandler.scala
+++ b/finagle-http2/src/main/scala/com/twitter/finagle/http2/transport/AdapterProxyChannelHandler.scala
@@ -10,6 +10,8 @@ import io.netty.handler.codec.http.HttpClientUpgradeHandler.UpgradeEvent
 import io.netty.handler.codec.http.{HttpObject, LastHttpContent}
 import io.netty.util.ReferenceCountUtil
 import io.netty.util.concurrent.PromiseCombiner
+import io.netty.util.concurrent.ImmediateEventExecutor
+import io.netty.util.concurrent.{Future => NFuture}
 import scala.collection.mutable.HashMap
 
 /**
@@ -96,11 +98,11 @@ private[http2] final class AdapterProxyChannelHandler(
   }
 
   override def close(ctx: ChannelHandlerContext, promise: ChannelPromise): Unit = {
-    val combiner = new PromiseCombiner()
+    val combiner = new PromiseCombiner(ImmediateEventExecutor.INSTANCE)
     map.foreach {
       case (_, value) =>
         val p = value.embedded.newPromise()
-        combiner.add(p)
+        combiner.add(p: NFuture[_])
         value.embedded.close(p)
     }
     val streamsClosed = ctx.newPromise()

--- a/finagle-http2/src/main/scala/com/twitter/finagle/http2/transport/AdapterProxyChannelHandler.scala
+++ b/finagle-http2/src/main/scala/com/twitter/finagle/http2/transport/AdapterProxyChannelHandler.scala
@@ -11,7 +11,7 @@ import io.netty.handler.codec.http.{HttpObject, LastHttpContent}
 import io.netty.util.ReferenceCountUtil
 import io.netty.util.concurrent.PromiseCombiner
 import io.netty.util.concurrent.ImmediateEventExecutor
-import io.netty.util.concurrent.{Future => NFuture}
+import io.netty.util.concurrent.{Future => NettyFuture}
 import scala.collection.mutable.HashMap
 
 /**
@@ -102,7 +102,7 @@ private[http2] final class AdapterProxyChannelHandler(
     map.foreach {
       case (_, value) =>
         val p = value.embedded.newPromise()
-        combiner.add(p: NFuture[_])
+        combiner.add(p: NettyFuture[_])
         value.embedded.close(p)
     }
     val streamsClosed = ctx.newPromise()

--- a/finagle-http2/src/main/scala/com/twitter/finagle/http2/transport/PriorKnowledgeTransporter.scala
+++ b/finagle-http2/src/main/scala/com/twitter/finagle/http2/transport/PriorKnowledgeTransporter.scala
@@ -82,7 +82,7 @@ private[http2] final class PriorKnowledgeTransporter(
   def apply(): Future[Transport[Any, Any]] = {
     val result = getStreamTransportFactory()
 
-    result.x.flatMap { fac =>
+    result.get.flatMap { fac =>
       fac.newChildTransport().rescue {
         case exn: Throwable =>
           // We try to evict the current session concurrently. We recurse if some other thread raced

--- a/finagle-http2/src/main/scala/com/twitter/finagle/http2/transport/RichHttpToHttp2ConnectionHandler.scala
+++ b/finagle-http2/src/main/scala/com/twitter/finagle/http2/transport/RichHttpToHttp2ConnectionHandler.scala
@@ -8,7 +8,7 @@ import io.netty.handler.codec.http._
 import io.netty.handler.codec.http2.Http2Exception.HeaderListSizeException
 import io.netty.handler.codec.http2._
 import io.netty.util.ReferenceCountUtil
-import io.netty.util.concurrent.{Future => NFuture}
+import io.netty.util.concurrent.{Future => NettyFuture}
 import io.netty.util.concurrent.ImmediateEventExecutor
 import io.netty.util.concurrent.PromiseCombiner
 import scala.util.control.NonFatal
@@ -92,7 +92,7 @@ private[http2] class RichHttpToHttp2ConnectionHandler(
     // our very own Future.join.
     //
     val p = ctx.newPromise()
-    combiner.add(p.asInstanceOf[io.netty.util.concurrent.Future[_]])
+    combiner.add(p: NettyFuture[_])
     p
   }
 

--- a/finagle-http2/src/main/scala/com/twitter/finagle/http2/transport/RichHttpToHttp2ConnectionHandler.scala
+++ b/finagle-http2/src/main/scala/com/twitter/finagle/http2/transport/RichHttpToHttp2ConnectionHandler.scala
@@ -8,6 +8,8 @@ import io.netty.handler.codec.http._
 import io.netty.handler.codec.http2.Http2Exception.HeaderListSizeException
 import io.netty.handler.codec.http2._
 import io.netty.util.ReferenceCountUtil
+import io.netty.util.concurrent.{Future => NFuture}
+import io.netty.util.concurrent.ImmediateEventExecutor
 import io.netty.util.concurrent.PromiseCombiner
 import scala.util.control.NonFatal
 
@@ -101,7 +103,7 @@ private[http2] class RichHttpToHttp2ConnectionHandler(
     streamId: Int
   ): Unit = {
     try {
-      val combiner = new PromiseCombiner()
+      val combiner = new PromiseCombiner(ImmediateEventExecutor.INSTANCE)
       msg match {
         case full: FullHttpRequest =>
           // Full HTTP requests might have everything, headers, payload, and trailers. We write them

--- a/finagle-http2/src/main/scala/com/twitter/finagle/http2/transport/StreamTransportFactory.scala
+++ b/finagle-http2/src/main/scala/com/twitter/finagle/http2/transport/StreamTransportFactory.scala
@@ -103,7 +103,7 @@ final private[http2] class StreamTransportFactory(
   }
 
   private[this] val detector =
-    FailureDetector(detectorConfig, ping, statsReceiver.scope("failuredetector"))
+    FailureDetector(detectorConfig, ping _, statsReceiver.scope("failuredetector"))
 
   // H2 uses the default WatermarkPool, which believes each StreamTransport
   // represents a connection. When the WatermarkPool sees a peer marked "Closed",

--- a/finagle-http2/src/test/scala/com/twitter/finagle/http2/Http2TransportTest.scala
+++ b/finagle-http2/src/test/scala/com/twitter/finagle/http2/Http2TransportTest.scala
@@ -8,7 +8,7 @@ import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finagle.http.exp.{Multi, StreamTransport}
 import com.twitter.finagle.http2.exp.transport.Http2Transport
 import com.twitter.util.{Await, Awaitable, Duration, Future, Promise, Time}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{FunSuite, OneInstancePerTest}
 
 class Http2TransportTest extends FunSuite with OneInstancePerTest with MockitoSugar {

--- a/finagle-http2/src/test/scala/com/twitter/finagle/http2/Http2TransporterTest.scala
+++ b/finagle-http2/src/test/scala/com/twitter/finagle/http2/Http2TransporterTest.scala
@@ -11,7 +11,7 @@ import io.netty.handler.codec.http._
 import org.mockito.Mockito._
 import org.mockito.Matchers._
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class Http2TransporterTest extends FunSuite with MockitoSugar {
   def await[T](f: Future[T], wait: Duration = 1.second) =

--- a/finagle-http2/src/test/scala/com/twitter/finagle/http2/RefTransportTest.scala
+++ b/finagle-http2/src/test/scala/com/twitter/finagle/http2/RefTransportTest.scala
@@ -6,7 +6,7 @@ import com.twitter.util.{Await, Future, Time}
 import org.mockito.Matchers.{anyInt, any}
 import org.mockito.Mockito.{verify, when}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class RefTransportTest extends FunSuite with MockitoSugar {
 

--- a/finagle-http2/src/test/scala/com/twitter/finagle/http2/exp/transport/DeferredCloseSessionTest.scala
+++ b/finagle-http2/src/test/scala/com/twitter/finagle/http2/exp/transport/DeferredCloseSessionTest.scala
@@ -3,7 +3,7 @@ package com.twitter.finagle.http2.exp.transport
 import com.twitter.finagle.http2.transport.ClientSession
 import com.twitter.util.{Await, Awaitable, Duration, Future, Promise, Time}
 import org.scalatest.{FunSuite, OneInstancePerTest}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.mockito.Mockito._
 import org.mockito.Matchers._
 

--- a/finagle-http2/src/test/scala/com/twitter/finagle/http2/exp/transport/H2PoolTest.scala
+++ b/finagle-http2/src/test/scala/com/twitter/finagle/http2/exp/transport/H2PoolTest.scala
@@ -8,7 +8,7 @@ import com.twitter.finagle.http2.exp.transport.H2Pool.OnH2Session
 import com.twitter.util.{Await, Awaitable, Closable, Duration, Future, Time}
 import java.util.concurrent.atomic.AtomicInteger
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.mockito.Mockito._
 import org.mockito.Matchers._
 

--- a/finagle-http2/src/test/scala/com/twitter/finagle/http2/exp/transport/RefCountedFactoryTest.scala
+++ b/finagle-http2/src/test/scala/com/twitter/finagle/http2/exp/transport/RefCountedFactoryTest.scala
@@ -3,7 +3,7 @@ package com.twitter.finagle.http2.exp.transport
 import com.twitter.finagle.{FailureFlags, Service, Status}
 import com.twitter.util.{Await, Awaitable, Duration, Future}
 import org.scalatest.{FunSuite, OneInstancePerTest}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.mockito.Mockito._
 import org.mockito.Matchers._
 

--- a/finagle-http2/src/test/scala/com/twitter/finagle/http2/exp/transport/SingleDispatchTransportTest.scala
+++ b/finagle-http2/src/test/scala/com/twitter/finagle/http2/exp/transport/SingleDispatchTransportTest.scala
@@ -6,7 +6,7 @@ import com.twitter.util.{Await, Awaitable, Duration, Future}
 import io.netty.buffer.{ByteBufAllocator, EmptyByteBuf}
 import io.netty.handler.codec.http.{DefaultHttpContent, DefaultLastHttpContent, HttpContent}
 import org.scalatest.{FunSuite, OneInstancePerTest}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.mockito.Mockito._
 
 class SingleDispatchTransportTest extends FunSuite with MockitoSugar with OneInstancePerTest {

--- a/finagle-http2/src/test/scala/com/twitter/finagle/http2/transport/H2UriValidatorHandlerTest.scala
+++ b/finagle-http2/src/test/scala/com/twitter/finagle/http2/transport/H2UriValidatorHandlerTest.scala
@@ -4,7 +4,7 @@ import io.netty.channel.embedded.EmbeddedChannel
 import io.netty.handler.codec.http2.{Http2Headers, Http2HeadersFrame}
 import org.mockito.Mockito._
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class H2UriValidatorHandlerTest extends FunSuite with MockitoSugar {
 

--- a/finagle-http2/src/test/scala/com/twitter/finagle/http2/transport/Http2NegotiatingTransporterTest.scala
+++ b/finagle-http2/src/test/scala/com/twitter/finagle/http2/transport/Http2NegotiatingTransporterTest.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import org.mockito.Mockito._
 import org.scalatest.FunSuite
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class Http2NegotiatingTransporterTest
     extends FunSuite

--- a/finagle-http2/src/test/scala/com/twitter/finagle/http2/transport/Http2StreamMessageHandlerTest.scala
+++ b/finagle-http2/src/test/scala/com/twitter/finagle/http2/transport/Http2StreamMessageHandlerTest.scala
@@ -8,13 +8,13 @@ import io.netty.util.ReferenceCounted
 import org.scalatest.FunSuite
 import org.mockito.Mockito.when
 import org.scalacheck.Gen
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 class Http2StreamMessageHandlerTest
     extends FunSuite
     with MockitoSugar
-    with GeneratorDrivenPropertyChecks {
+    with ScalaCheckDrivenPropertyChecks {
   test("doesn't leak message written post-RST") {
     forAll { isServer: Boolean =>
       val em = new EmbeddedChannel(Http2StreamMessageHandler(isServer))

--- a/finagle-http2/src/test/scala/com/twitter/finagle/http2/transport/Http2UpgradingTransportTest.scala
+++ b/finagle-http2/src/test/scala/com/twitter/finagle/http2/transport/Http2UpgradingTransportTest.scala
@@ -12,7 +12,7 @@ import com.twitter.util.{Await, Future, Promise}
 import java.util.concurrent.Executor
 import io.netty.handler.codec.http._
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class Http2UpgradingTransportTest extends FunSuite with MockitoSugar {
   class Ctx {

--- a/finagle-http2/src/test/scala/com/twitter/finagle/http2/transport/PriorKnowledgeHandlerTest.scala
+++ b/finagle-http2/src/test/scala/com/twitter/finagle/http2/transport/PriorKnowledgeHandlerTest.scala
@@ -14,7 +14,7 @@ import io.netty.util.CharsetUtil._
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.mockito.{ArgumentCaptor, Matchers}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfter, FunSuite}
 
 class PriorKnowledgeHandlerTest extends FunSuite with BeforeAndAfter with MockitoSugar {

--- a/finagle-http2/src/test/scala/com/twitter/finagle/http2/transport/RichHttpToHttp2ConnectionHandlerTest.scala
+++ b/finagle-http2/src/test/scala/com/twitter/finagle/http2/transport/RichHttpToHttp2ConnectionHandlerTest.scala
@@ -17,7 +17,7 @@ import io.netty.handler.codec.http2._
 import org.mockito.ArgumentCaptor
 import org.mockito.Matchers.{eq => meq, _}
 import org.mockito.Mockito.{RETURNS_SMART_NULLS, verify, when}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfter, FunSuite}
 
 class RichHttpToHttp2ConnectionHandlerTest extends FunSuite with BeforeAndAfter with MockitoSugar {

--- a/finagle-http2/src/test/scala/com/twitter/finagle/http2/transport/ServerNpnOrAlpnHandlerTest.scala
+++ b/finagle-http2/src/test/scala/com/twitter/finagle/http2/transport/ServerNpnOrAlpnHandlerTest.scala
@@ -10,7 +10,7 @@ import io.netty.channel.embedded.EmbeddedChannel
 import io.netty.handler.ssl.{ApplicationProtocolNames, SslHandler, SslHandshakeCompletionEvent}
 import org.mockito.Matchers._
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfter, FunSuite}
 
 class ServerNpnOrAlpnHandlerTest extends FunSuite with BeforeAndAfter with MockitoSugar {

--- a/finagle-integration/src/test/scala/com/twitter/finagle/integration/ClientSessionTest.scala
+++ b/finagle-integration/src/test/scala/com/twitter/finagle/integration/ClientSessionTest.scala
@@ -18,7 +18,7 @@ import com.twitter.util._
 import com.twitter.conversions.DurationOps._
 import org.mockito.Mockito.when
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
  * We want client session statuses to reflect the status of their underlying transports/handles

--- a/finagle-integration/src/test/scala/com/twitter/finagle/integration/ContextPropagationTest.scala
+++ b/finagle-integration/src/test/scala/com/twitter/finagle/integration/ContextPropagationTest.scala
@@ -11,7 +11,7 @@ import com.twitter.io.Buf
 import com.twitter.util.{Await, Future, Return}
 import java.net.{InetAddress, InetSocketAddress}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class ContextPropagationTest extends FunSuite with MockitoSugar {
 

--- a/finagle-memcached/src/main/scala/com/twitter/finagle/memcached/ZookeeperStateMonitor.scala
+++ b/finagle-memcached/src/main/scala/com/twitter/finagle/memcached/ZookeeperStateMonitor.scala
@@ -8,7 +8,7 @@ import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.util.{Duration, FuturePool, JavaTimer, Return, Throw}
 import org.apache.zookeeper.Watcher.Event.KeeperState
 import org.apache.zookeeper.{WatchedEvent, Watcher}
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 object ZookeeperStateMonitor {
   val DefaultZkConnectionRetryBackoff =
@@ -149,7 +149,7 @@ trait ZookeeperStateMonitor {
           .get(DefaultZKWaitTimeout)
           .getChildren(zkPath, true, null)
 
-        applyZKChildren(children.toList)
+        applyZKChildren(children.asScala.toList)
     }
 
   /**

--- a/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/integration/external/ExternalMemcached.scala
+++ b/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/integration/external/ExternalMemcached.scala
@@ -74,7 +74,7 @@ private[memcached] object ExternalMemcached { self =>
   def start(address: Option[InetSocketAddress]): Option[TestMemcachedServer] = {
     def exec(address: InetSocketAddress): Process = {
       val cmd = Seq("memcached", "-l", address.getHostName, "-p", address.getPort.toString)
-      val builder = new ProcessBuilder(cmd.toList)
+      val builder = new ProcessBuilder(cmd: _*)
       builder.start()
     }
 

--- a/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/integration/external/ExternalMemcached.scala
+++ b/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/integration/external/ExternalMemcached.scala
@@ -3,7 +3,7 @@ package com.twitter.finagle.memcached.integration.external
 import com.twitter.conversions.DurationOps._
 import com.twitter.util.{Duration, RandomSocket, Stopwatch}
 import java.net.{BindException, InetAddress, InetSocketAddress, ServerSocket}
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.collection._
 import scala.util.control.NonFatal
 

--- a/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/ConnectedClientTest.scala
+++ b/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/ConnectedClientTest.scala
@@ -8,8 +8,8 @@ import com.twitter.finagle.Service
 import com.twitter.util.{Await, Awaitable, Future}
 import org.mockito.Matchers._
 import org.mockito.Mockito._
-import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.FunSuite
+import org.scalatestplus.mockito.MockitoSugar
 
 class ConnectedClientTest extends FunSuite with MockitoSugar {
 

--- a/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/ConnectedClientTest.scala
+++ b/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/ConnectedClientTest.scala
@@ -8,7 +8,7 @@ import com.twitter.finagle.Service
 import com.twitter.util.{Await, Awaitable, Future}
 import org.mockito.Matchers._
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.FunSuite
 
 class ConnectedClientTest extends FunSuite with MockitoSugar {

--- a/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/GetResultTest.scala
+++ b/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/GetResultTest.scala
@@ -3,7 +3,7 @@ package com.twitter.finagle.memcached.unit
 import com.twitter.finagle.memcached._
 import com.twitter.finagle.memcached.protocol.Value
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import scala.collection.immutable
 
 class GetResultTest extends FunSuite with MockitoSugar {

--- a/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/KetamaClientTest.scala
+++ b/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/KetamaClientTest.scala
@@ -11,7 +11,7 @@ import scala.collection.mutable
 import _root_.java.io.{BufferedReader, InputStreamReader}
 import org.mockito.Matchers._
 import org.mockito.Mockito.{RETURNS_SMART_NULLS, times, verify, verifyZeroInteractions, when}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.FunSuite
 
 class KetamaClientTest extends FunSuite with MockitoSugar {

--- a/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/KetamaFailureAccrualFactoryTest.scala
+++ b/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/KetamaFailureAccrualFactoryTest.scala
@@ -12,7 +12,7 @@ import org.mockito.Mockito.{times, verify, when}
 import org.mockito.Matchers
 import org.mockito.Matchers._
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class KetamaFailureAccrualFactoryTest extends FunSuite with MockitoSugar {
 

--- a/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/PHPMemCacheClientTest.scala
+++ b/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/PHPMemCacheClientTest.scala
@@ -7,7 +7,7 @@ import com.twitter.util.{Await, Future}
 import org.mockito.Matchers.any
 import org.mockito.Mockito.{verify, when}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class PHPMemCacheClientTest extends FunSuite with MockitoSugar {
 

--- a/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/RubyMemCacheClientTest.scala
+++ b/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/RubyMemCacheClientTest.scala
@@ -6,7 +6,7 @@ import com.twitter.util.{Await, Future}
 import org.mockito.Matchers.any
 import org.mockito.Mockito.{times, verify, when}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class RubyMemCacheClientTest extends FunSuite with MockitoSugar {
 

--- a/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/partitioning/MemcachedPartitioningServiceTest.scala
+++ b/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/partitioning/MemcachedPartitioningServiceTest.scala
@@ -16,7 +16,7 @@ import com.twitter.util.{Command => _, _}
 import java.net.{InetAddress, InetSocketAddress}
 import org.mockito.Matchers._
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, FunSuite, MustMatchers}
 
 class MemcachedPartitioningServiceTest

--- a/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/protocol/text/FramingDecoderTest.scala
+++ b/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/protocol/text/FramingDecoderTest.scala
@@ -3,7 +3,7 @@ package com.twitter.finagle.memcached.unit.protocol.text
 import com.twitter.finagle.memcached.protocol.text.{FrameDecoder, FramingDecoder}
 import com.twitter.io.{Buf, ByteReader}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import scala.collection.mutable
 
 class FramingDecoderTest extends FunSuite with MockitoSugar {

--- a/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/protocol/text/client/CommandToBufTest.scala
+++ b/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/protocol/text/client/CommandToBufTest.scala
@@ -5,9 +5,9 @@ import com.twitter.io.BufByteWriter
 import java.nio.charset.StandardCharsets
 import org.scalacheck.Gen
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class CommandToBufTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class CommandToBufTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
 
   test("`commandToBuf.lengthAsString` returns same value as `Integer.toString.length`") {
     forAll(Gen.posNum[Int]) { i: Int =>

--- a/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/protocol/text/client/DecoderTest.scala
+++ b/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/protocol/text/client/DecoderTest.scala
@@ -10,7 +10,7 @@ import com.twitter.finagle.memcached.protocol.text.{
 }
 import com.twitter.io.Buf
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import scala.collection.mutable
 
 class DecoderTest extends FunSuite with MockitoSugar {

--- a/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/protocol/text/server/ResponseToBufTest.scala
+++ b/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/protocol/text/server/ResponseToBufTest.scala
@@ -4,9 +4,9 @@ import com.twitter.finagle.memcached.protocol.{ClientError, Error, NonexistentCo
 import com.twitter.finagle.memcached.protocol.text.server.ResponseToBuf
 import com.twitter.io.Buf
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class ResponseToBufTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class ResponseToBufTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
 
   test("encode errors - ERROR") {
     val error = Error(new NonexistentCommand("No such command"))

--- a/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/util/MemcachedTest.scala
+++ b/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/util/MemcachedTest.scala
@@ -16,7 +16,7 @@ import com.twitter.finagle.toggle.flag
 import com.twitter.util.{Await, Time}
 import org.scalatest.FunSuite
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class MemcachedTest extends FunSuite with MockitoSugar with Eventually with IntegrationPatience {
 

--- a/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/util/ParserUtilsTest.scala
+++ b/finagle-memcached/src/test/scala/com/twitter/finagle/memcached/unit/util/ParserUtilsTest.scala
@@ -4,9 +4,9 @@ import com.twitter.finagle.memcached.util.ParserUtils
 import com.twitter.io.Buf
 import java.nio.charset.StandardCharsets.UTF_8
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class ParserUtilsTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class ParserUtilsTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
 
   private def isDigitsBB(str: String): Boolean = {
     val bb = UTF_8.encode(str)

--- a/finagle-mux/src/main/scala/com/twitter/finagle/mux/lease/exp/ClockedDrainer.scala
+++ b/finagle-mux/src/main/scala/com/twitter/finagle/mux/lease/exp/ClockedDrainer.scala
@@ -193,7 +193,7 @@ private[finagle] class ClockedDrainer(
       )
     }
 
-    coord.sleepUntilFinishedDraining(space, maxWait, npending, log)
+    coord.sleepUntilFinishedDraining(space, maxWait, npending _, log)
   }
 
   // GC

--- a/finagle-mux/src/main/scala/com/twitter/finagle/mux/pushsession/MuxClientSession.scala
+++ b/finagle-mux/src/main/scala/com/twitter/finagle/mux/pushsession/MuxClientSession.scala
@@ -61,7 +61,7 @@ private[finagle] final class MuxClientSession(
   private[this] val exec: Executor = handle.serialExecutor
 
   private[this] val failureDetector =
-    FailureDetector(detectorConfig, ping, statsReceiver.scope("failuredetector"))
+    FailureDetector(detectorConfig, ping _, statsReceiver.scope("failuredetector"))
 
   // Metrics
   private[this] val leaseCounter = statsReceiver.counter(Verbosity.Debug, "leased")

--- a/finagle-mux/src/test/scala/com/twitter/finagle/mux/AbstractEndToEndTest.scala
+++ b/finagle-mux/src/test/scala/com/twitter/finagle/mux/AbstractEndToEndTest.scala
@@ -21,7 +21,7 @@ import java.nio.ByteBuffer
 import java.util.concurrent.atomic.{AtomicInteger, AtomicBoolean}
 import org.scalactic.source.Position
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
-import org.scalatest.junit.AssertionsForJUnit
+import org.scalatestplus.junit.AssertionsForJUnit
 import org.scalatest.{BeforeAndAfter, FunSuite, Tag}
 import scala.language.reflectiveCalls
 

--- a/finagle-mux/src/test/scala/com/twitter/finagle/mux/ClientServerTest.scala
+++ b/finagle-mux/src/test/scala/com/twitter/finagle/mux/ClientServerTest.scala
@@ -25,8 +25,8 @@ import org.mockito.Mockito.{never, verify, when}
 import org.mockito.stubbing.Answer
 import org.scalactic.source.Position
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
-import org.scalatest.junit.AssertionsForJUnit
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.junit.AssertionsForJUnit
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{FunSuite, OneInstancePerTest, Tag}
 
 private object TestContext {

--- a/finagle-mux/src/test/scala/com/twitter/finagle/mux/ReqRepHeadersTest.scala
+++ b/finagle-mux/src/test/scala/com/twitter/finagle/mux/ReqRepHeadersTest.scala
@@ -3,9 +3,9 @@ package com.twitter.finagle.mux
 import com.twitter.io.Buf
 import org.scalacheck.Gen
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class ReqRepHeadersTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class ReqRepHeadersTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
 
   private val Header: Gen[(Buf, Buf)] = {
     val byte = Gen.choose[Byte](Byte.MinValue, Byte.MaxValue)

--- a/finagle-mux/src/test/scala/com/twitter/finagle/mux/lease/exp/CoordinatorTest.scala
+++ b/finagle-mux/src/test/scala/com/twitter/finagle/mux/lease/exp/CoordinatorTest.scala
@@ -8,7 +8,7 @@ import java.util.logging.Logger
 import org.mockito.Mockito.when
 import org.scalactic.source.Position
 import org.scalatest.{FunSuite, Tag}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import scala.collection.mutable.Buffer
 
 class CoordinatorTest extends FunSuite with LocalConductors with MockitoSugar {

--- a/finagle-mux/src/test/scala/com/twitter/finagle/mux/lease/exp/DedupingLogsReceiverTest.scala
+++ b/finagle-mux/src/test/scala/com/twitter/finagle/mux/lease/exp/DedupingLogsReceiverTest.scala
@@ -4,7 +4,7 @@ import java.util.logging.Logger
 import org.mockito.Mockito.{never, times, verify}
 import org.mockito.Matchers.anyString
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class DedupingLogsReceiverTest extends FunSuite with MockitoSugar {
   test("DedupingLogsReceiver logs when recording and flushing") {

--- a/finagle-mux/src/test/scala/com/twitter/finagle/mux/lease/exp/GenerationalRandomTest.scala
+++ b/finagle-mux/src/test/scala/com/twitter/finagle/mux/lease/exp/GenerationalRandomTest.scala
@@ -2,7 +2,7 @@ package com.twitter.finagle.mux.lease.exp
 
 import org.mockito.Mockito.{when, verify, times}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import scala.util.Random
 
 class GenerationalRandomTest extends FunSuite with MockitoSugar {

--- a/finagle-mux/src/test/scala/com/twitter/finagle/mux/lease/exp/MemorySpaceTest.scala
+++ b/finagle-mux/src/test/scala/com/twitter/finagle/mux/lease/exp/MemorySpaceTest.scala
@@ -4,7 +4,7 @@ import com.twitter.conversions.StorageUnitOps._
 import com.twitter.util.StorageUnit
 import org.mockito.Mockito.{when, verify}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class MemorySpaceTest extends FunSuite with MockitoSugar {
   test("MemorySpace#left should find the number of bytes left before we hit minDiscount") {

--- a/finagle-mux/src/test/scala/com/twitter/finagle/mux/lease/exp/RequestSnooperTest.scala
+++ b/finagle-mux/src/test/scala/com/twitter/finagle/mux/lease/exp/RequestSnooperTest.scala
@@ -5,7 +5,7 @@ import com.twitter.conversions.DurationOps._
 import com.twitter.conversions.StorageUnitOps._
 import org.mockito.Mockito.when
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class RequestSnooperTest extends FunSuite with MockitoSugar {
   test("RequestSnooper should compute handleBytes reasonably") {

--- a/finagle-mux/src/test/scala/com/twitter/finagle/mux/pushsession/MuxClientNegotiatingSessionTest.scala
+++ b/finagle-mux/src/test/scala/com/twitter/finagle/mux/pushsession/MuxClientNegotiatingSessionTest.scala
@@ -15,7 +15,7 @@ import com.twitter.finagle.{ChannelClosedException, Failure, FailureFlags, Mux, 
 import com.twitter.io.{Buf, ByteReader}
 import com.twitter.util.{Await, Awaitable, Future, Promise}
 import org.scalactic.source.Position
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{FunSuite, Tag}
 
 class MuxClientNegotiatingSessionTest extends FunSuite with MockitoSugar {

--- a/finagle-mux/src/test/scala/com/twitter/finagle/mux/util/TagMapTest.scala
+++ b/finagle-mux/src/test/scala/com/twitter/finagle/mux/util/TagMapTest.scala
@@ -2,9 +2,9 @@ package com.twitter.finagle.mux.util
 
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class TagMapTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class TagMapTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
 
   val min = 8
   val max = 10000

--- a/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/CursoredStatement.scala
+++ b/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/CursoredStatement.scala
@@ -211,7 +211,7 @@ private class StdCursorResult[T](
         }
       }
     }
-    go
+    go _
   }
 
   override def stream: AsyncStream[T] = self.synchronized {

--- a/finagle-mysql/src/test/scala/com/twitter/finagle/mysql/unit/ClientTest.scala
+++ b/finagle-mysql/src/test/scala/com/twitter/finagle/mysql/unit/ClientTest.scala
@@ -6,7 +6,7 @@ import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.util.Time
 import org.mockito.Matchers._
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{FunSuite, MustMatchers}
 
 /**

--- a/finagle-mysql/src/test/scala/com/twitter/finagle/mysql/unit/PoisonConnectionTest.scala
+++ b/finagle-mysql/src/test/scala/com/twitter/finagle/mysql/unit/PoisonConnectionTest.scala
@@ -7,7 +7,7 @@ import com.twitter.util.{Future, Promise, Throw, Time}
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class PoisonableServiceFactoryTest extends FunSuite with MockitoSugar {
 

--- a/finagle-mysql/src/test/scala/com/twitter/finagle/mysql/unit/SessionsTest.scala
+++ b/finagle-mysql/src/test/scala/com/twitter/finagle/mysql/unit/SessionsTest.scala
@@ -7,7 +7,7 @@ import com.twitter.util.{Await, Awaitable, Future, Time}
 import org.mockito.Matchers.any
 import org.mockito.Mockito.{spy, times, verify}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class SessionsTest extends FunSuite with MockitoSugar {
   private[this] val sqlQuery = "SELECT * FROM FOO"

--- a/finagle-mysql/src/test/scala/com/twitter/finagle/mysql/unit/TransactionTest.scala
+++ b/finagle-mysql/src/test/scala/com/twitter/finagle/mysql/unit/TransactionTest.scala
@@ -5,7 +5,7 @@ import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.util.{Await, Awaitable, Time}
 import org.mockito.Matchers._
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{FunSuite, MustMatchers}
 
 /**

--- a/finagle-netty4-http/src/test/scala/com/twitter/finagle/netty4/http/BijectionsTest.scala
+++ b/finagle-netty4-http/src/test/scala/com/twitter/finagle/netty4/http/BijectionsTest.scala
@@ -8,7 +8,7 @@ import java.net.{InetSocketAddress, URI}
 import java.nio.charset.StandardCharsets.UTF_8
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scala.collection.JavaConverters._
 import scala.util.Random
 
@@ -129,7 +129,7 @@ object BijectionsTest {
   }
 }
 
-class BijectionsTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class BijectionsTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
   import BijectionsTest._
 
   test("netty http request -> finagle") {

--- a/finagle-netty4-http/src/test/scala/com/twitter/finagle/netty4/http/ByteBufManagerTest.scala
+++ b/finagle-netty4-http/src/test/scala/com/twitter/finagle/netty4/http/ByteBufManagerTest.scala
@@ -6,7 +6,7 @@ import com.twitter.finagle.http.codec.ChannelBufferUsageTracker
 import io.netty.buffer.Unpooled
 import io.netty.channel.{ChannelHandlerContext, ChannelPromise}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class ByteBufManagerTest extends FunSuite with MockitoSugar {
 

--- a/finagle-netty4-http/src/test/scala/com/twitter/finagle/netty4/http/TextualContentCompressorTest.scala
+++ b/finagle-netty4-http/src/test/scala/com/twitter/finagle/netty4/http/TextualContentCompressorTest.scala
@@ -3,7 +3,7 @@ package com.twitter.finagle.netty4.http
 import io.netty.channel.embedded.EmbeddedChannel
 import io.netty.handler.codec.http._
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class TextualContentCompressorTest extends FunSuite with MockitoSugar {
   import com.twitter.finagle.http.codec.TextualContentCompressor.TextLike

--- a/finagle-netty4-http/src/test/scala/com/twitter/finagle/netty4/http/handler/BadRequestHandlerTest.scala
+++ b/finagle-netty4-http/src/test/scala/com/twitter/finagle/netty4/http/handler/BadRequestHandlerTest.scala
@@ -140,14 +140,14 @@ class BadRequestHandlerTest extends FunSuite {
     }
 
     check(
-      "foo\0",
+      "foo\u0000",
       "bar",
       Seq("rejected_invalid_header_names")
     )
 
     check(
       "foo",
-      "bar\0",
+      "bar\u0000",
       Seq("rejected_invalid_header_values")
     )
   }

--- a/finagle-netty4-http/src/test/scala/com/twitter/finagle/netty4/http/handler/UnpoolHttpHandlerTest.scala
+++ b/finagle-netty4-http/src/test/scala/com/twitter/finagle/netty4/http/handler/UnpoolHttpHandlerTest.scala
@@ -4,12 +4,12 @@ import io.netty.buffer._
 import io.netty.channel.embedded.EmbeddedChannel
 import io.netty.handler.codec.http._
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.{FunSuite, OneInstancePerTest}
 
 class UnpoolHttpHandlerTest
     extends FunSuite
-    with GeneratorDrivenPropertyChecks
+    with ScalaCheckDrivenPropertyChecks
     with OneInstancePerTest {
 
   val channel = new EmbeddedChannel(UnpoolHttpHandler)

--- a/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/transport/ChannelTransport.scala
+++ b/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/transport/ChannelTransport.scala
@@ -101,7 +101,7 @@ private[finagle] class ChannelTransport(
       def operationComplete(f: nettyChan.ChannelFuture): Unit =
         if (f.isSuccess) p.setDone()
         else {
-          p.setException(ChannelException(f.cause, remoteAddress))
+          p.setException(ChannelException(f.cause, context.remoteAddress))
         }
     })
 
@@ -172,12 +172,12 @@ private[finagle] class ChannelTransport(
 
       override def channelInactive(ctx: nettyChan.ChannelHandlerContext): Unit = {
         if (omitStackTraceOnInactive) {
-          fail(new NoStackTraceChannelClosedException(remoteAddress))
-        } else fail(new ChannelClosedException(remoteAddress))
+          fail(new NoStackTraceChannelClosedException(context.remoteAddress))
+        } else fail(new ChannelClosedException(context.remoteAddress))
       }
 
       override def exceptionCaught(ctx: nettyChan.ChannelHandlerContext, e: Throwable): Unit = {
-        fail(ChannelException(e, remoteAddress))
+        fail(ChannelException(e, context.remoteAddress))
       }
     }
   )

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/AbstractByteBufByteReaderTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/AbstractByteBufByteReaderTest.scala
@@ -7,7 +7,7 @@ import java.lang.{Double => JDouble, Float => JFloat}
 import java.nio.charset.StandardCharsets
 import org.scalacheck.Gen
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 object CopyingByteBufByteReaderTest {
 
@@ -64,7 +64,7 @@ class CopyingByteBufByteReaderProcessorTest
       }
     )
 
-abstract class AbstractByteBufByteReaderTest extends FunSuite with GeneratorDrivenPropertyChecks {
+abstract class AbstractByteBufByteReaderTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
 
   private val SignedMediumMax = 0x800000
 

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ReadableBufProcessorTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ReadableBufProcessorTest.scala
@@ -2,7 +2,7 @@ package com.twitter.finagle.netty4
 
 import com.twitter.io.Buf
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 object ReadableBufProcessorTest {
 
@@ -38,7 +38,7 @@ abstract class ReadableBufProcessorTest(
   processable: String,
   newProcessable: (Array[Byte] => ReadableBufProcessorTest.CanProcess))
     extends FunSuite
-    with GeneratorDrivenPropertyChecks {
+    with ScalaCheckDrivenPropertyChecks {
   import ReadableBufProcessorTest._
 
   test(s"$processable: process throws exception when `from` < 0") {

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/StatsLeakDetectorFactoryTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/StatsLeakDetectorFactoryTest.scala
@@ -3,7 +3,7 @@ package com.twitter.finagle.netty4
 import io.netty.buffer.ByteBuf
 import io.netty.util.{ResourceLeakDetector, ResourceLeakDetectorFactory}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.mockito.Mockito._
 import org.mockito.Matchers._
 

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/channel/BufferingChannelOutboundHandlerTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/channel/BufferingChannelOutboundHandlerTest.scala
@@ -2,12 +2,12 @@ package com.twitter.finagle.netty4.channel
 
 import io.netty.channel.{ChannelHandlerContext, ChannelOutboundHandlerAdapter}
 import io.netty.channel.embedded.EmbeddedChannel
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.{OneInstancePerTest, FunSuite}
 
 class BufferingChannelOutboundHandlerTest
     extends FunSuite
-    with GeneratorDrivenPropertyChecks
+    with ScalaCheckDrivenPropertyChecks
     with OneInstancePerTest {
 
   class Buffering extends ChannelOutboundHandlerAdapter with BufferingChannelOutboundHandler {

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/channel/ChannelRequestStatsHandlerTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/channel/ChannelRequestStatsHandlerTest.scala
@@ -5,7 +5,7 @@ import com.twitter.finagle.stats.InMemoryStatsReceiver
 import io.netty.channel._
 import org.mockito.Mockito.when
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class ChannelRequestStatsHandlerTest extends FunSuite with MockitoSugar {
 

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/channel/ChannelSnooperTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/channel/ChannelSnooperTest.scala
@@ -6,7 +6,7 @@ import io.netty.channel._
 import java.net.InetSocketAddress
 import org.mockito.Mockito.when
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class ChannelSnooperTest extends FunSuite with MockitoSugar {
 

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/channel/ChannelStatsHandlerTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/channel/ChannelStatsHandlerTest.scala
@@ -11,7 +11,7 @@ import io.netty.channel.embedded.EmbeddedChannel
 import java.util.concurrent.TimeoutException
 import org.mockito.Mockito.when
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class ChannelStatsHandlerTest extends FunSuite with MockitoSugar {
 

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/channel/HandlerEventTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/channel/HandlerEventTest.scala
@@ -8,7 +8,7 @@ import io.netty.channel.embedded.EmbeddedChannel
 import io.netty.channel.nio.NioEventLoopGroup
 import java.net.SocketAddress
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class HandlerEventTest extends FunSuite with MockitoSugar {
 

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/codec/BufCodecTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/codec/BufCodecTest.scala
@@ -8,9 +8,9 @@ import io.netty.channel.embedded.EmbeddedChannel
 import java.nio.ByteBuffer
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.{FunSuite, OneInstancePerTest}
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class BufCodecTest extends FunSuite with GeneratorDrivenPropertyChecks with OneInstancePerTest {
+class BufCodecTest extends FunSuite with ScalaCheckDrivenPropertyChecks with OneInstancePerTest {
 
   val channel = new EmbeddedChannel(BufCodec)
 

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/decoder/DecoderHandlerTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/decoder/DecoderHandlerTest.scala
@@ -6,7 +6,7 @@ import com.twitter.io.Buf
 import io.netty.channel.embedded.EmbeddedChannel
 import io.netty.channel.{ChannelHandlerContext, ChannelInboundHandlerAdapter}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import scala.collection.mutable.ArrayBuffer
 
 class DecoderHandlerTest extends FunSuite with MockitoSugar {

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/ContextReloaderTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/ContextReloaderTest.scala
@@ -5,7 +5,7 @@ import com.twitter.util.{FuturePool, MockTimer, Time}
 import io.netty.handler.ssl.SslContext
 import java.util.concurrent.atomic.AtomicInteger
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class ContextReloaderTest extends FunSuite with MockitoSugar {
 

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/client/SslClientVerificationHandlerTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/client/SslClientVerificationHandlerTest.scala
@@ -10,7 +10,7 @@ import java.net.InetSocketAddress
 import javax.net.ssl.{SSLEngine, SSLSession}
 import org.mockito.Mockito._
 import org.scalatest.{FunSuite, OneInstancePerTest}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class SslClientVerificationHandlerTest extends FunSuite with MockitoSugar with OneInstancePerTest {
 

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/server/SslServerVerificationHandlerTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/ssl/server/SslServerVerificationHandlerTest.scala
@@ -9,7 +9,7 @@ import io.netty.util.concurrent.DefaultPromise
 import javax.net.ssl.{SSLEngine, SSLSession}
 import org.mockito.Mockito.when
 import org.scalatest.{FunSuite, OneInstancePerTest}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class SslServerVerificationHandlerTest extends FunSuite with MockitoSugar with OneInstancePerTest {
 

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/threading/EventLoopGroupExecutionDelayTrackerTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/threading/EventLoopGroupExecutionDelayTrackerTest.scala
@@ -10,7 +10,7 @@ import org.mockito.Mockito.{never, verify, atLeast}
 import org.mockito.Matchers.{anyString, contains, anyVararg}
 import org.scalatest.FunSuite
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import scala.collection.JavaConversions.asScalaSet
 
 class EventLoopGroupExecutionDelayTrackerTest

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/threading/EventLoopGroupExecutionDelayTrackerTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/threading/EventLoopGroupExecutionDelayTrackerTest.scala
@@ -11,7 +11,7 @@ import org.mockito.Matchers.{anyString, contains, anyVararg}
 import org.scalatest.FunSuite
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatestplus.mockito.MockitoSugar
-import scala.collection.JavaConversions.asScalaSet
+import scala.collection.JavaConverters._
 
 class EventLoopGroupExecutionDelayTrackerTest
     extends FunSuite
@@ -54,7 +54,7 @@ class EventLoopGroupExecutionDelayTrackerTest
     assert(statsReceiver.stats.get(Seq("workerpool", "deviation_ms")).isDefined)
 
     // we should have no threads with the name no_threads_expected
-    asScalaSet(Thread.getAllStackTraces.keySet()).foreach { thread: Thread =>
+    Thread.getAllStackTraces.keySet().asScala.foreach { thread: Thread =>
       assert(!thread.getName.contains("no_threads_expected"))
     }
 
@@ -98,7 +98,7 @@ class EventLoopGroupExecutionDelayTrackerTest
 
     // we should have threads with the name no_threads_expected
     assert(
-      asScalaSet(Thread.getAllStackTraces.keySet())
+      Thread.getAllStackTraces.keySet().asScala
         .exists(thread => thread.getName.contains("execution_delay_test_pool"))
     )
 

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/transport/ChannelTransportContextTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/transport/ChannelTransportContextTest.scala
@@ -6,7 +6,7 @@ import io.netty.handler.ssl.SslHandler
 import java.security.cert.{Certificate, X509Certificate}
 import javax.net.ssl.{SSLEngine, SSLSession}
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.FunSuite
 
 class ChannelTransportContextTest extends FunSuite with MockitoSugar {

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/transport/ChannelTransportTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/transport/ChannelTransportTest.scala
@@ -9,13 +9,13 @@ import io.netty.channel.{ChannelException => _, _}
 import io.netty.channel.embedded.EmbeddedChannel
 import org.scalatest.{FunSuite, OneInstancePerTest}
 import org.scalatest.concurrent.Eventually._
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.mockito.Mockito._
 
 class ChannelTransportTest
     extends FunSuite
-    with GeneratorDrivenPropertyChecks
+    with ScalaCheckDrivenPropertyChecks
     with OneInstancePerTest
     with MockitoSugar {
 

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/transport/ChannelTransportTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/transport/ChannelTransportTest.scala
@@ -30,7 +30,7 @@ class ChannelTransportTest
 
   def assertFailedRead[A](seen: Future[A], e: Exception): Unit = {
     val thrown = intercept[Exception](Await.result(seen, timeout))
-    assert(thrown == ChannelException(e, transport.remoteAddress))
+    assert(thrown == ChannelException(e, transport.context.remoteAddress))
     assert(transport.status == Status.Closed)
   }
 
@@ -93,7 +93,7 @@ class ChannelTransportTest
     })
 
     forAll { s: String =>
-      assert(transport.write(s).poll == Some(Throw(ChannelException(e, transport.remoteAddress))))
+      assert(transport.write(s).poll == Some(Throw(ChannelException(e, transport.context.remoteAddress))))
     }
   }
 
@@ -120,7 +120,7 @@ class ChannelTransportTest
     assert(!transport.onClose.isDefined)
     channel.pipeline.fireExceptionCaught(e)
 
-    assert(Await.result(transport.onClose, timeout) == ChannelException(e, transport.remoteAddress))
+    assert(Await.result(transport.onClose, timeout) == ChannelException(e, transport.context.remoteAddress))
     assert(transport.status == Status.Closed)
   }
 

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/util/Netty4TimerTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/util/Netty4TimerTest.scala
@@ -3,7 +3,7 @@ package com.twitter.finagle.netty4.util
 import com.twitter.conversions.DurationOps._
 import com.twitter.util.{Duration, Time}
 import io.netty.util.{HashedWheelTimer, Timeout, Timer, TimerTask}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.FunSuite
 import org.mockito.Mockito._
 import org.mockito.Matchers._

--- a/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/util/Netty4TimerTest.scala
+++ b/finagle-netty4/src/test/scala/com/twitter/finagle/netty4/util/Netty4TimerTest.scala
@@ -40,8 +40,8 @@ class Netty4TimerTest extends FunSuite with MockitoSugar with Eventually {
     when(underlying.newTimeout(any[TimerTask], any[Long], any[TimeUnit])).thenReturn(timeout)
 
     // Cancel both tasks.
-    timer.schedule(Time.Top)().cancel()
-    timer.schedule(Duration.Top)().cancel()
+    timer.schedule(Time.Top)(()).cancel()
+    timer.schedule(Duration.Top)(()).cancel()
     verify(timeout, times(2)).cancel()
   }
 

--- a/finagle-opencensus-tracing/src/test/scala/com/twitter/finagle/tracing/opencensus/LazySpanTest.scala
+++ b/finagle-opencensus-tracing/src/test/scala/com/twitter/finagle/tracing/opencensus/LazySpanTest.scala
@@ -4,7 +4,7 @@ import io.opencensus.trace.{BlankSpan, Sampler, Span, SpanBuilder}
 import java.util
 import org.mockito.Mockito._
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class LazySpanTest extends FunSuite with MockitoSugar {
 

--- a/finagle-opencensus-tracing/src/test/scala/com/twitter/finagle/tracing/opencensus/TraceContextFilterTest.scala
+++ b/finagle-opencensus-tracing/src/test/scala/com/twitter/finagle/tracing/opencensus/TraceContextFilterTest.scala
@@ -3,10 +3,10 @@ package com.twitter.finagle.tracing.opencensus
 import io.opencensus.trace.{SpanContext, SpanId, TraceId, TraceOptions, Tracestate}
 import java.util.concurrent.ThreadLocalRandom
 import org.scalacheck.Gen
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.FunSuite
 
-class TraceContextFilterTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class TraceContextFilterTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
 
   private def genSpanContext: Gen[SpanContext] =
     Gen.resultOf { isSampled: Boolean =>

--- a/finagle-opencensus-tracing/src/test/scala/com/twitter/finagle/tracing/opencensus/TracingOpsTest.scala
+++ b/finagle-opencensus-tracing/src/test/scala/com/twitter/finagle/tracing/opencensus/TracingOpsTest.scala
@@ -5,7 +5,7 @@ import io.opencensus.trace.{BlankSpan, EndSpanOptions, Span, SpanBuilder}
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class TracingOpsTest extends FunSuite with MockitoSugar {
   import TracingOps._

--- a/finagle-redis/src/test/scala/com/twitter/finagle/redis/RedisTest.scala
+++ b/finagle-redis/src/test/scala/com/twitter/finagle/redis/RedisTest.scala
@@ -6,7 +6,7 @@ import com.twitter.finagle.redis.util._
 import com.twitter.finagle.Redis
 import com.twitter.io.Buf
 import com.twitter.util.{Await, Awaitable, Duration, Future, Try}
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.{BeforeAndAfterAll, FunSuite, Tag}
 import org.scalacheck.{Arbitrary, Gen}
 import java.net.InetSocketAddress
@@ -117,7 +117,7 @@ trait MissingInstances {
   implicit def arbitraryReply: Arbitrary[Reply] = Arbitrary(genReply)
 }
 
-trait RedisResponseTest extends RedisTest with GeneratorDrivenPropertyChecks with MissingInstances {
+trait RedisResponseTest extends RedisTest with ScalaCheckDrivenPropertyChecks with MissingInstances {
 
   private[this] def chunk(buf: Buf): Gen[Seq[Buf]] =
     if (buf.isEmpty) Gen.const(Seq.empty[Buf])
@@ -167,7 +167,7 @@ trait RedisResponseTest extends RedisTest with GeneratorDrivenPropertyChecks wit
   }
 }
 
-trait RedisRequestTest extends RedisTest with GeneratorDrivenPropertyChecks with MissingInstances {
+trait RedisRequestTest extends RedisTest with ScalaCheckDrivenPropertyChecks with MissingInstances {
 
   def genZMember: Gen[ZMember] =
     for {

--- a/finagle-redis/src/test/scala/com/twitter/finagle/redis/RedisTest.scala
+++ b/finagle-redis/src/test/scala/com/twitter/finagle/redis/RedisTest.scala
@@ -6,8 +6,8 @@ import com.twitter.finagle.redis.util._
 import com.twitter.finagle.Redis
 import com.twitter.io.Buf
 import com.twitter.util.{Await, Awaitable, Duration, Future, Try}
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.{BeforeAndAfterAll, FunSuite, Tag}
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalacheck.{Arbitrary, Gen}
 import java.net.InetSocketAddress
 import org.scalactic.source.Position

--- a/finagle-redis/src/test/scala/com/twitter/finagle/redis/protocol/StageTest.scala
+++ b/finagle-redis/src/test/scala/com/twitter/finagle/redis/protocol/StageTest.scala
@@ -3,9 +3,9 @@ package com.twitter.finagle.redis.protocol
 import com.twitter.finagle.redis.MissingInstances
 import com.twitter.io.{Buf, ByteReader}
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class StageTest extends FunSuite with GeneratorDrivenPropertyChecks with MissingInstances {
+class StageTest extends FunSuite with ScalaCheckDrivenPropertyChecks with MissingInstances {
 
   import Stage.NextStep
 

--- a/finagle-serversets/src/test/scala/com/twitter/ServersetNamerTest.scala
+++ b/finagle-serversets/src/test/scala/com/twitter/ServersetNamerTest.scala
@@ -6,7 +6,7 @@ import com.twitter.util.{Activity, Var}
 import org.mockito.Matchers.{anyString, any}
 import org.mockito.Mockito.{verify, when, never, times}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class ServersetNamerTest extends FunSuite with MockitoSugar {
   trait Ctx {

--- a/finagle-serversets/src/test/scala/com/twitter/finagle/serverset2/ServiceDiscovererTest.scala
+++ b/finagle-serversets/src/test/scala/com/twitter/finagle/serverset2/ServiceDiscovererTest.scala
@@ -16,7 +16,7 @@ import com.twitter.util._
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import java.util.concurrent.atomic.AtomicReference
 
 class ServiceDiscovererTest

--- a/finagle-serversets/src/test/scala/com/twitter/finagle/serverset2/addr/ZkMetadataTest.scala
+++ b/finagle-serversets/src/test/scala/com/twitter/finagle/serverset2/addr/ZkMetadataTest.scala
@@ -4,10 +4,10 @@ import com.twitter.finagle.{Addr, Address}
 import java.net.InetSocketAddress
 import org.scalacheck.Gen
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scala.util.Random
 
-class ZkMetadataTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class ZkMetadataTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
   val shardHashOrdering = ZkMetadata.shardHashOrdering(ZkMetadata.key.hashCode)
   val metadata = ZkMetadata(Some(4))
 

--- a/finagle-serversets/src/test/scala/com/twitter/finagle/serverset2/client/apache/ApacheZooKeeperTest.scala
+++ b/finagle-serversets/src/test/scala/com/twitter/finagle/serverset2/client/apache/ApacheZooKeeperTest.scala
@@ -10,7 +10,7 @@ import org.apache.zookeeper
 import org.mockito.ArgumentCaptor
 import org.mockito.Matchers.{eq => meq}
 import org.mockito.Mockito.{doNothing, doThrow, verify, when}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{FunSuite, OneInstancePerTest}
 import scala.collection.JavaConverters._
 class ApacheZooKeeperTest extends FunSuite with MockitoSugar with OneInstancePerTest {

--- a/finagle-stats-core/src/main/scala/com/twitter/finagle/stats/MetricsRegistry.scala
+++ b/finagle-stats-core/src/main/scala/com/twitter/finagle/stats/MetricsRegistry.scala
@@ -1,6 +1,6 @@
 package com.twitter.finagle.stats
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.collection.mutable
 
 private object MetricsRegistry {
@@ -33,7 +33,7 @@ private[twitter] trait MetricsRegistry extends StatsRegistry {
 
   private[this] def updateMetrics(): Unit =
     if (registry != null) {
-      for (entry <- registry.counters.entrySet) {
+      for (entry <- registry.counters.entrySet.asScala) {
         val key = entry.getKey()
         val newValue = entry.getValue().doubleValue
         val newMetric = metrics.get(key) match {
@@ -43,7 +43,7 @@ private[twitter] trait MetricsRegistry extends StatsRegistry {
         metrics.put(key, newMetric)
       }
 
-      for (entry <- registry.gauges.entrySet) {
+      for (entry <- registry.gauges.entrySet.asScala) {
         val key = entry.getKey()
         val newValue = entry.getValue().doubleValue
         metrics.put(key, instantaneous(newValue, "gauge"))

--- a/finagle-stats-core/test/scala/com/twitter/finagle/stats/BucketedHistogramTest.scala
+++ b/finagle-stats-core/test/scala/com/twitter/finagle/stats/BucketedHistogramTest.scala
@@ -1,10 +1,10 @@
 package com.twitter.finagle.stats
 
 import org.scalacheck.Gen
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.{Matchers, FunSuite}
 
-class BucketedHistogramTest extends FunSuite with GeneratorDrivenPropertyChecks with Matchers {
+class BucketedHistogramTest extends FunSuite with ScalaCheckDrivenPropertyChecks with Matchers {
   test("percentile when empty") {
     val h = BucketedHistogram()
     assert(h.percentile(0.0) == 0)

--- a/finagle-thrift/src/test/scala/com/twitter/finagle/thrift/ClientIdRequiredFilterTest.scala
+++ b/finagle-thrift/src/test/scala/com/twitter/finagle/thrift/ClientIdRequiredFilterTest.scala
@@ -6,7 +6,7 @@ import com.twitter.util.{Await, Future}
 import org.mockito.Matchers
 import org.mockito.Mockito.{times, verify, when}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class ClientIdRequiredFilterTest extends FunSuite with MockitoSugar {
 

--- a/finagle-thrift/src/test/scala/com/twitter/finagle/thrift/DeserializeCtxTest.scala
+++ b/finagle-thrift/src/test/scala/com/twitter/finagle/thrift/DeserializeCtxTest.scala
@@ -5,7 +5,7 @@ import com.twitter.scrooge.ThriftStruct
 import com.twitter.util.Return
 import java.util.concurrent.atomic.AtomicInteger
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class DeserializeCtxTest extends FunSuite with MockitoSugar {
 

--- a/finagle-thrift/src/test/scala/com/twitter/finagle/thrift/SeqIdFilterTest.scala
+++ b/finagle-thrift/src/test/scala/com/twitter/finagle/thrift/SeqIdFilterTest.scala
@@ -7,7 +7,7 @@ import org.apache.thrift.transport.TMemoryBuffer
 import org.mockito.{Matchers, ArgumentCaptor}
 import org.mockito.Mockito.{verify, when}
 import org.scalatest.{OneInstancePerTest, FunSuite}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class SeqIdFilterTest extends FunSuite with MockitoSugar with OneInstancePerTest {
   val protocolFactory = new TBinaryProtocol.Factory()

--- a/finagle-thrift/src/test/scala/com/twitter/finagle/thrift/TTwitterClientFilterTest.scala
+++ b/finagle-thrift/src/test/scala/com/twitter/finagle/thrift/TTwitterClientFilterTest.scala
@@ -10,7 +10,7 @@ import org.mockito.ArgumentCaptor
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import scala.collection.JavaConverters._
 
 class TTwitterClientFilterTest extends FunSuite with MockitoSugar {

--- a/finagle-thrift/src/test/scala/com/twitter/finagle/thrift/ThriftRichClientTest.scala
+++ b/finagle-thrift/src/test/scala/com/twitter/finagle/thrift/ThriftRichClientTest.scala
@@ -9,7 +9,7 @@ import org.mockito.ArgumentCaptor
 import org.mockito.Mockito._
 import org.mockito.Matchers._
 import org.scalatest.{FunSuite, OneInstancePerTest}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class ThriftRichClientTest extends FunSuite with MockitoSugar with OneInstancePerTest {
   object ThriftRichClientMock

--- a/finagle-thrift/src/test/scala/com/twitter/finagle/thrift/ThriftServerTracingFilterTest.scala
+++ b/finagle-thrift/src/test/scala/com/twitter/finagle/thrift/ThriftServerTracingFilterTest.scala
@@ -8,7 +8,7 @@ import org.apache.thrift.protocol.{TBinaryProtocol, TMessage, TMessageType}
 import org.mockito.Matchers
 import org.mockito.Mockito.when
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class ThriftServerTracingFilterTest extends FunSuite with MockitoSugar {
   val protocolFactory = new TBinaryProtocol.Factory()

--- a/finagle-thrift/src/test/scala/com/twitter/finagle/thrift/ValidateThriftServiceTest.scala
+++ b/finagle-thrift/src/test/scala/com/twitter/finagle/thrift/ValidateThriftServiceTest.scala
@@ -8,7 +8,7 @@ import org.apache.thrift.protocol.{TBinaryProtocol, TMessage, TMessageType}
 import org.mockito.Matchers
 import org.mockito.Mockito.{verify, when, times}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class ValidateThriftServiceTest extends FunSuite with MockitoSugar {
 

--- a/finagle-thriftmux/src/test/scala/com/twitter/finagle/thriftmux/EndToEndTest.scala
+++ b/finagle-thriftmux/src/test/scala/com/twitter/finagle/thriftmux/EndToEndTest.scala
@@ -33,7 +33,7 @@ import org.apache.thrift.TApplicationException
 import org.apache.thrift.protocol._
 import org.scalactic.source.Position
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
-import org.scalatest.junit.AssertionsForJUnit
+import org.scalatestplus.junit.AssertionsForJUnit
 import org.scalatest.{FunSuite, Tag}
 import scala.language.reflectiveCalls
 

--- a/finagle-thriftmux/src/test/scala/com/twitter/finagle/thriftmux/ThriftIfaceTest.scala
+++ b/finagle-thriftmux/src/test/scala/com/twitter/finagle/thriftmux/ThriftIfaceTest.scala
@@ -3,7 +3,7 @@ package com.twitter.finagle.thriftmux
 import com.twitter.finagle.ThriftMux
 import com.twitter.util.Future
 import org.scalatest.FunSuite
-import org.scalatest.junit.AssertionsForJUnit
+import org.scalatestplus.junit.AssertionsForJUnit
 
 class ThriftIfaceTest extends FunSuite with AssertionsForJUnit {
   test("invalid thrift ifaces") {

--- a/finagle-toggle/src/test/scala/com/twitter/finagle/toggle/JsonToggleMapTest.scala
+++ b/finagle-toggle/src/test/scala/com/twitter/finagle/toggle/JsonToggleMapTest.scala
@@ -3,10 +3,10 @@ package com.twitter.finagle.toggle
 import com.twitter.util.{Return, Throw, Try}
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scala.collection.JavaConverters._
 
-class JsonToggleMapTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class JsonToggleMapTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
 
   import JsonToggleMap.{DescriptionIgnored, DescriptionRequired}
 

--- a/finagle-toggle/src/test/scala/com/twitter/finagle/toggle/NullToggleMapTest.scala
+++ b/finagle-toggle/src/test/scala/com/twitter/finagle/toggle/NullToggleMapTest.scala
@@ -2,9 +2,9 @@ package com.twitter.finagle.toggle
 
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class NullToggleMapTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class NullToggleMapTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
 
   private val IntGen = arbitrary[Int]
 

--- a/finagle-toggle/src/test/scala/com/twitter/finagle/toggle/ToggleMapTest.scala
+++ b/finagle-toggle/src/test/scala/com/twitter/finagle/toggle/ToggleMapTest.scala
@@ -4,12 +4,12 @@ import com.twitter.finagle.stats.{InMemoryStatsReceiver, NullStatsReceiver}
 import com.twitter.logging.{BareFormatter, Level, Logger, StringHandler}
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.{FunSuite, Matchers}
 import scala.collection.immutable
 import scala.util.Random
 
-class ToggleMapTest extends FunSuite with GeneratorDrivenPropertyChecks with Matchers {
+class ToggleMapTest extends FunSuite with ScalaCheckDrivenPropertyChecks with Matchers {
 
   private val IntGen = arbitrary[Int]
 

--- a/finagle-toggle/src/test/scala/com/twitter/finagle/toggle/ToggleTest.scala
+++ b/finagle-toggle/src/test/scala/com/twitter/finagle/toggle/ToggleTest.scala
@@ -2,7 +2,7 @@ package com.twitter.finagle.toggle
 
 import org.scalacheck.Gen
 import org.scalatest.FunSuite
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 object ToggleGenerator {
 
@@ -15,7 +15,7 @@ object ToggleGenerator {
 
 }
 
-class ToggleTest extends FunSuite with GeneratorDrivenPropertyChecks {
+class ToggleTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
 
   private val IntGen =
     Gen.chooseNum(Int.MinValue, Int.MaxValue)

--- a/finagle-zipkin-core/src/test/scala/com/twitter/finagle/zipkin/core/SamplerTest.scala
+++ b/finagle-zipkin-core/src/test/scala/com/twitter/finagle/zipkin/core/SamplerTest.scala
@@ -1,6 +1,6 @@
 package com.twitter.finagle.zipkin.core
 
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.FunSuite
 import com.twitter.finagle.tracing.{Annotation, Record, SpanId, TraceId}
 import com.twitter.util.Time

--- a/finagle-zipkin-core/src/test/scala/com/twitter/finagle/zipkin/core/SamplingTracerTest.scala
+++ b/finagle-zipkin-core/src/test/scala/com/twitter/finagle/zipkin/core/SamplingTracerTest.scala
@@ -5,11 +5,11 @@ import com.twitter.util._
 import org.mockito.Mockito._
 import org.scalacheck.{Gen, Arbitrary}
 import org.scalatest.FunSuite
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import java.net.InetSocketAddress
 
-class ZipkinTracerTest extends FunSuite with MockitoSugar with GeneratorDrivenPropertyChecks {
+class ZipkinTracerTest extends FunSuite with MockitoSugar with ScalaCheckDrivenPropertyChecks {
   test("ZipkinTracer should handle sampling") {
     val traceId = TraceId(Some(SpanId(123)), Some(SpanId(123)), SpanId(123), None)
 


### PR DESCRIPTION
Problem

Many deprecated constructs make upgrading difficult

Solution

Update deprecated terms and language constructs

Result

Far fewer deprecation warnings
