### PR TITLE
finagle-grpc-context: 2.13 cross build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -734,7 +734,8 @@ lazy val finagleGrpcContext = Project(
   id = "finagle-grpc-context",
   base = file("finagle-grpc-context")
 ).settings(
-  sharedSettings
+  sharedSettings,
+  withTwoThirteen
 ).settings(
   name := "finagle-grpc-context",
   libraryDependencies ++= Seq(


### PR DESCRIPTION
Problem

no 2.13 build for finagle-grpc-context

Solution

enable 2.13 in build. Trivial change.
