### PR TITLE
finagle-mysql: Add connection init sql stack

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ Note that ``PHAB_ID=#`` and ``RB_ID=#`` correspond to associated messages in com
 Unreleased
 ----------
 
+New Features
+~~~~~~~~~~~~
+
+* finagle-mysql: Add `ConnectionInitSql` stack to set connection init sql.
+
 Runtime Behavior Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/finagle-mysql/src/main/scala/com/twitter/finagle/Mysql.scala
+++ b/finagle-mysql/src/main/scala/com/twitter/finagle/Mysql.scala
@@ -117,6 +117,7 @@ object Mysql extends com.twitter.finagle.Client[Request, Result] with MysqlRichC
       // Note: there is a stack overflow in insertAfter using CanStackFrom, thus the module.
       .insertAfter(DefaultPool.Role, PoisonConnection.module)
       .prepend(RollbackFactory.module)
+      .insertAfter(StackClient.Role.prepConn, ConnectionInitSql.module)
   }
 
   /**
@@ -246,6 +247,12 @@ object Mysql extends com.twitter.finagle.Client[Request, Result] with MysqlRichC
      */
     def withNoRollback: Client =
       withStack(stack.remove(RollbackFactory.Role))
+
+    /**
+     * The connection init request to use when establishing a new session.
+     */
+    def withConnectionInitRequest(request: Request): Client =
+      configured(ConnectionInitRequest(Some(request)))
 
     // Java-friendly forwarders
     // See https://issues.scala-lang.org/browse/SI-8905

--- a/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/ConnectionInitSql.scala
+++ b/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/ConnectionInitSql.scala
@@ -1,0 +1,33 @@
+package com.twitter.finagle.mysql
+
+import com.twitter.finagle._
+import com.twitter.finagle.mysql.param.ConnectionInitRequest
+import com.twitter.util._
+
+/**
+  * A stack module that executes a request when create a connection.
+  */
+object ConnectionInitSql {
+  val Role: Stack.Role = Stack.Role("ConnectionInitSql")
+
+  private[finagle] def module: Stackable[ServiceFactory[Request, Result]] =
+    new Stack.Module1[ConnectionInitRequest, ServiceFactory[Request, Result]] {
+      val role: Stack.Role = Role
+      val description: String = "Installs a connection init sql module in the stack"
+
+      def make(in: ConnectionInitRequest, next: ServiceFactory[Request, Result]): ServiceFactory[Request, Result] = {
+        in.request match {
+          case Some(req) =>
+            // we assume that this module added below the connection pool
+            next.flatMap { service =>
+              service(req).flatMap {
+                case Error(code, sqlState, message) =>
+                  Future.exception(ServerError(code, sqlState, message))
+                case _ => Future.value(service)
+              }
+            }
+          case None => next
+        }
+      }
+    }
+}

--- a/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/param/params.scala
+++ b/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/param/params.scala
@@ -2,6 +2,7 @@ package com.twitter.finagle.mysql.param
 
 import com.twitter.finagle.mysql.MysqlCharset.Utf8_general_ci
 import com.twitter.finagle.Stack
+import com.twitter.finagle.mysql.Request
 
 /**
  * A class eligible for configuring a mysql client's credentials during
@@ -80,4 +81,12 @@ object MaxConcurrentPrepareStatements {
 case class UnsignedColumns(supported: Boolean)
 object UnsignedColumns {
   implicit val param: Stack.Param[UnsignedColumns] = Stack.Param(UnsignedColumns(false))
+}
+
+/**
+ * A class eligible for configuring a initial request which used when establishing a new session.
+ */
+case class ConnectionInitRequest(request: Option[Request])
+object ConnectionInitRequest {
+  implicit val param: Stack.Param[ConnectionInitRequest] = Stack.Param(ConnectionInitRequest(None))
 }

--- a/finagle-mysql/src/test/scala/com/twitter/finagle/mysql/integration/ConnectionInitSqlTest.scala
+++ b/finagle-mysql/src/test/scala/com/twitter/finagle/mysql/integration/ConnectionInitSqlTest.scala
@@ -1,0 +1,25 @@
+package com.twitter.finagle.mysql.integration
+
+import com.twitter.conversions.DurationOps._
+import com.twitter.finagle.mysql.QueryRequest
+import com.twitter.util.{Await, Awaitable}
+import org.scalatest.{FunSuite, OptionValues}
+
+class ConnectionInitSqlTest extends FunSuite with IntegrationClient with OptionValues {
+
+  private[this] def await[T](t: Awaitable[T]): T = Await.result(t, 5.seconds)
+
+  override def configureClient(username: String, password: String, db: String) = {
+    super
+      .configureClient(username, password, db)
+      .withConnectionInitRequest(QueryRequest("SET @CIS_VAR = 99"))
+  }
+
+  test("get connection init request variable") {
+    val theClient = client.orNull
+    val result = await(theClient.select("SELECT @CIS_VAR as v") { row =>
+      row.getLong("v")
+    })
+    assert(result.headOption.value.value == 99L)
+  }
+}

--- a/finagle-mysql/src/test/scala/com/twitter/finagle/mysql/integration/MysqlBuilderTest.scala
+++ b/finagle-mysql/src/test/scala/com/twitter/finagle/mysql/integration/MysqlBuilderTest.scala
@@ -2,6 +2,7 @@ package com.twitter.finagle.mysql.integration
 
 import com.twitter.conversions.DurationOps._
 import com.twitter.finagle.Mysql
+import com.twitter.finagle.mysql.QueryRequest
 import com.twitter.finagle.param
 import com.twitter.finagle.tracing._
 import com.twitter.util.{Await, Awaitable}
@@ -32,6 +33,7 @@ class MysqlBuilderTest extends FunSuite with IntegrationClient {
         .withDatabase("test")
         .withCredentials(username, password)
         .withDatabase(db)
+        .withConnectionInitRequest(QueryRequest("SET SESSION sql_mode='TRADITIONAL,NO_AUTO_VALUE_ON_ZERO,ONLY_FULL_GROUP_BY'"))
         .newRichClient("localhost:3306")
 
       ready(client.query("SELECT 1"))


### PR DESCRIPTION
## Problem

Sometimes we want to execute settings query after create connection.
Currently there is no api to add connection-init-sql.

## Solution

Add connection-init-request api into mysql client. this is based on HikariCP `connectionInitSql`.

ref: https://github.com/brettwooldridge/HikariCP/blob/dev/README.md#infrequently-used
![image](https://user-images.githubusercontent.com/915731/78548706-29084480-783c-11ea-8d03-4b1e48521600.png)

----

This feature is possible to implement in user applications using stack.
If you don't want to add this feature into finagle-mysql, please let me know and close this PR 🙏 