### PR TITLE
finagle-serversets: -> 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -504,7 +504,8 @@ lazy val finagleServersets = Project(
   id = "finagle-serversets",
   base = file("finagle-serversets")
 ).settings(
-  sharedSettings
+  sharedSettings,
+  withTwoThirteen
 ).settings(
   name := "finagle-serversets",
   libraryDependencies ++= Seq(

--- a/finagle-serversets/src/main/scala/com/twitter/finagle/serverset2/Entry.scala
+++ b/finagle-serversets/src/main/scala/com/twitter/finagle/serverset2/Entry.scala
@@ -1,7 +1,7 @@
 package com.twitter.finagle.serverset2
 
-import collection.JavaConverters._
-import collection.mutable.ArrayBuffer
+import scala.collection.mutable.ArrayBuffer
+import scala.jdk.CollectionConverters._
 
 import com.twitter.util.Memoize
 

--- a/finagle-serversets/src/main/scala/com/twitter/finagle/serverset2/Parse.scala
+++ b/finagle-serversets/src/main/scala/com/twitter/finagle/serverset2/Parse.scala
@@ -1,7 +1,7 @@
 package com.twitter.finagle.serverset2
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 
 private[serverset2] object IntObj {

--- a/finagle-serversets/src/main/scala/com/twitter/finagle/serverset2/ZkNodeDataCache.scala
+++ b/finagle-serversets/src/main/scala/com/twitter/finagle/serverset2/ZkNodeDataCache.scala
@@ -8,7 +8,7 @@ import com.twitter.io.Buf
 import com.twitter.logging.{Level, Logger}
 import com.twitter.util.Future
 import java.util.concurrent.atomic.AtomicReference
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /**
  * A cache for the members and vectors of a given cluster (/twitter/service/role/env/job).

--- a/finagle-serversets/src/main/scala/com/twitter/finagle/serverset2/client/apache/ApacheZooKeeper.scala
+++ b/finagle-serversets/src/main/scala/com/twitter/finagle/serverset2/client/apache/ApacheZooKeeper.scala
@@ -8,7 +8,7 @@ import com.twitter.util._
 import com.twitter.finagle.serverset2.client._
 import org.apache.zookeeper
 import org.apache.zookeeper.AsyncCallback._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /**
  * ZooKeeperClient implementation based on Apache ZooKeeper Library
@@ -86,7 +86,7 @@ private[serverset2] class ApacheZooKeeper private[apache] (zk: zookeeper.ZooKeep
     val cb = new VoidCallback {
       def processResult(ret: Int, path: String, ctx: Object) =
         ApacheKeeperException(ret, Option(path)) match {
-          case None => rv.setValue(Unit)
+          case None => rv.setValue(())
           case Some(e) => rv.setException(e)
         }
     }
@@ -306,7 +306,7 @@ private[serverset2] class ApacheZooKeeper private[apache] (zk: zookeeper.ZooKeep
     val cb = new VoidCallback {
       def processResult(ret: Int, path: String, ctx: Object) =
         ApacheKeeperException(ret, Option(path)) match {
-          case None => rv.setValue(Unit)
+          case None => rv.setValue(())
           case Some(e) => rv.setException(e)
         }
     }

--- a/finagle-serversets/src/main/scala/com/twitter/finagle/serverset2/client/types.scala
+++ b/finagle-serversets/src/main/scala/com/twitter/finagle/serverset2/client/types.scala
@@ -1,6 +1,7 @@
 package com.twitter.finagle.serverset2.client
 
 import com.twitter.io.Buf
+import scala.collection.Seq
 
 private[serverset2] object Perms {
   val Read: Int = 1 << 0

--- a/finagle-serversets/src/main/scala/com/twitter/finagle/zookeeper/ZkAnnouncer.scala
+++ b/finagle-serversets/src/main/scala/com/twitter/finagle/zookeeper/ZkAnnouncer.scala
@@ -6,8 +6,8 @@ import com.twitter.finagle.{Announcer, Announcement}
 import com.twitter.util.{Future, Promise}
 import java.net.InetSocketAddress
 import java.util.concurrent.LinkedBlockingQueue
-import scala.collection.JavaConverters._
 import scala.collection.mutable
+import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 
 /**

--- a/finagle-serversets/src/main/scala/com/twitter/finagle/zookeeper/ZkClientFactory.scala
+++ b/finagle-serversets/src/main/scala/com/twitter/finagle/zookeeper/ZkClientFactory.scala
@@ -8,8 +8,8 @@ import com.twitter.util.Duration
 import java.net.InetSocketAddress
 import org.apache.zookeeper.Watcher.Event.KeeperState
 import org.apache.zookeeper.{Watcher, WatchedEvent}
-import scala.collection.JavaConverters._
 import scala.collection._
+import scala.jdk.CollectionConverters._
 
 private[finagle] class ZooKeeperHealthHandler extends Watcher {
   private[this] val mu = new AsyncMutex

--- a/finagle-serversets/src/main/scala/com/twitter/finagle/zookeeper/ZkResolver.scala
+++ b/finagle-serversets/src/main/scala/com/twitter/finagle/zookeeper/ZkResolver.scala
@@ -11,8 +11,8 @@ import com.twitter.thrift.{Endpoint, ServiceInstance}
 import com.twitter.util.Var
 import java.net.InetSocketAddress
 import java.util.logging.{Level, Logger}
-import scala.collection.JavaConverters._
 import scala.collection.mutable
+import scala.jdk.CollectionConverters._
 
 /**
  * Indicates that a failure occurred while attempting to resolve a cluster

--- a/finagle-serversets/src/test/scala/com/twitter/finagle/serverset2/EntryTest.scala
+++ b/finagle-serversets/src/test/scala/com/twitter/finagle/serverset2/EntryTest.scala
@@ -37,10 +37,14 @@ class EntryTest extends FunSuite {
 
   test("Endpoint.parseJson: ok input same hostports") {
     val eps = Endpoint.parseJson(exampleJson2)
-    assert(
-      eps ==
-        Seq(Endpoint(Array(null, "aurora", "http"), "10.0.0.1", port, 0, Endpoint.Status.Alive, ""))
-    )
+    assert(eps.size == 1)
+    val ep = eps.head
+    assert(ep.names.toSet == Set(null, "aurora", "http"))
+    assert(ep.host == "10.0.0.1")
+    assert(ep.port == port)
+    assert(ep.shard == 0)
+    assert(ep.status == Endpoint.Status.Alive)
+    assert(ep.memberId.isEmpty)
   }
 
   test("Endpoint.parseJson: bad input") {

--- a/finagle-serversets/src/test/scala/com/twitter/finagle/serverset2/Zk2ResolverTest.scala
+++ b/finagle-serversets/src/test/scala/com/twitter/finagle/serverset2/Zk2ResolverTest.scala
@@ -12,7 +12,7 @@ import org.scalatest.concurrent.Eventually
 import org.scalatest.concurrent.PatienceConfiguration
 import org.scalatest.time.{Span, SpanSugar}
 import org.scalatest.{BeforeAndAfter, FunSuite, Tag}
-import scala.collection.JavaConverters.mapAsJavaMapConverter
+import scala.jdk.CollectionConverters._
 
 class Zk2ResolverTest
     extends FunSuite

--- a/finagle-serversets/src/test/scala/com/twitter/finagle/serverset2/client/apache/ApacheZooKeeperTest.scala
+++ b/finagle-serversets/src/test/scala/com/twitter/finagle/serverset2/client/apache/ApacheZooKeeperTest.scala
@@ -12,7 +12,8 @@ import org.mockito.Matchers.{eq => meq}
 import org.mockito.Mockito.{doNothing, doThrow, verify, when}
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{FunSuite, OneInstancePerTest}
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
+
 class ApacheZooKeeperTest extends FunSuite with MockitoSugar with OneInstancePerTest {
   val statsReceiver = new InMemoryStatsReceiver
   val mockZK = mock[org.apache.zookeeper.ZooKeeper]

--- a/finagle-serversets/src/test/scala/com/twitter/finagle/zookeeper/ZkResolverTest.scala
+++ b/finagle-serversets/src/test/scala/com/twitter/finagle/zookeeper/ZkResolverTest.scala
@@ -9,7 +9,7 @@ import java.net.InetSocketAddress
 import org.scalatest.{BeforeAndAfter, FunSuite}
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.time._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class ZkResolverTest extends FunSuite with BeforeAndAfter {
   val zkTimeout = 100.milliseconds


### PR DESCRIPTION
Problem

no 2.13 cross build

Solution
  * Use `scala.jdk.CollectionConverters` from collection-compat
  * Replace usages of `Unit` as a value with `()`
  * `EntryTest` - don't observe the order of keys in a map

Result

`finagle-serversets` compiles on 2.13 and tests are passing.

Ref #771