### PR TITLE
finagle-core: Filter IPv6 address-es when NICs have only local ones

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/InetResolver.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/InetResolver.scala
@@ -33,7 +33,7 @@ private[finagle] class DnsResolver(statsReceiver: StatsReceiver, resolvePool: Fu
     } else {
       dnsLookups.incr()
       dnsCond.acquire().flatMap { permit =>
-        resolvePool(InetAddress.getAllByName(host).toSeq)
+        resolvePool(InetSocketAddressUtil.getAllByName(host).toSeq)
           .onFailure { e =>
             log.debug(s"Failed to resolve $host. Error $e")
             dnsLookupFailures.incr()

--- a/finagle-core/src/main/scala/com/twitter/finagle/util/InetSocketAddressUtil.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/util/InetSocketAddressUtil.scala
@@ -1,13 +1,48 @@
 package com.twitter.finagle.util
 
-import java.net.{InetAddress, InetSocketAddress, SocketAddress, UnknownHostException}
+import java.net.{Inet4Address, Inet6Address, InetAddress, InetSocketAddress,
+  NetworkInterface, SocketAddress, SocketException, UnknownHostException}
+import com.twitter.logging.Logger
 
 object InetSocketAddressUtil {
 
   type HostPort = (String, Int)
 
+  private[this] val log = Logger()
+
   private[finagle] val unconnected =
     new SocketAddress { override def toString = "unconnected" }
+
+  private[this] lazy val anyInterfaceSupportsIpV6: Boolean = {
+    try {
+      val interfaces = NetworkInterface.getNetworkInterfaces()
+      while (interfaces.hasMoreElements()) {
+        val iface = interfaces.nextElement()
+        val addresses = iface.getInetAddresses()
+        while (addresses.hasMoreElements()) {
+          val inetAddress = addresses.nextElement()
+          if (inetAddress.isInstanceOf[Inet6Address] && !inetAddress.isAnyLocalAddress() &&
+            !inetAddress.isLoopbackAddress() && !inetAddress.isLinkLocalAddress()) {
+            true
+          }
+        }
+      }
+    }
+    catch {
+      case e: SocketException => {
+        log.debug(s"Unable to detect if any interface supports IPv6, assuming IPv4-only. Error $e")
+      }
+    }
+    false
+  }
+
+  private[finagle] def getAllByName(host: String): Array[InetAddress] = {
+    def isAddressSupported(a: InetAddress) = {
+      if (!anyInterfaceSupportsIpV6) a.isInstanceOf[Inet4Address]
+      else true
+    }
+    InetAddress.getAllByName(host).filter(isAddressSupported)
+  }
 
   /** converts 0.0.0.0 -> public ip in bound ip */
   def toPublic(bound: SocketAddress): SocketAddress = {
@@ -57,8 +92,7 @@ object InetSocketAddressUtil {
   private[finagle] def resolveHostPortsSeq(hostPorts: Seq[HostPort]): Seq[Seq[SocketAddress]] =
     hostPorts.map {
       case (host, port) =>
-        InetAddress
-          .getAllByName(host)
+          getAllByName(host)
           .iterator
           .map { addr => new InetSocketAddress(addr, port) }
           .toSeq


### PR DESCRIPTION
Problem

When NICs have IPv6 address-es, `InetAddress.getAllByName` sends both
AAAA and A queries for a given host.

When a DNS server returns both IPv4 and IPv6 address-es, the client can
choose to use the IPv6 address.

When the related NIC has only a local IPv6 address, and that the IPv6
address is chosen, subsequent queries will fail given that
none of the available networks is able to route IPv6 packets.

Netty fixed that bug at
https://github.com/netty/netty/pull/10170

That bug is still present in at least openjdk (1.8.0_191, 11.0.1).

Solution

Filter IPv6 address-es from the result of `InetAddress.getAllByName`
when NICs have only local IPv6 address-es.
