### PR TITLE
Bumping zookeeper version due to security issues with Netty

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ val netty4StaticSslVersion: String =
 val nettyVersionInfo = settingKey[String]("A setting reference for printing the netty version info")
 
 // zkVersion should be kept in sync with the 'util-zk' dependency version
-val zkVersion = "3.5.0-alpha"
+val zkVersion = "3.5.6"
 
 val scalaCollectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.2"
 val caffeineLib = "com.github.ben-manes.caffeine" % "caffeine" % "2.8.5"


### PR DESCRIPTION
## Problem

The most recent release from finagle is using `org.apache.zookeeper/zookeeper` on the version `3.5.0-alpha`.
This zookeeper version is using `io.netty/netty` on the version `3.7.0` which introduces several vulnerable scenarios on the code.

## Solution

The solution for this issue was bumping `zkVersion` on the project, to an compatible version of zookeeper that is using netty in a newer version (most precisely, zookeeper was bumped to the version `3.5.6`).

## Result

The result of this pull-request will be finagle be free from this vulnerable scenarios from this outdated dependency.
