### PR TITLE
Upgrade jackson libraries to 2.12.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ val netty4LibsTest = Seq(
 val netty4Http = "io.netty" % "netty-codec-http" % netty4Version
 val netty4Http2 = "io.netty" % "netty-codec-http2" % netty4Version
 val opencensusVersion = "0.24.0"
-val jacksonVersion = "2.12.0"
+val jacksonVersion = "2.12.1"
 val jacksonLibs = Seq(
   "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ val netty4LibsTest = Seq(
 val netty4Http = "io.netty" % "netty-codec-http" % netty4Version
 val netty4Http2 = "io.netty" % "netty-codec-http2" % netty4Version
 val opencensusVersion = "0.24.0"
-val jacksonVersion = "2.11.2"
+val jacksonVersion = "2.12.0"
 val jacksonLibs = Seq(
   "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,


### PR DESCRIPTION
Reference: https://github.com/twitter/finagle/issues/885

FasterXML has recently version released jackson [version 2.12.0](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.12) libraries, the dependency can be upgraded. 