### PR TITLE
Make withTraceInitializer visible in http.MethodBuilder.

### DIFF
--- a/finagle-http/src/main/scala/com/twitter/finagle/http/MethodBuilder.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/http/MethodBuilder.scala
@@ -1,6 +1,8 @@
 package com.twitter.finagle.http
 
+import com.twitter.finagle.Filter
 import com.twitter.finagle.builder.{ClientBuilder, ClientConfig}
+import com.twitter.finagle.client.MethodBuilder
 import com.twitter.finagle.client.StackClient
 import com.twitter.finagle.http.service.HttpResponseClassifier
 import com.twitter.finagle.param.{Tracer => TracerParam}
@@ -214,6 +216,9 @@ class MethodBuilder private (mb: client.MethodBuilder[Request, Response])
 
   def withTimeoutPerRequest(howLong: Tunable[Duration]): MethodBuilder =
     new MethodBuilder(mb.withTimeout.perRequest(howLong))
+
+  def withTraceInitializer(initializer: Filter.TypeAgnostic): MethodBuilder =
+    new MethodBuilder(mb.withTraceInitializer(initializer))
 
   def withRetryForClassifier(classifier: ResponseClassifier): MethodBuilder =
     new MethodBuilder(mb.withRetry.forClassifier(classifier))


### PR DESCRIPTION
Problem

https://github.com/twitter/finagle/issues/857

Solution

Expose the hidden method.

Result

Clients can override the `TraceInitilizerFilter` when using `http.MethodBuilder`