### PR TITLE
Enable scala 2.13 on finagle-exp

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -724,7 +724,8 @@ lazy val finagleExp = Project(
   id = "finagle-exp",
   base = file("finagle-exp")
 ).settings(
-  sharedSettings
+  sharedSettings,
+  withTwoThirteen
 ).settings(
   name := "finagle-exp",
   libraryDependencies ++= Seq(


### PR DESCRIPTION
Problem

finagle-exp is not available for scala 2.13 

Solution

add 2.13 for this module in build.sbt

Result

Have scala 2.13 support for this module

