### PR TITLE
finagle-opencensus-tracing: upgraded opencensus and added TextFormat param

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ Unreleased
 New Features
 ~~~~~~~~~~~~
 
+* finagle-opencensus-tracing: Add support for providing a custom TextFormat for header propagation.
+
+* finagle-opencensus-tracing: Fixed internal server error when invalid or no propagation headers are provided.
+
 * finagle-thriftmux: Add support for automatically negotiating compression between a client
   and server.  Off by default, clients and servers must be configured to negotiate.
   ``PHAB_ID=D414638``

--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,7 @@ val netty4LibsTest = Seq(
 val netty4Http = "io.netty" % "netty-codec-http" % netty4Version
 val netty4Http2 = "io.netty" % "netty-codec-http2" % netty4Version
 val netty4StaticSsl = "io.netty" % "netty-tcnative-boringssl-static" % netty4StaticSslVersion
-val opencensusVersion = "0.19.1"
+val opencensusVersion = "0.24.0"
 val jacksonVersion = "2.9.10"
 val jacksonDatabindVersion = "2.9.10.1"
 val jacksonLibs = Seq(
@@ -805,7 +805,8 @@ lazy val finagleOpenCensusTracing = Project(
   name := "finagle-opencensus-tracing",
   libraryDependencies ++= Seq(
     "io.opencensus" % "opencensus-api" % opencensusVersion,
-    "io.opencensus" % "opencensus-impl" % opencensusVersion
+    "io.opencensus" % "opencensus-impl" % opencensusVersion,
+    "io.opencensus" % "opencensus-contrib-http-util" % opencensusVersion % "test",
   ) ++ scroogeLibs
 ).dependsOn(
   finagleCore,

--- a/finagle-opencensus-tracing/src/main/scala/com/twitter/finagle/tracing/opencensus/StackClientOps.scala
+++ b/finagle-opencensus-tracing/src/main/scala/com/twitter/finagle/tracing/opencensus/StackClientOps.scala
@@ -44,7 +44,8 @@ object StackClientOps {
   }
 
   implicit final class HttpOpenCensusTracing(private val client: Http.Client) extends AnyVal {
-    def withOpenCensusTracing: Http.Client =
+    def withOpenCensusTracing: Http.Client = withOpenCensusTracing()
+    def withOpenCensusTracing(textFormat:TextFormat = Tracing.getPropagationComponent.getB3Format): Http.Client =
       client.withStack { stack =>
         // serialization must happen after we attach the OpenCensus span
         stack
@@ -52,13 +53,12 @@ object StackClientOps {
             TraceInitializerFilter.role,
             ClientTraceContextFilter.module[http.Request, http.Response]
           )
-          .replace(TraceInitializerFilter.role, httpSerializeModule)
+          .replace(TraceInitializerFilter.role, httpSerializeModule(textFormat))
       }
   }
 
-  private[this] val httpSerializeFilter: SimpleFilter[http.Request, http.Response] =
+  private[this] def httpSerializeFilter(textFormat:TextFormat): SimpleFilter[http.Request, http.Response] =
     new SimpleFilter[http.Request, http.Response] {
-      private[this] val textFormat = Tracing.getPropagationComponent.getB3Format
       private[this] val setter = new TextFormat.Setter[http.Request] {
         def put(carrier: http.Request, key: String, value: String): Unit =
           carrier.headerMap.set(key, value)
@@ -80,12 +80,12 @@ object StackClientOps {
   private[opencensus] val HttpSerializationStackRole: Stack.Role =
     Stack.Role("OpenCensusHeaderSerialization")
 
-  private[this] val httpSerializeModule: Stackable[ServiceFactory[http.Request, http.Response]] =
+  private[this] def httpSerializeModule(textFormat:TextFormat): Stackable[ServiceFactory[http.Request, http.Response]] =
     new Stack.Module0[ServiceFactory[http.Request, http.Response]] {
       def make(
         next: ServiceFactory[http.Request, http.Response]
       ): ServiceFactory[http.Request, http.Response] =
-        httpSerializeFilter.andThen(next)
+        httpSerializeFilter(textFormat).andThen(next)
 
       def role: Stack.Role = HttpSerializationStackRole
 

--- a/finagle-opencensus-tracing/src/main/scala/com/twitter/finagle/tracing/opencensus/StackServerOps.scala
+++ b/finagle-opencensus-tracing/src/main/scala/com/twitter/finagle/tracing/opencensus/StackServerOps.scala
@@ -2,7 +2,7 @@ package com.twitter.finagle.tracing.opencensus
 
 import com.twitter.finagle.context.Contexts
 import com.twitter.finagle._
-import com.twitter.util.Future
+import com.twitter.util.{Future, Try}
 import io.opencensus.trace.{SpanContext, Tracing}
 import io.opencensus.trace.propagation.TextFormat
 
@@ -44,18 +44,18 @@ object StackServerOps {
   }
 
   implicit final class HttpOpenCensusTracing(private val server: Http.Server) extends AnyVal {
-    def withOpenCensusTracing: Http.Server = {
+    def withOpenCensusTracing: Http.Server = withOpenCensusTracing()
+    def withOpenCensusTracing(textFormat:TextFormat = Tracing.getPropagationComponent.getB3Format): Http.Server = {
       server.withStack { stack =>
         stack
           .prepend(ServerTraceContextFilter.module)
-          .prepend(httpDeserModule) // attach to broadcast ctx before setting OC
+          .prepend(httpDeserModule(textFormat)) // attach to broadcast ctx before setting OC
       }
     }
   }
 
-  private val httpDeserFilter: SimpleFilter[http.Request, http.Response] =
+  private def httpDeserFilter(textFormat:TextFormat): SimpleFilter[http.Request, http.Response] =
     new SimpleFilter[http.Request, http.Response] {
-      private[this] val textFormat = Tracing.getPropagationComponent.getB3Format
       private[this] val getter = new TextFormat.Getter[http.Request] {
         def get(carrier: http.Request, key: String): String =
           carrier.headerMap.getOrNull(key)
@@ -65,7 +65,7 @@ object StackServerOps {
         request: http.Request,
         service: Service[http.Request, http.Response]
       ): Future[http.Response] = {
-        val spanContext = textFormat.extract(request, getter)
+        val spanContext = Try(textFormat.extract(request, getter)).getOrElse(SpanContext.INVALID)
         if (spanContext != SpanContext.INVALID) {
           Contexts.broadcast.let(TraceContextFilter.SpanContextKey, spanContext) {
             service(request)
@@ -80,12 +80,12 @@ object StackServerOps {
   private[opencensus] val HttpDeserializationStackRole: Stack.Role =
     Stack.Role("OpenCensusHeaderDeserialization")
 
-  private val httpDeserModule: Stackable[ServiceFactory[http.Request, http.Response]] =
+  private def httpDeserModule(textFormat:TextFormat): Stackable[ServiceFactory[http.Request, http.Response]] =
     new Stack.Module0[ServiceFactory[http.Request, http.Response]] {
       def make(
         next: ServiceFactory[http.Request, http.Response]
       ): ServiceFactory[http.Request, http.Response] =
-        httpDeserFilter.andThen(next)
+        httpDeserFilter(textFormat).andThen(next)
 
       def role: Stack.Role = HttpDeserializationStackRole
 

--- a/finagle-opencensus-tracing/src/test/scala/com/twitter/finagle/tracing/opencensus/HttpEndToEndTest.scala
+++ b/finagle-opencensus-tracing/src/test/scala/com/twitter/finagle/tracing/opencensus/HttpEndToEndTest.scala
@@ -8,6 +8,9 @@ import com.twitter.util.{Await, Duration, Future}
 import io.opencensus.trace.{SpanContext, Tracing}
 import java.net.{InetAddress, InetSocketAddress}
 import java.util.concurrent.atomic.AtomicReference
+
+import io.opencensus.contrib.http.util.HttpPropagationUtil
+import io.opencensus.trace.propagation.TextFormat
 import org.scalatest.FunSuite
 
 class HttpEndToEndTest extends FunSuite {
@@ -15,14 +18,57 @@ class HttpEndToEndTest extends FunSuite {
   private def await[T](f: Future[T]): T =
     Await.result(f, Duration.fromSeconds(15))
 
-  private def httpServer: Http.Server = {
+  private def httpServer(textFormat:TextFormat = Tracing.getPropagationComponent.getB3Format): Http.Server = {
     import com.twitter.finagle.tracing.opencensus.StackServerOps._
-    Http.server.withOpenCensusTracing
+    Http.server.withOpenCensusTracing(textFormat)
   }
 
-  private def httpClient: Http.Client = {
+  private def httpClient(textFormat:TextFormat = Tracing.getPropagationComponent.getB3Format): Http.Client = {
     import com.twitter.finagle.tracing.opencensus.StackClientOps._
-    Http.client.withOpenCensusTracing
+    Http.client.withOpenCensusTracing(textFormat)
+  }
+
+  test("SpanContext is propagated when using CloudTraceFormat") {
+    val spanCtx = new AtomicReference[SpanContext](SpanContext.INVALID)
+
+    val svc: Service[Request, Response] = Service.mk { req =>
+      val rep = Contexts.broadcast.get(TraceContextFilter.SpanContextKey) match {
+        case None =>
+          val rep = Response(Status.BadRequest)
+          rep.contentString = "Broadcast context not set"
+          rep
+        case Some(ctx) if ctx.getTraceId != spanCtx.get.getTraceId =>
+          val rep = Response(Status.BadRequest)
+          rep.contentString =
+            s"TraceId mismatch, expected ${spanCtx.get.getTraceId}, but was ${ctx.getTraceId}"
+          rep
+        case Some(_) =>
+          Response(Status.Ok)
+      }
+
+      Future.value(rep)
+    }
+    val server = httpServer(HttpPropagationUtil.getCloudTraceFormat).serve(
+      new InetSocketAddress(InetAddress.getLoopbackAddress, 0),
+      svc
+    )
+    val client = httpClient(HttpPropagationUtil.getCloudTraceFormat).newService(
+      Name.bound(Address(server.boundAddress.asInstanceOf[InetSocketAddress])),
+      "cheese-processor"
+    )
+
+    val span = Tracing.getTracer
+      .spanBuilder("test")
+      .startSpan()
+    assert(span.getContext.isValid)
+    span.scopedAndEnd {
+      spanCtx.set(Tracing.getTracer.getCurrentSpan.getContext)
+
+      val rep = await(client(Request()))
+      assert(Status.Ok == rep.status, rep.contentString)
+    }
+    client.close()
+    server.close()
   }
 
   test("SpanContext is propagated") {
@@ -45,11 +91,11 @@ class HttpEndToEndTest extends FunSuite {
 
       Future.value(rep)
     }
-    val server = httpServer.serve(
+    val server = httpServer().serve(
       new InetSocketAddress(InetAddress.getLoopbackAddress, 0),
       svc
     )
-    val client = httpClient.newService(
+    val client = httpClient().newService(
       Name.bound(Address(server.boundAddress.asInstanceOf[InetSocketAddress])),
       "cheese-processor"
     )


### PR DESCRIPTION
Problem

B3Format is currently the only propagation method we can use.
Invalid or missing propagation headers result in a 500
response.

Solution

raised opencensusVersion in build.sbt to "0.24.0"

added optional TextFormat parameter to the withOpenCensusTracing for both Server
and Client that defaults to previously used B3Format

in StackServerOps.scala previous version seemed to expect SpanContext.INVALID as
a failure result from TextFormat.extract, which was incorrect.  This resulted in
missing or invalid propagation headers causing a 500 response.
TextFormat.extract throws an exception on bad or missing data, which is now
treated as SpanContext.INVALID

added a test dependency to opencensus-contrib-http-util which provides an
implementation of TextFormat for stackdriver style "x-cloud-trace-context"
headers.

added copy of existing test that uses the CloudTraceFormat from
opencensus-contrib-http-util

Result

You can now use other forms of tracing header propagation, i.e. the
CloudTraceFormat format from the opencensus-contrib-http-util package.