### PR TITLE
Fix instructions to build via dodo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,9 +9,11 @@ means that it may be necessary to publish the `develop` branches of these
 libraries locally in order to work on Finagle's `develop` branch. To do so
 you can use our build tool, [dodo](https://github.com/twitter/dodo).
 
-``` bash
-curl -s https://raw.githubusercontent.com/twitter/dodo/develop/bin/build | bash -s -- --no-test finagle
-```
+1. Clone [dodo](https://github.com/twitter/dodo.git)
+2. `./dodo/bin/build --no-test finagle`
+
+dodo depends on bash version > 4 to run correctly, in case of an error that
+`BASH_SOURCE` is unbound, make sure to run with bash
 
 ## Building Finagle
 


### PR DESCRIPTION
The `build` script for dodo has been split into multiple so the curl oneliner no
longer works. I think the most straight forward way is to clone dodo and
actually run it.

Dodo depends on bash > 4, which is not the default bash on MacOSX.

Problem

Running the commands in `CONTRIBUTING.md` fails as dodo no longer is a single file bin.

```
bash: line 5: BASH_SOURCE[0]: unbound variable
bash: line 5: /Users/USER/source/finagle/functions: No such file or directory
```

Solution

Tell the user to clone dodo and and use from the clones repository. Also inform the user that running dodo requires bash > 4

Result

Instructions in `CONTRIBUTING.md` result in a successful built.