### PR TITLE
Filter IPv6 address-es when NIC has only local IPv6 addresses

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/InetResolver.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/InetResolver.scala
@@ -33,7 +33,7 @@ private[finagle] class DnsResolver(statsReceiver: StatsReceiver, resolvePool: Fu
     } else {
       dnsLookups.incr()
       dnsCond.acquire().flatMap { permit =>
-        resolvePool(InetAddress.getAllByName(host).toSeq)
+        resolvePool(InetSocketAddressUtil.getAllByName(host).toSeq)
           .onFailure { e =>
             log.debug(s"Failed to resolve $host. Error $e")
             dnsLookupFailures.incr()


### PR DESCRIPTION
Netty fixed that bug at
https://github.com/netty/netty/pull/10170

That bug is still present in at least openjdk (1.8.0_191, 11.0.1).

More precisely `InetAddress.getAllByName`
sends both AAAA and A queries for a given host.

When a DNS server returns IPv4/IPv6 address-es and
that the IPv6 address is chosen by the client,
subsequent queries will fail, given that network of
the NIC is not able to route IPv6 packets.

Problem

Explain the context and why you're making that change.  What is the
problem you're trying to solve? In some cases there is not a problem
and this can be thought of being the motivation for your change.

Solution

Describe the modifications you've done.

Result

What will change as a result of your pull request? Note that sometimes
this section is unnecessary because it is self-explanatory based on
the solution.
