### PR TITLE
Fix typos

### DIFF
--- a/doc/src/sphinx/FAQ.rst
+++ b/doc/src/sphinx/FAQ.rst
@@ -63,7 +63,7 @@ a :API:`ClientDiscardedRequestException <com/twitter/finagle/mux/ClientDiscarded
 is the same as above though.
 
 Server operators may prefer to measure their server side success rates excluding these classes of
-exceptions. The rationale is that these failures don't neccessarily represent a server side issue
+exceptions. The rationale is that these failures don't necessarily represent a server side issue
 and are dependent on client side configuration (e.g. timeouts). The recommended way to achieve this
 is to configure a custom `com.twitter.finagle.service.ResponseClassifier` via `$Protocol.server.withResponseClassifier(...)`.
 

--- a/doc/src/sphinx/developers/Futures.rst
+++ b/doc/src/sphinx/developers/Futures.rst
@@ -146,7 +146,7 @@ Detachable
 ~~~~~~~~~~
 
 When more than one execution dependency depends on the result of a future, it can be dangerous to
-interrupt it, since you might inadvertantly fail other folks' work.  However, if you never interrupt
+interrupt it, since you might inadvertently fail other folks' work.  However, if you never interrupt
 it, you can end up with memory leaks if the future is never satisfied and we continuously add work
 to it.  Detachable Promises are an attempt to fix this, so that we can mark promises as "may not be
 needed later, though the underlying future they depend on will be useful", and must be

--- a/doc/src/sphinx/metrics/Mux.rst
+++ b/doc/src/sphinx/metrics/Mux.rst
@@ -38,13 +38,13 @@
   mux framing is enabled.
 
 **<label>/mux/framer/pending_write_streams**
-  A guage of the number of outstanding write streams when mux framing is enabled.
+  A gauge of the number of outstanding write streams when mux framing is enabled.
 
 **<label>/mux/framer/pending_read_streams**
-  A guage of the number of outstanding read streams when mux framing is enabled.
+  A gauge of the number of outstanding read streams when mux framing is enabled.
 
 **<label>/mux/framer/write_window_bytes**
-  A guage indicating the maximum size of fragments when mux framing is enabled.
+  A gauge indicating the maximum size of fragments when mux framing is enabled.
   A value of -1 means that writes are not fragmented.
 
 **<label>/mux/transport/read/failures/**

--- a/finagle-base-http/src/main/scala/com/twitter/finagle/http/codec/context/LoadableHttpContext.scala
+++ b/finagle-base-http/src/main/scala/com/twitter/finagle/http/codec/context/LoadableHttpContext.scala
@@ -11,7 +11,7 @@ import com.twitter.util.{Base64StringEncoder, Try}
  * LoadableHttpContext will by default use [[com.twitter.finagle.context.Contexts.broadcast.Key]]'s
  * `marshal`, `tryUnmarshal` and `id` to create the header (key: String, value: String) pairs. The
  * result of `marshal` is base64 encoded. Exceptions thrown from `tryUnmarshal` or `fromHeader` will
- * be supressed and only the faulty key name will be logged (debug level).
+ * be suppressed and only the faulty key name will be logged (debug level).
  *
  *
  * Override the methods of [[HttpContext]] to define a custom scheme. All headers are prefixed with

--- a/finagle-base-http/src/main/scala/com/twitter/finagle/http/filter/DtabFilter.scala
+++ b/finagle-base-http/src/main/scala/com/twitter/finagle/http/filter/DtabFilter.scala
@@ -72,7 +72,7 @@ object DtabFilter {
     def apply(req: Request, service: Service[Request, Response]): Future[Response] = {
       // Log errors if a request already has dtab headers AND they
       // were not set by this filter (i.e. on a previous attempt at
-      // emiting this request).
+      // emitting this request).
       val dtabHeaders = strip(req)
       if (dtabHeaders.nonEmpty && !req.ctx(HasSetDtab)) {
         // Log an error immediately if we find any Dtab headers already in the request and report them

--- a/finagle-core/src/main/scala/com/twitter/finagle/tracing/Tracing.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/tracing/Tracing.scala
@@ -19,7 +19,7 @@ object Tracing {
   )
 
   /**
-   * Some tracing systems such as Amazon X-Ray encode the orginal timestamp in
+   * Some tracing systems such as Amazon X-Ray encode the original timestamp in
    * order to enable even partitions in the backend. As sampling only occurs on
    * low 64-bits anyway, we encode epoch seconds into high-bits to support
    * downstreams who have a timestamp requirement.

--- a/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/aperture/ApertureTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/aperture/ApertureTest.scala
@@ -355,7 +355,7 @@ class ApertureTest extends FunSuite with ApertureSuite {
     // should be available due to the single endpoint
     assert(bal.status == Status.Open)
 
-    // should be moved foward on rebuild
+    // should be moved forward on rebuild
     val svc = Await.result(bal(ClientConnection.nil))
     assert(bal.rebuilds == 1)
     assert(bal.status == Status.Open)

--- a/finagle-memcached/src/main/scala/com/twitter/finagle/memcached/Client.scala
+++ b/finagle-memcached/src/main/scala/com/twitter/finagle/memcached/Client.scala
@@ -377,7 +377,7 @@ trait BaseClient[T] extends Closable {
    * client but is in reality a string-encoded u64.
    *
    * @return a Map[String, (T, Buf, Buf)] of all the keys
-   * the server had, together with ther "cas unique" token and flags
+   * the server had, together with their "cas unique" token and flags
    * @see [[get]] if you do not need the token or the flags.
    * @see [[gets]] if you do not need the flag.
    * @see [[getWithFlag]] if you do not need the token.

--- a/finagle-partitioning/src/main/scala/com/twitter/finagle/partitioning/CacheNodeMetadata.scala
+++ b/finagle-partitioning/src/main/scala/com/twitter/finagle/partitioning/CacheNodeMetadata.scala
@@ -14,7 +14,7 @@ import com.twitter.finagle.Addr
  * [[com.twitter.finagle.Address]]s.
  *
  * @param weight The weight of the cache node. Default value is 1. Note that this determines where
- * data is stored in the Ketama ring and is not interchangable with the notion of weight in
+ * data is stored in the Ketama ring and is not interchangeable with the notion of weight in
  * [[com.twitter.finagle.addr.WeightedAddress]], which pertains to load balancing.
  * @param key An optional unique identifier for the cache node (e.g.  shard ID).
  */

--- a/finagle-serversets/src/main/java/com/twitter/finagle/common/util/TruncatedBinaryBackoff.java
+++ b/finagle-serversets/src/main/java/com/twitter/finagle/common/util/TruncatedBinaryBackoff.java
@@ -34,7 +34,7 @@ public class TruncatedBinaryBackoff implements BackoffStrategy {
    * which point shouldContinue() will return false and any future backoffs will always wait for
    * that amount of time.
    *
-   * @param initialBackoff the intial amount of time to backoff
+   * @param initialBackoff the initial amount of time to backoff
    * @param maxBackoff the maximum amount of time to backoff
    * @param stopAtMax whether shouldContinue() returns false when the max is reached
    */
@@ -56,7 +56,7 @@ public class TruncatedBinaryBackoff implements BackoffStrategy {
   /**
    * Same as main constructor, but this will always return true from shouldContinue().
    *
-   * @param initialBackoff the intial amount of time to backoff
+   * @param initialBackoff the initial amount of time to backoff
    * @param maxBackoff the maximum amount of time to backoff
    */
   public TruncatedBinaryBackoff(Duration initialBackoff, Duration maxBackoff) {


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos.