### PR TITLE
Upgrade to netty 4.1.51.Final and netty-tcnative 2.0.33.Final

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,8 +6,8 @@ val releaseVersion = "20.9.0-SNAPSHOT"
 
 val libthriftVersion = "0.10.0"
 
-val defaultNetty4Version = "4.1.47.Final"
-val defaultNetty4StaticSslVersion = "2.0.30.Final"
+val defaultNetty4Version = "4.1.51.Final"
+val defaultNetty4StaticSslVersion = "2.0.33.Final"
 
 val useNettySnapshot: Boolean = sys.env.get("FINAGLE_USE_NETTY_4_SNAPSHOT") match {
   case Some(useSnapshot) => useSnapshot.toBoolean

--- a/finagle-core/src/test/scala/com/twitter/finagle/util/LossyEmaTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/util/LossyEmaTest.scala
@@ -45,22 +45,23 @@ class LossyEmaTest extends FunSuite {
   test("update over durations greater than window") {
     Time.withCurrentTimeFrozen { tc =>
       val value = 100.0
+      val tolerance = 0.000000000000025
       val ema = new LossyEma(300.millis.inMillis, Stopwatch.timeMillis, value)
 
       tc.advance(100.millis)
-      assert(ema.update(0.0) == 71.65313105737893)
+      assert((ema.update(0.0) - 71.65313105737893).abs <= tolerance)
 
       tc.advance(100.millis)
-      assert(ema.update(0.0) == 51.34171190325921)
+      assert((ema.update(0.0) - 51.34171190325921).abs <= tolerance)
 
       tc.advance(100.millis)
-      assert(ema.update(0.0) == 36.787944117144235)
+      assert((ema.update(0.0) - 36.787944117144235).abs <= tolerance)
 
       tc.advance(100.millis)
-      assert(ema.update(0.0) == 26.35971381157268)
+      assert((ema.update(0.0) - 26.35971381157268).abs <= tolerance)
 
       tc.advance(100.millis)
-      assert(ema.update(0.0) == 18.887560283756187)
+      assert((ema.update(0.0) - 18.887560283756187).abs <= tolerance)
     }
   }
 


### PR DESCRIPTION
 - Upgrade to netty 4.1.50.Final and netty-tcnative 2.0.31.Final for both security fixes and AArch64 performance improvements
 - Refer release notes for detail: https://netty.io/news/2020/05/13/4-1-50-Final.html
 - Added very minor tolerance in a value comparison in a test case file LossyEmaTest.scala to make it compatible with aarch64.

Signed-off-by: odidev <odidev@puresoftware.com>


