### PR TITLE
finagle: update doc

### DIFF
--- a/doc/src/sphinx/Futures.rst
+++ b/doc/src/sphinx/Futures.rst
@@ -249,9 +249,9 @@ Other resources
   importantly how to detect and fix it.
 
 .. _Akka: https://akka.io/
-.. _`Effective Scala`: https://twitter.github.com/effectivescala/
+.. _`Effective Scala`: https://twitter.github.io/effectivescala/
 .. _`Finagle Block Party`: https://finagle.github.io/blog/2016/09/01/block-party/
-.. _`section discussing futures`: https://twitter.github.com/effectivescala/#Twitter's%20standard%20libraries-Futures
+.. _`section discussing futures`: https://twitter.github.io/effectivescala/#Twitter's%20standard%20libraries-Futures
 .. _here: https://docs.scala-lang.org/overviews/core/futures.html
 .. _`section dedicated to futures`: https://doc.akka.io/docs/akka/2.1.0/scala/futures.html
 

--- a/doc/src/sphinx/Quickstart.rst
+++ b/doc/src/sphinx/Quickstart.rst
@@ -4,7 +4,7 @@ Quickstart
 In this section we'll use Finagle to build a very simple HTTP server
 that is also an HTTP client — an HTTP proxy. We assume that you
 are familiar with Scala_ (if not, may we recommend
-`Scala School <https://twitter.github.com/scala_school/>`_).
+`Scala School <https://twitter.github.io/scala_school/>`_).
 
 .. _Scala: https://www.scala-lang.org
 

--- a/doc/src/sphinx/index.rst
+++ b/doc/src/sphinx/index.rst
@@ -31,7 +31,7 @@ Other useful resources include:
 
 - `Your Server as a Function <https://monkey.org/~marius/funsrv.pdf>`_, a paper motivating the core abstractions behind finagle (`PLOS’13 <https://sigops.org/sosp/sosp13/plos.html>`_).
 - `Twitter engineering blog entry introducing Finagle <https://blog.twitter.com/2011/finagle-a-protocol-agnostic-rpc-system>`_
-- Twitter's `Scala School <https://twitter.github.com/scala_school/>`_ has a section `introducing Finagle <https://twitter.github.com/scala_school/finagle.html>`_ and another `constructing a distributed search engine using Finagle <https://twitter.github.com/scala_school/searchbird.html>`_
+- Twitter's `Scala School <https://twitter.github.io/scala_school/>`_ has a section `introducing Finagle <https://twitter.github.io/scala_school/finagle.html>`_ and another `constructing a distributed search engine using Finagle <https://twitter.github.io/scala_school/searchbird.html>`_
 - `Finagle 101 <https://kostyukov.net/posts/finagle-101/>`_ by Vladimir Kostyukov
 
 .. _Dapper: https://research.google.com/pubs/pub36356.html

--- a/site/index.html
+++ b/site/index.html
@@ -107,9 +107,9 @@
     <ul>
       <li><a href="https://blog.twitter.com/2011/finagle-a-protocol-agnostic-rpc-system">
         Twitter engineering blog post</a> motivating and introducting Finagle</li>
-      <li>Twitter’s <a href="https://twitter.github.com/scala_school/">Scala School</a> ends with an
-      <a href="https://twitter.github.com/scala_school/finagle.html">introduction to Finagle</a>, and finally
-      <a href="https://twitter.github.com/scala_school/searchbird.html">an example distributed system</a>.</li>
+      <li>Twitter’s <a href="https://twitter.github.io/scala_school/">Scala School</a> ends with an
+      <a href="https://twitter.github.io/scala_school/finagle.html">introduction to Finagle</a>, and finally
+      <a href="https://twitter.github.io/scala_school/searchbird.html">an example distributed system</a>.</li>
       <li>A <a href="https://days2011.scala-lang.org/node/138/286">talk introducing Finagle</a>, given by <a href="https://github.com/mariusae">Marius</a> at ScalaDays 2011</li>
       <li><a href="https://monkey.org/~marius/talks/twittersystems/#1">Slides</a> from another talk explaining
       the role of Finagle in Twitter’s distributed systems</li>


### PR DESCRIPTION
Problem

- https://twitter.github.com/ has been moved to https://twitter.github.io/

Solution

- update all URLs contains `https://twitter.github.com/`
