### PR TITLE
finagle-opencensus-tracing: -> 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -800,7 +800,8 @@ lazy val finagleOpenCensusTracing = Project(
   id = "finagle-opencensus-tracing",
   base = file("finagle-opencensus-tracing")
 ).settings(
-  sharedSettings
+  sharedSettings,
+  withTwoThirteen
 ).settings(
   name := "finagle-opencensus-tracing",
   libraryDependencies ++= Seq(


### PR DESCRIPTION
Problem

No cross-build for finagle-opencensus-tracing 2.13

Solution

include 2.13 in finagle-opencensus-tracing cross versions.