### PR TITLE
finagle-memcached: -> 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -668,7 +668,8 @@ lazy val finagleMemcached = Project(
   id = "finagle-memcached",
   base = file("finagle-memcached")
 ).settings(
-  sharedSettings
+  sharedSettings,
+  withTwoThirteen
 ).settings(
   name := "finagle-memcached",
   libraryDependencies ++= Seq(


### PR DESCRIPTION
Problem

No cross-build for finagle-memcached 2.13

Solution

include 2.13 in finagle-memcached cross versions.