### PR TITLE
The README file in this repo has a bad link - [404:NotFound]

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ us a pull request!
 ## Contributing
 
 We feel that a welcoming community is important and we ask that you follow Twitter's
-[Open Source Code of Conduct](https://github.com/twitter/code-of-conduct/blob/release/code-of-conduct.md)
+[Open Source Code of Conduct](https://github.com/twitter/code-of-conduct/blob/master/code-of-conduct.md)
 in all interactions with the community.
 
 The `release` branch of this repository contains the latest stable release of


### PR DESCRIPTION
### Problem

When clicking: “Open Source Code of Conduct”
Status code [404:NotFound] - Link: https://github.com/twitter/code-of-conduct/blob/release/code-of-conduct.md

Issue #878

### Solution

Link should work and I think it should point to here:
https://github.com/twitter/code-of-conduct/blob/master/code-of-conduct.md



### additional

This bad link was found by a tool I very recently created as part of an new experimental hobby project: https://github.com/MrCull/GitHub-Repo-ReadMe-Dead-Link-Finder


Re-check this Repo via: http://githubreadmechecker.com/Home/Search?SingleRepoUri=https%3A%2F%2Fgithub.com%2Ftwitter%2Ffinagle
Check all Repos for this GitHub account: http://githubreadmechecker.com/Home/Search?User=twitter


If this has been in any way helpful then please consider giving the above Repo a Star.
If you have any feedback on the information provided here, or on the tool itself, then please feel free to share your thoughts and pass on the feedback.
