### PR TITLE
Update build.sbt to get aarch64 binaries and fix behavior of NonReentrantReadWriteLock on Arm

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,6 +44,7 @@ val netty4Libs = Seq(
   "io.netty" % "netty-handler" % netty4Version,
   "io.netty" % "netty-transport" % netty4Version,
   "io.netty" % "netty-transport-native-epoll" % netty4Version classifier "linux-x86_64",
+  "io.netty" % "netty-transport-native-epoll" % netty4Version classifier "linux-aarch64",
   // this package is a dep of native-epoll above, explicitly add this for coursier plugin
   "io.netty" % "netty-transport-native-unix-common" % netty4Version,
   "io.netty" % "netty-handler-proxy" % netty4Version
@@ -52,6 +53,7 @@ val netty4LibsTest = Seq(
   "io.netty" % "netty-handler" % netty4Version % "test",
   "io.netty" % "netty-transport" % netty4Version % "test",
   "io.netty" % "netty-transport-native-epoll" % netty4Version % "test" classifier "linux-x86_64",
+  "io.netty" % "netty-transport-native-epoll" % netty4Version classifier "linux-aarch64",
   // this package is a dep of native-epoll above, explicitly add this for coursier plugin
   "io.netty" % "netty-transport-native-unix-common" % netty4Version % "test",
   "io.netty" % "netty-handler-proxy" % netty4Version % "test",

--- a/finagle-stats-core/src/main/scala/com/twitter/finagle/stats/NonReentrantReadWriteLock.scala
+++ b/finagle-stats-core/src/main/scala/com/twitter/finagle/stats/NonReentrantReadWriteLock.scala
@@ -3,6 +3,17 @@ package com.twitter.finagle.stats
 import java.util.concurrent.locks.AbstractQueuedSynchronizer
 import scala.annotation.tailrec
 
+import com.twitter.app.GlobalFlag
+
+object rwLockSpinWait
+    // Defaults to -1 which allows the NonReentrantReadWriteLock class to 
+    // set a system specific default.
+    extends GlobalFlag[Int](-1, 
+      """Experimental flag.  Control how many times NonReentrantReadWriteLock 
+      | retries an acquire before executing its slow path acquire.  Default
+      | value of -1 lets the system decide how long to spin""".stripMargin
+    )
+
 /**
  * This is a cheaper read-write lock than the ReentrantReadWriteLock.
  *
@@ -23,10 +34,30 @@ private[stats] final class NonReentrantReadWriteLock extends AbstractQueuedSynch
   // we haven't provided an implementation for isHeldExclusively because the
   // docs for AQS advise implementors to provide implementations "as applicable"
   // and our use case doesn't require knowing when the lock is held exclusively.
+  private val SpinMax: Int = if (rwLockSpinWait() == -1) {
+    // Default number of spins for aarch64 machines set to 5 by default. 
+    // See below comment on reason.
+    if (System.getProperty("os.arch") == "aarch_64") 5
+    else 1
+  } 
+  else rwLockSpinWait()
 
   override def tryAcquireShared(num: Int): Int = {
-    val cur = getState()
-    if (cur >= 0 && compareAndSetState(cur, cur + 1)) 1 else -1
+    tryAcquireShared(getState(), 1)
+  }
+
+  // Try to acquire the lock up to SpinMax times before failing and 
+  // allowing AbstractQueuedSynchronizer to execute the slow-path lock.
+  // This is important on Arm systems where compareAndSetState may fail
+  // more often due to its weaker memory model.
+  @tailrec
+  private[this] def tryAcquireShared(cur: Int, tries: Int): Int = {
+    if (cur >= 0 && compareAndSetState(cur, cur + 1)) 1
+    // When JDK8 support is deprecated, Thread.onSpinWait() should be
+    // used in the else if clause to avoid flooding the memory 
+    // system with compareAndSetState in a tight loop.
+    else if (tries < SpinMax) tryAcquireShared(getState(), tries + 1)
+    else -1
   }
 
   @tailrec


### PR DESCRIPTION
Problem

There are 2 small problems addressed in this PR:
1) build.sbt does not properly pull down netty-epoll-native for
Arm64,  meaning by default Arm with use NIO instead of
native-epoll. 
2) Current behavior of NonReentrantReadWriteLock in the 
finagle-stats-core package is sub-optimal on Arm and will enter into
slow-path synchronization via kernel futexes more often than
expected (measuring 100x more often) in some cases.

Explain the context and why you're making that change.  What is the
problem you're trying to solve? In some cases there is not a problem
and this can be thought of being the motivation for your change.

Solution

1) Modify build.sbt to get the aarch64 packages for netty-epoll-native
in addition to x86
2) Try the fast path acquire up to 5 times before failing over to the
AbstractQueuedSynchronizer slow path in NonReentrantReadWriteLock
for Arm64, all other systems try the fast path once.
