### PR TITLE
finagle-benchmark-thrift: -> 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -798,7 +798,8 @@ lazy val finagleBenchmarkThrift = Project(
   id = "finagle-benchmark-thrift",
   base = file("finagle-benchmark-thrift")
 ).settings(
-  sharedSettings
+  sharedSettings,
+  withTwoThirteen
 ).settings(
   libraryDependencies ++= scroogeLibs
 ).dependsOn(finagleThrift)


### PR DESCRIPTION
Problem

no 2.13 cross build

Solution

Add Scala 2.13 to the project settings.

Result

`finagle-benchmark-thrift` compiles on 2.13

Ref #771 