### PR TITLE
Enable 2.13 build for finagle-exception

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -488,7 +488,8 @@ lazy val finagleException = Project(
   id = "finagle-exception",
   base = file("finagle-exception")
 ).settings(
-  sharedSettings
+  sharedSettings,
+  withTwoThirteen
 ).settings(
   name := "finagle-exception",
   libraryDependencies ++= Seq(


### PR DESCRIPTION
finagle-exception: Compile for scala 2.13

Problem

Finagle-exception is not available for scala 2.13

Solution

Cross compile the module for scala 2.13

Result
Have finagle-exception available for scala 2.13

It turns out there are no collection changes in this module

All tests pass when running sbt +finagle-exception/test
