### PR TITLE
Initialize state in H2Pool before use in gauge

### DIFF
--- a/finagle-http2/src/main/scala/com/twitter/finagle/http2/transport/client/H2Pool.scala
+++ b/finagle-http2/src/main/scala/com/twitter/finagle/http2/transport/client/H2Pool.scala
@@ -78,6 +78,8 @@ private final class H2Pool(params: Params, stackFragment: Stack[ServiceFactory[R
     extends ServiceFactory[Request, Response] {
 
   import H2Pool._
+      
+  private[this] val state = new AtomicReference[State](State.H1)
 
   // This gauge will be nice during the rollout for debugging but it may
   // become DEBUG scoped or removed altogether after the rollout phase.
@@ -88,8 +90,6 @@ private final class H2Pool(params: Params, stackFragment: Stack[ServiceFactory[R
         case _ => 0.0f
       }
     }
-
-  private[this] val state = new AtomicReference[State](State.H1)
 
   @tailrec
   private[this] final def onH2Service(h2Session: Service[Request, Response]): Unit =


### PR DESCRIPTION
Problem

On gauge creation the `state` is not defined yet. This causes an NPE in the following cases:

* Some stats receivers (e.g. PrometheusStatsReceiver) eagerly evaluate the gauge probe on gauge creation.
* Calls to metrics endpoints before the client is completely initialized (very small chance.)

Solution

Define the state before the gauge to make sure that the state is always defined.

Result

No NPE will be thrown on evaluating the gauge.