### PR TITLE
Enable 2.13 build for finagle-zipkin-{core,scribe}

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -465,7 +465,8 @@ lazy val finagleZipkinCore = Project(
   id = "finagle-zipkin-core",
   base = file("finagle-zipkin-core")
 ).settings(
-  sharedSettings
+  sharedSettings,
+  withTwoThirteen
 ).settings(
   name := "finagle-zipkin-core",
   libraryDependencies ++= Seq(
@@ -478,7 +479,8 @@ lazy val finagleZipkinScribe = Project(
   id = "finagle-zipkin-scribe",
   base = file("finagle-zipkin-scribe")
 ).settings(
-  sharedSettings
+  sharedSettings,
+  withTwoThirteen
 ).settings(
   name := "finagle-zipkin-scribe",
   libraryDependencies ++= scroogeLibs

--- a/finagle-zipkin-core/src/main/scala/com/twitter/finagle/zipkin/core/DeadlineSpanMap.scala
+++ b/finagle-zipkin-core/src/main/scala/com/twitter/finagle/zipkin/core/DeadlineSpanMap.scala
@@ -102,7 +102,7 @@ private class DeadlineSpanMap(
     }
 
     if (beforeDeadline.isEmpty) Future.Done
-    else logSpans(beforeDeadline)
+    else logSpans(beforeDeadline.toSeq)
   }
 
   /**

--- a/finagle-zipkin-scribe/src/main/scala/com/twitter/finagle/zipkin/thrift/ScribeRawZipkinTracer.scala
+++ b/finagle-zipkin-scribe/src/main/scala/com/twitter/finagle/zipkin/thrift/ScribeRawZipkinTracer.scala
@@ -264,7 +264,7 @@ private[thrift] class ScribeRawZipkinTracer(
       }
     }
 
-    entries
+    entries.toSeq
   }
 
   /**

--- a/finagle-zipkin-scribe/src/test/scala/com/twitter/finagle/zipkin/thrift/ScribeRawZipkinTracerTest.scala
+++ b/finagle-zipkin-scribe/src/test/scala/com/twitter/finagle/zipkin/thrift/ScribeRawZipkinTracerTest.scala
@@ -4,10 +4,10 @@ import com.twitter.conversions.DurationOps._
 import com.twitter.finagle.service.TimeoutFilter
 import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.finagle.tracing._
-import com.twitter.finagle.zipkin.core.{BinaryAnnotation, Span, ZipkinAnnotation, Endpoint}
-import com.twitter.finagle.zipkin.thriftscala.{Scribe, ResultCode, LogEntry}
+import com.twitter.finagle.zipkin.core.{BinaryAnnotation, Endpoint, Span, ZipkinAnnotation}
+import com.twitter.finagle.zipkin.thriftscala.{LogEntry, ResultCode, Scribe}
 import com.twitter.util._
-import java.net.{InetSocketAddress, InetAddress}
+import java.net.{InetAddress, InetSocketAddress}
 import org.scalatest.FunSuite
 
 class ScribeRawZipkinTracerTest extends FunSuite {
@@ -17,7 +17,7 @@ class ScribeRawZipkinTracerTest extends FunSuite {
   class ScribeClient extends Scribe.FutureIface {
     var messages: Seq[LogEntry] = Seq.empty[LogEntry]
     var response: Future[ResultCode] = Future.value(ResultCode.Ok)
-    def log(msgs: Seq[LogEntry]): Future[ResultCode] = {
+    def log(msgs: scala.collection.Seq[LogEntry]): Future[ResultCode] = {
       messages ++= msgs
       response
     }


### PR DESCRIPTION
finagle-zipkin-{core,scribe}: Compile for scala 2.13

Problem

finagle-zipkin-{core,scribe} is not available for scala 2.13

Solution

Cross compile the modules for scala 2.13

Result
Have finagle-zipkin-{core,scribe} available for scala 2.13
