### PR TITLE
finagle-base-http: Add MultipartDecoder support for chunked requests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,9 @@ Unreleased
 Breaking API Changes
 ~~~~~~~~~~~~~~~~~~~~
 
+* finagle-base-http: Change return type of `MultipartDecoder.decodeFull` to return a `Future` and add
+  support for chunked requests.
+
 * finagle-core: Correct the spelling of `Tracing.recordClientSendFrargmet()` to
   `Tracing.recordClientSendFragment()` ``PHAB_ID=D505617``
 

--- a/finagle-http/src/test/scala/com/twitter/finagle/http/AbstractMultipartDecoderTest.scala
+++ b/finagle-http/src/test/scala/com/twitter/finagle/http/AbstractMultipartDecoderTest.scala
@@ -1,11 +1,12 @@
 package com.twitter.finagle.http
 
 import com.twitter.finagle.http.exp.{Multipart, MultipartDecoder}
+import com.twitter.io.{Buf, BufReader, Files}
+import com.twitter.util.{Await, Duration}
 import org.scalatest.FunSuite
-import com.twitter.io.{Buf, Files}
+import com.twitter.io.Reader
 
 abstract class AbstractMultipartDecoderTest(decoder: MultipartDecoder) extends FunSuite {
-
   /*
    * The generated request is equivalent to the following form:
    *
@@ -23,13 +24,28 @@ abstract class AbstractMultipartDecoderTest(decoder: MultipartDecoder) extends F
       .add(SimpleElement("type", "text"))
       .buildFormPost(multipart = true)
 
+  private[this] def newChunkedRequest(buf: Buf): Request = {
+    val req = newRequest(buf)
+    val chunkedReq = new Request.Inbound(
+      Reader.concat(Seq(BufReader(req.content, 2).map(Chunk(_)), Reader.value(Chunk.lastEmpty))),
+      req.remoteSocketAddress,
+      req.trailers
+    )
+    chunkedReq.method = req.method
+    chunkedReq.uri = req.uri
+    req.headerMap.filter(_._1 != Fields.ContentLength).map(chunkedReq.headerMap += )
+    chunkedReq.headerMap += Fields.TransferEncoding -> "chunked"
+    chunkedReq.setChunked(true)
+    chunkedReq
+  }
+
   test("Attribute") {
-    assert(decoder.decode(newRequest(Buf.Empty)).get.attributes("type").head == "text")
+    assert(decode(newRequest(Buf.Empty)).get.attributes("type").head == "text")
   }
 
   test("FileUpload (in-memory)") {
     val foo = Buf.Utf8("foo")
-    val multipart = decoder.decode(newRequest(foo)).get
+    val multipart = decode(newRequest(foo)).get
 
     val Multipart.InMemoryFileUpload(buf, contentType, fileName, contentTransferEncoding) =
       multipart.files("groups").head
@@ -44,7 +60,37 @@ abstract class AbstractMultipartDecoderTest(decoder: MultipartDecoder) extends F
 
   test("FileUpload (on-disk)") {
     val foo = Buf.Utf8("." * (Multipart.DefaultMaxInMemoryFileSize.inBytes.toInt + 10))
-    val multipart = decoder.decode(newRequest(foo)).get
+    val multipart = decode(newRequest(foo)).get
+
+    val Multipart.OnDiskFileUpload(file, contentType, fileName, contentTransferEncoding) =
+      multipart.files("groups").head
+    val attr = multipart.attributes("type").head
+
+    assert(Buf.ByteArray.Owned(Files.readBytes(file, limit = Int.MaxValue)) == foo)
+    assert(contentType == "image/gif")
+    assert(fileName == "dealwithit.gif")
+    assert(contentTransferEncoding == "binary")
+    assert(attr == "text")
+  }
+
+  test("FileUpload (chunked, in-memory)") {
+    val foo = Buf.Utf8("foo")
+    val multipart = decode(newChunkedRequest(foo)).get
+
+    val Multipart.InMemoryFileUpload(buf, contentType, fileName, contentTransferEncoding) =
+      multipart.files("groups").head
+    val attr = multipart.attributes("type").head
+
+    assert(buf == foo)
+    assert(contentType == "image/gif")
+    assert(fileName == "dealwithit.gif")
+    assert(contentTransferEncoding == "binary")
+    assert(attr == "text")
+  }
+
+  test("FileUpload (chunked, on-disk)") {
+    val foo = Buf.Utf8("." * (Multipart.DefaultMaxInMemoryFileSize.inBytes.toInt + 10))
+    val multipart = decode(newChunkedRequest(foo)).get
 
     val Multipart.OnDiskFileUpload(file, contentType, fileName, contentTransferEncoding) =
       multipart.files("groups").head
@@ -58,19 +104,20 @@ abstract class AbstractMultipartDecoderTest(decoder: MultipartDecoder) extends F
   }
 
   test("Not a multipart request") {
-    assert(decoder.decode(Request()).isEmpty)
-    assert(decoder.decode(Request(Method.Post, "/")).isEmpty)
+    assert(decode(Request()).isEmpty)
+    assert(decode(Request(Method.Post, "/")).isEmpty)
     assert(
-      decoder
-        .decode(
-          { val r = Request(Method.Post, "/"); r.contentType = "application/json"; r }
-        ).isEmpty
+      decode(
+        { val r = Request(Method.Post, "/"); r.contentType = "application/json"; r }
+      ).isEmpty
     )
     assert(
-      decoder
-        .decode(
-          { val r = Request(Method.Put, "/"); r.contentType = "multipart/form-data"; r }
-        ).isEmpty
+      decode(
+        { val r = Request(Method.Put, "/"); r.contentType = "multipart/form-data"; r }
+      ).isEmpty
     )
   }
+
+  private def decode(r: Request) =
+  Await.result(decoder.decode(r), Duration.fromSeconds(5))
 }

--- a/finagle-netty4-http/src/main/scala/com/twitter/finagle/netty4/http/Netty4MultipartDecoder.scala
+++ b/finagle-netty4-http/src/main/scala/com/twitter/finagle/netty4/http/Netty4MultipartDecoder.scala
@@ -2,14 +2,17 @@ package com.twitter.finagle.netty4.http
 
 import com.twitter.finagle.http.exp.{Multipart, MultipartDecoder}
 import com.twitter.finagle.http.Request
-import com.twitter.io.Buf
-import com.twitter.util.StorageUnit
+import com.twitter.finagle.netty4.ByteBufConversion
+import com.twitter.io.{Buf, Reader}
+import com.twitter.util.{Future, StorageUnit}
+import com.twitter.concurrent.AsyncStream
+import io.netty.handler.codec.http.{DefaultHttpContent, DefaultLastHttpContent}
 import io.netty.handler.codec.http.multipart._
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
 private[finagle] class Netty4MultipartDecoder extends MultipartDecoder {
-  protected def decodeFull(req: Request, maxInMemoryFileSize: StorageUnit): Option[Multipart] = {
+  protected def decodeFull(req: Request, maxInMemoryFileSize: StorageUnit): Future[Option[Multipart]] = {
     val decoder = new HttpPostMultipartRequestDecoder(
       new DefaultHttpDataFactory(maxInMemoryFileSize.inBytes),
       Bijections.finagle.requestToNetty(req, req.contentLength)
@@ -18,33 +21,42 @@ private[finagle] class Netty4MultipartDecoder extends MultipartDecoder {
     val attrs = new mutable.HashMap[String, mutable.ListBuffer[String]]()
     val files = new mutable.HashMap[String, mutable.ListBuffer[Multipart.FileUpload]]()
 
-    decoder.getBodyHttpDatas.asScala.foreach {
-      case attr: Attribute =>
-        val buf = attrs.getOrElseUpdate(attr.getName, mutable.ListBuffer[String]())
-        buf += attr.getValue
+    (if (req.isChunked) {
+      Reader.toAsyncStream(req.chunkReader).map { chunk =>
+        val byteBuf = ByteBufConversion.bufAsByteBuf(chunk.content)
+        if (chunk.isLast) new DefaultLastHttpContent(byteBuf)
+        else new DefaultHttpContent(byteBuf)
+      }.foreach(decoder.offer)
+    } else Future.Void).map { _ =>
 
-      case fu: FileUpload =>
-        val buf = files
-          .getOrElseUpdate(fu.getName, mutable.ListBuffer[Multipart.FileUpload]())
-        if (fu.isInMemory) {
-          buf += Multipart.InMemoryFileUpload(
-            Buf.ByteArray.Owned(fu.get()),
-            fu.getContentType,
-            fu.getFilename,
-            fu.getContentTransferEncoding
-          )
-        } else {
-          buf += Multipart.OnDiskFileUpload(
-            fu.getFile,
-            fu.getContentType,
-            fu.getFilename,
-            fu.getContentTransferEncoding
-          )
-        }
+      decoder.getBodyHttpDatas.asScala.foreach {
+        case attr: Attribute =>
+          val buf = attrs.getOrElseUpdate(attr.getName, mutable.ListBuffer[String]())
+          buf += attr.getValue
 
-      case _ => // ignore everything else
+        case fu: FileUpload =>
+          val buf = files
+            .getOrElseUpdate(fu.getName, mutable.ListBuffer[Multipart.FileUpload]())
+          if (fu.isInMemory) {
+            buf += Multipart.InMemoryFileUpload(
+              Buf.ByteArray.Owned(fu.get()),
+              fu.getContentType,
+              fu.getFilename,
+              fu.getContentTransferEncoding
+            )
+          } else {
+            buf += Multipart.OnDiskFileUpload(
+              fu.getFile,
+              fu.getContentType,
+              fu.getFilename,
+              fu.getContentTransferEncoding
+            )
+          }
+
+        case _ => // ignore everything else
+      }
+
+      Some(Multipart(attrs.mapValues(_.toSeq).toMap, files.mapValues(_.toSeq).toMap))
     }
-
-    Some(Multipart(attrs.mapValues(_.toSeq).toMap, files.mapValues(_.toSeq).toMap))
   }
 }


### PR DESCRIPTION
Problem

Multipart decoding of chunked requests currently returns `None`.

Solution

Allow chunked requests to be passed to `MultipartDecoder` implementation.
For `Netty4MultipartDecoder`, offer all chunks from request to decoder before attempting to `getBodyHttpDatas`.

Result

`MultipartDecoder` now returns a `Future` and supports decoding of chunked requests.
