### PR TITLE
finagle-redis: Add connection init commands for select and auth

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ Note that ``PHAB_ID=#`` and ``RB_ID=#`` correspond to associated messages in com
 Unreleased
 ----------
 
+New Features
+~~~~~~~~~~~~
+
+* finagle-redis: Add `ConnectionInitCommand` stack to set database and password.
+
 Runtime Behavior Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/finagle-redis/src/it/scala/com/twitter/finagle/redis/stacks/ConnectionInitCommandIntegrationSuite.scala
+++ b/finagle-redis/src/it/scala/com/twitter/finagle/redis/stacks/ConnectionInitCommandIntegrationSuite.scala
@@ -1,0 +1,51 @@
+package com.twitter.finagle.redis.integration
+
+import com.twitter.conversions.DurationOps._
+import com.twitter.finagle.redis.tags.{ClientTest, RedisTest}
+import com.twitter.finagle.redis.util.RedisCluster
+import com.twitter.finagle.redis.{RedisClientTest, ServerError}
+import com.twitter.finagle.{Redis, redis}
+import com.twitter.util.{Await, Future}
+
+final class ConnectionInitCommandIntegrationSuite extends RedisClientTest {
+
+  def await[A](a: Future[A]): A = Await.result(a, 5.seconds)
+
+  test("Correctly perform using database", RedisTest, ClientTest) {
+    val client1 = redis.Client(
+      Redis.client.withDatabase(1)
+        .newClient(RedisCluster.hostAddresses())
+    )
+    val client2 = redis.Client(
+      Redis.client.withDatabase(2)
+        .newClient(RedisCluster.hostAddresses())
+    )
+    await(client1.flushAll())
+    await(client2.flushAll())
+    try {
+      val sameKey = bufFoo
+      await(client1.set(sameKey, bufBar))
+      await(client2.set(sameKey, bufBaz))
+      assert(await(client1.get(sameKey)).get == bufBar)
+      assert(await(client2.get(sameKey)).get == bufBaz)
+    } finally {
+      await(client1.close())
+      await(client2.close())
+    }
+  }
+
+  test("Correctly perform auth command", RedisTest, ClientTest) {
+    val client = redis.Client(
+      Redis.client.withPassword(bufFoo)
+        .newClient(RedisCluster.hostAddresses())
+    )
+    try {
+      val th = intercept[ServerError] {
+        await(client.get(bufFoo))
+      }
+      assert(th.message.contains("ERR Client sent AUTH, but no password is set"))
+    } finally {
+      await(client.close())
+    }
+  }
+}

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/exp/ConnectionInitCommand.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/exp/ConnectionInitCommand.scala
@@ -1,0 +1,42 @@
+package com.twitter.finagle.redis.exp
+
+import com.twitter.finagle._
+import com.twitter.finagle.redis.ServerError
+import com.twitter.finagle.redis.param.{Database, Password}
+import com.twitter.finagle.redis.protocol._
+import com.twitter.util.Future
+
+/**
+ * A stack module that executes commands when create a new connection.
+ */
+object ConnectionInitCommand {
+
+  val Role = Stack.Role("RedisInitialCommand")
+
+  def module: Stackable[ServiceFactory[Command, Reply]] =
+    new Stack.Module2[Database, Password, ServiceFactory[Command, Reply]] {
+      val role = Role
+      val description = "Manage redis connections"
+
+      def make(db: Database, password: Password, next: ServiceFactory[Command, Reply]): ServiceFactory[Command, Reply] = {
+        for {
+          service <- next
+          authed <- apply(service, password.code, Auth.apply)
+          selected <- apply(authed, db.index, Select.apply)
+        } yield selected
+      }
+    }
+
+  private def apply[A](service: Service[Command, Reply], param: Option[A], command: A => Command): Future[Service[Command, Reply]] = {
+    param match {
+      case Some(p) =>
+        service(command(p)).flatMap {
+          case StatusReply(_) => Future.value(service)
+          case ErrorReply(msg) =>
+            Future.exception(ServerError(msg))
+          case r => Future.exception(new IllegalStateException(s"Unsupported response to a modify='$r'"))
+        }
+      case None => Future.value(service)
+    }
+  }
+}

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/param/Params.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/param/Params.scala
@@ -2,6 +2,7 @@ package com.twitter.finagle.redis.param
 
 import com.twitter.finagle.Stack
 import com.twitter.hashing
+import com.twitter.io.Buf
 
 object RedisKeyHasher {
   // murmur3 hash was picked because it's very fast, it has a reasonably good
@@ -14,4 +15,20 @@ object RedisKeyHasher {
 case class RedisKeyHasher(hasher: hashing.KeyHasher) {
   def mk(): (RedisKeyHasher, Stack.Param[RedisKeyHasher]) =
     (this, RedisKeyHasher.param)
+}
+
+/**
+ * A class eligible for configuring a redis client's database after connection init phase.
+ */
+case class Database(index: Option[Int])
+object Database {
+  implicit val param: Stack.Param[Database] = Stack.Param(Database(None))
+}
+
+/**
+ * A class eligible for configuring a redis client's password after connection init phase.
+ */
+case class Password(code: Option[Buf])
+object Password {
+  implicit val param: Stack.Param[Password] = Stack.Param(Password(None))
 }


### PR DESCRIPTION
## Problem

There is no api to set select database and auth password in redis client.
These commands are enough to be executed once in a connection.

## Solution

Add ConnectionInitCommand stack and client api to set database and password.