### PR TITLE
finagle-redis: Add the RedisTracingFilter and RedisLoggingFilter back into the default Redis Stack

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -129,6 +129,9 @@ Bug Fixes
 * finagle-zipkin-scribe: The scribe client should be configured using the `NullTracer`. Otherwise, spans
   produced by the client stack will be sampled at `initialSampleRate`. ``PHAB_ID=D507318``
 
+* finagle-redis: The redis client now includes the `RedisTracingFilter` and `RedisLoggingFilter` by default.
+  Previously, the filters existed but were not applied to the client or accessible.
+
 20.6.0
 ------
 

--- a/finagle-redis/src/main/scala/com/twitter/finagle/Redis.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/Redis.scala
@@ -74,7 +74,7 @@ object Redis extends Client[Command, Reply] with RedisRichClient {
       .insertBefore(DefaultPool.Role, RedisPool.module)
       .insertAfter(StackClient.Role.prepConn, ConnectionInitCommand.module)
       .replace(StackClient.Role.protoTracing, RedisTracingFilter.module)
-      .insertAfter(RedisLoggingFilter.role, RedisLoggingFilter.module)
+      .insertBefore(StackClient.Role.protoTracing, RedisLoggingFilter.module)
 
     private[finagle] val hashRingStack: Stack[ServiceFactory[Command, Reply]] =
       stack.insertAfter(BindingFactory.role, RedisPartitioningService.module)

--- a/finagle-redis/src/main/scala/com/twitter/finagle/Redis.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/Redis.scala
@@ -14,6 +14,7 @@ import com.twitter.finagle.param.{
 }
 import com.twitter.finagle.redis.RedisPartitioningService
 import com.twitter.finagle.redis.exp.{ConnectionInitCommand, RedisPool}
+import com.twitter.finagle.redis.filter.{RedisLoggingFilter, RedisTracingFilter}
 import com.twitter.finagle.redis.param.{Database, Password}
 import com.twitter.finagle.redis.protocol.{Command, Reply, StageTransport}
 import com.twitter.finagle.service.{ResponseClassifier, RetryBudget}
@@ -72,6 +73,8 @@ object Redis extends Client[Command, Reply] with RedisRichClient {
     private val stack: Stack[ServiceFactory[Command, Reply]] = StackClient.newStack
       .insertBefore(DefaultPool.Role, RedisPool.module)
       .insertAfter(StackClient.Role.prepConn, ConnectionInitCommand.module)
+      .replace(StackClient.Role.protoTracing, RedisTracingFilter.module)
+      .insertAfter(RedisLoggingFilter.role, RedisLoggingFilter.module)
 
     private[finagle] val hashRingStack: Stack[ServiceFactory[Command, Reply]] =
       stack.insertAfter(BindingFactory.role, RedisPartitioningService.module)

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/filter/RedisLoggingFilter.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/filter/RedisLoggingFilter.scala
@@ -1,12 +1,30 @@
 package com.twitter.finagle.redis.filter
 
-import com.twitter.finagle.{Service, SimpleFilter}
+import com.twitter.finagle._
 import com.twitter.finagle.redis.protocol._
 import com.twitter.finagle.redis.util.BufToString
 import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.util.{Future, Return}
 
-private[redis] class RedisLoggingFilter(stats: StatsReceiver) extends SimpleFilter[Command, Reply] {
+private[finagle] object RedisLoggingFilter {
+  val role: Stack.Role = Stack.Role("RedisStatsFilter")
+  val description: String = "Redis Stats"
+
+  def module: Stackable[ServiceFactory[Command, Reply]] =
+    new Stack.Module1[param.Stats, ServiceFactory[Command, Reply]] {
+      val role: Stack.Role = RedisLoggingFilter.role
+      val description: String = RedisLoggingFilter.description
+
+      def make(statsParam: param.Stats, next: ServiceFactory[Command, Reply]): ServiceFactory[Command, Reply] = {
+        if (statsParam.statsReceiver.isNull)
+          next
+        else
+          new RedisLoggingFilter(statsParam.statsReceiver.scope("http")).andThen(next)
+      }
+    }
+}
+
+private[finagle] class RedisLoggingFilter(stats: StatsReceiver) extends SimpleFilter[Command, Reply] {
 
   private[this] val error = stats.scope("error")
   private[this] val succ = stats.scope("success")

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/filter/RedisLoggingFilter.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/filter/RedisLoggingFilter.scala
@@ -19,7 +19,7 @@ private[finagle] object RedisLoggingFilter {
         if (statsParam.statsReceiver.isNull)
           next
         else
-          new RedisLoggingFilter(statsParam.statsReceiver.scope("http")).andThen(next)
+          new RedisLoggingFilter(statsParam.statsReceiver).andThen(next)
       }
     }
 }

--- a/finagle-redis/src/main/scala/com/twitter/finagle/redis/filter/RedisTracingFilter.scala
+++ b/finagle-redis/src/main/scala/com/twitter/finagle/redis/filter/RedisTracingFilter.scala
@@ -1,12 +1,26 @@
 package com.twitter.finagle.redis.filter
 
-import com.twitter.finagle.{Service, SimpleFilter}
+import com.twitter.finagle._
 import com.twitter.finagle.redis.protocol.{Command, Reply}
 import com.twitter.finagle.redis.util.BufToString
 import com.twitter.finagle.tracing.{Annotation, Trace}
 import com.twitter.util.Future
 
-private[redis] class RedisTracingFilter extends SimpleFilter[Command, Reply] {
+private[finagle] object RedisTracingFilter {
+  val role: Stack.Role = Stack.Role("RedisTracing")
+  val description: String = "redis client annotations"
+
+  def module = new Stack.Module0[ServiceFactory[Command, Reply]] {
+    val role: Stack.Role = RedisTracingFilter.role
+    val description: String = RedisTracingFilter.description
+
+    override def make(next: ServiceFactory[Command, Reply]): ServiceFactory[Command, Reply] = {
+      new RedisTracingFilter().andThen(next)
+    }
+  }
+}
+
+private[finagle] class RedisTracingFilter extends SimpleFilter[Command, Reply] {
 
   def apply(command: Command, service: Service[Command, Reply]): Future[Reply] = {
     val trace = Trace()


### PR DESCRIPTION
Problem

I was experimenting with the Tracing module and instrumented a Redis Client. I noticed that Redis rpc calls did not get named unlike the Http calls that were being traced. After some discussion on gitter, @mosesn pointed out that a commit where the `RedisLoggingFilter` and `RedisTracingFilter` had been ported during the move from Netty 3 -> Netty 4, but had not been added back to the stack.

Solution

I added the `RedisLoggingFilter` and the `RedisTracingFilter` to the default client stack.

Result

This will add stats and tracing back to the Redis Client by default.

I followed the mysql client for adding the `role` and `module` definitions. If there as a better way to do this let me know and I can change it.
