### PR TITLE
finagle-memcached: update bijection-core to 0.9.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -674,7 +674,7 @@ lazy val finagleMemcached = Project(
   libraryDependencies ++= Seq(
     util("hashing"),
     util("zk-test") % "test",
-    "com.twitter" %% "bijection-core" % "0.9.4",
+    "com.twitter" %% "bijection-core" % "0.9.7",
     "org.apache.thrift" % "libthrift" % libthriftVersion
   ),
   libraryDependencies ++= jacksonLibs


### PR DESCRIPTION
Problem

bijection-core version is out of date, and there is no 2.13 release for the current version.

Solution

Update bijection-core version to 0.9.7

Result

Bijection-core dependency can be cross-built for 2.13