### PR TITLE
Accept SameSite=None when creating cookies

### DIFF
--- a/finagle-base-http/src/main/scala/com/twitter/finagle/http/cookie/SameSite.scala
+++ b/finagle-base-http/src/main/scala/com/twitter/finagle/http/cookie/SameSite.scala
@@ -21,6 +21,8 @@ object SameSite {
 
   case object Strict extends SameSite
 
+  case object None extends SameSite
+
   /**
    * Represents the attribute not being set on the Cookie.
    */
@@ -34,6 +36,7 @@ object SameSite {
   def fromString(s: String): SameSite = s match {
     case "Lax" => Lax
     case "Strict" => Strict
+    case "None" => None
     case _ => Unset
   }
 

--- a/finagle-base-http/src/main/scala/com/twitter/finagle/http/cookie/SameSiteCodec.scala
+++ b/finagle-base-http/src/main/scala/com/twitter/finagle/http/cookie/SameSiteCodec.scala
@@ -57,6 +57,7 @@ private[http] object SameSiteCodec {
   def encodeSameSite(cookie: Cookie, encoded: String): String = cookie.sameSite match {
     case SameSite.Lax => encoded + "; SameSite=Lax"
     case SameSite.Strict => encoded + "; SameSite=Strict"
+    case SameSite.None => encoded + "; SameSite=None"
     case _ => encoded
   }
 
@@ -94,6 +95,7 @@ private[http] object SameSiteCodec {
       val sameSite =
         if (values.get(pos).equalsIgnoreCase("lax")) SameSite.Lax
         else if (values.get(pos).equalsIgnoreCase("strict")) SameSite.Strict
+        else if (values.get(pos).equalsIgnoreCase("none")) SameSite.None
         else SameSite.Unset
 
       cookie.sameSite(sameSite)

--- a/finagle-base-http/src/test/scala/com/twitter/finagle/http/CookieTest.scala
+++ b/finagle-base-http/src/test/scala/com/twitter/finagle/http/CookieTest.scala
@@ -23,8 +23,8 @@ class CookieTest extends FunSuite {
     assert(cookie.domain == "domain")
     assert(cookie.path == "path")
     assert(cookie.maxAge == 99.seconds)
-    assert(cookie.secure == true)
-    assert(cookie.httpOnly == false)
+    assert(cookie.secure)
+    assert(!cookie.httpOnly)
 
     /* Experimental */
     assert(cookie.sameSite == SameSite.Strict)
@@ -155,8 +155,8 @@ class CookieTest extends FunSuite {
     assert(cookie.value == "value2")
     assert(cookie.domain == "domain")
     assert(cookie.maxAge == 99.seconds)
-    assert(cookie.httpOnly == true)
-    assert(cookie.secure == true)
+    assert(cookie.httpOnly)
+    assert(cookie.secure)
 
     /* Experimental */
     assert(cookie.sameSite == SameSite.Lax)


### PR DESCRIPTION
Problem

The `SameSite` attribute is intended to accept `Lax`, `Strict` and `None` as values (0). Currently, only `Lax` and `Strict` is supported. 

Also, as motivation, Chrome is supposedly planning to treat `SameSite=None` as a way to signal you want to use x-site cookies as of February 2020 (1).

Solution

Added `None` in the sealed trait as a valid case. 

Result

You can set `SameSite=None` in the cookie.

(0): https://tools.ietf.org/html/draft-west-first-party-cookies-07
(1): https://blog.chromium.org/2019/05/improving-privacy-and-security-on-web.html