### PR TITLE
finagle-serversets: Handle KeeperState.Closed ZooKeeper session state

### DIFF
--- a/doc/src/sphinx/metrics/ServiceDiscovery.rst
+++ b/doc/src/sphinx/metrics/ServiceDiscovery.rst
@@ -171,3 +171,6 @@ Under the \`zkclient\` scope
 
 **session_expired**
   A counter of the number of session expirations.
+
+**session_closed**
+  A counter of the number of closed sessions.

--- a/finagle-serversets/src/main/scala/com/twitter/finagle/serverset2/ServiceDiscoverer.scala
+++ b/finagle-serversets/src/main/scala/com/twitter/finagle/serverset2/ServiceDiscoverer.scala
@@ -38,7 +38,7 @@ private[serverset2] object ServiceDiscoverer {
         case SessionState.Unknown =>
           Unknown
         case SessionState.Expired | SessionState.NoSyncConnected | SessionState.AuthFailed |
-            SessionState.Disconnected =>
+            SessionState.Disconnected | SessionState.Closed =>
           Unhealthy
         case SessionState.ConnectedReadOnly | SessionState.SaslAuthenticated |
             SessionState.SyncConnected =>

--- a/finagle-serversets/src/main/scala/com/twitter/finagle/serverset2/ZkSession.scala
+++ b/finagle-serversets/src/main/scala/com/twitter/finagle/serverset2/ZkSession.scala
@@ -168,6 +168,8 @@ private[serverset2] class ZkSession(
                 u() = Activity.Failed(new Exception("" + sessionState))
               // Do NOT keep retrying, wait to be reconnected automatically by the underlying session
 
+              case WatchState.SessionState(SessionState.Closed) =>
+
               case WatchState.SessionState(sessionState) =>
                 logger.error(s"Unexpected session state $sessionState. Session: $sessionIdAsHex")
                 u() = Activity.Failed(new Exception("" + sessionState))


### PR DESCRIPTION
**Problem**

Upon closing ZooKeeper connection, ClientCnxn dispatches KeeperState.Closed
event to watchers. Because there is no mapping from KeeperState.Closed to
SessionState, closing ZooKeeper connection results in a NoSuchElementException
in ClientCnxn event thread. The exception is caught and logged.

Existing tests in ZkSessionEndToEndTest reproduce the issue. An example how the issue looks like
```
DEBUG - Disconnecting client for session: 0x1000180f0f40000
DEBUG - An exception was thrown while closing send thread for session 0x1000180f0f40000 : Unable to read additional data from server sessionid 0x1000180f0f40000, likely server has closed socket
ERROR - Error while calling watcher 
java.util.NoSuchElementException: key not found: Closed
	at scala.collection.MapLike.default(MapLike.scala:235)
	at scala.collection.MapLike.default$(MapLike.scala:234)
	at scala.collection.AbstractMap.default(Map.scala:65)
	at scala.collection.MapLike.apply(MapLike.scala:144)
	at scala.collection.MapLike.apply$(MapLike.scala:143)
	at scala.collection.AbstractMap.apply(Map.scala:65)
	at com.twitter.finagle.serverset2.client.apache.ApacheSessionState$.apply(types.scala:44)
	at com.twitter.finagle.serverset2.client.apache.ApacheWatcher.process(ApacheWatcher.scala:18)
	at org.apache.zookeeper.ClientCnxn$EventThread.processEvent(ClientCnxn.java:535)
	at org.apache.zookeeper.ClientCnxn$EventThread.run(ClientCnxn.java:510)
INFO - Session: 0x1000180f0f40000 closed
INFO - EventThread shut down for session: 0x1000180f0f40000
```

**Solution**

Add mapping from KeeperState.Closed to SessionState.Closed and handle the new
state in relevant places.


