### PR TITLE
Parametrised HTTP/2 NACK to RST_STREAM frame handling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,9 @@ Runtime Behavior Changes
   lightweight component that listens for new incoming connections before handing them out to the
   global worker pool.  ``PHAB_ID=D662116``
 
+* finagle-http2: introduce optional parameter `NackRstFrameHandling` to enable or disable NACK
+  conversion to RST_STREAM frames.
+
 Bug Fixes
 ~~~~~~~~~~
 

--- a/finagle-http2/src/main/scala/com/twitter/finagle/http2/param/Params.scala
+++ b/finagle-http2/src/main/scala/com/twitter/finagle/http2/param/Params.scala
@@ -203,3 +203,32 @@ object FrameLoggerNamePrefix {
 
   implicit val param = Stack.Param(FrameLoggerNamePrefix(DefaultFrameLoggerPrefix))
 }
+
+/**
+ * Whether or not [[com.twitter.finagle.http2.transport.common.Http2NackHandler]]
+ * is included in channel pipeline, which is responsible for converting NACKs
+ * to RST_STREAM frame.
+ *
+ * Defaults to enabled.
+ *
+ * @see `Enabled` and `Disabled` on companion class for getting instances.
+ */
+final case class NackRstFrameHandling private(enabled: Boolean) {
+  def mk(): (NackRstFrameHandling, Stack.Param[NackRstFrameHandling]) =
+    (this, NackRstFrameHandling.param)
+}
+
+object NackRstFrameHandling {
+
+  /**
+   * Http2NackHandler is disabled.
+   */
+  val Disabled: NackRstFrameHandling = NackRstFrameHandling(false)
+
+  /**
+   * Http2NackHandler is enabled.
+   */
+  val Enabled: NackRstFrameHandling = NackRstFrameHandling(true)
+
+  implicit val param: Stack.Param[NackRstFrameHandling] = Stack.Param(Enabled)
+}

--- a/finagle-http2/src/main/scala/com/twitter/finagle/http2/transport/common/H2StreamChannelInit.scala
+++ b/finagle-http2/src/main/scala/com/twitter/finagle/http2/transport/common/H2StreamChannelInit.scala
@@ -1,6 +1,7 @@
 package com.twitter.finagle.http2.transport.common
 
 import com.twitter.finagle.Stack
+import com.twitter.finagle.http2.param.NackRstFrameHandling
 import com.twitter.finagle.http2.transport.client.Http2ClientEventMapper
 import com.twitter.finagle.http2.transport.server.H2UriValidatorHandler
 import com.twitter.finagle.netty4.http
@@ -31,9 +32,10 @@ private[http2] object H2StreamChannelInit {
       val alloc = params[Allocator].allocator
       ch.config.setAllocator(alloc)
       if (isServer) {
-        ch.pipeline
-          .addLast(new Http2NackHandler)
-          .addLast(H2UriValidatorHandler.HandlerName, H2UriValidatorHandler)
+        if (params[NackRstFrameHandling].enabled) {
+          ch.pipeline.addLast(new Http2NackHandler)
+        }
+        ch.pipeline.addLast(H2UriValidatorHandler.HandlerName, H2UriValidatorHandler)
       }
 
       ch.pipeline.addLast(

--- a/finagle-http2/src/test/scala/com/twitter/finagle/http2/transport/server/Http2NackHandlerTest.scala
+++ b/finagle-http2/src/test/scala/com/twitter/finagle/http2/transport/server/Http2NackHandlerTest.scala
@@ -1,0 +1,63 @@
+package com.twitter.finagle.http2.transport.server
+
+import com.twitter.finagle.Stack.Params
+import com.twitter.finagle.http.filter.HttpNackFilter.{NonRetryableNackHeader, RetryableNackHeader}
+import com.twitter.finagle.http2.param.NackRstFrameHandling
+import com.twitter.finagle.http2.transport.common.H2StreamChannelInit
+import io.netty.channel.embedded.EmbeddedChannel
+import io.netty.channel.{Channel, ChannelInitializer}
+import io.netty.handler.codec.http2.{Http2Error, Http2Headers, Http2HeadersFrame, Http2ResetFrame}
+import org.mockito.Mockito._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.mockito.MockitoSugar
+
+class Http2NackHandlerTest extends AnyFunSuite with MockitoSugar {
+
+  test("converts retryable NACK to RST_STREAM frame") {
+    val init = mock[ChannelInitializer[Channel]]
+    val channel = new EmbeddedChannel(H2StreamChannelInit.initServer(init, Params.empty))
+    val frame = mock[Http2HeadersFrame]
+    val headers = mock[Http2Headers]
+    when(frame.headers()).thenReturn(headers)
+    when(headers.contains(RetryableNackHeader)).thenReturn(true)
+
+    channel.writeOutbound(frame)
+
+    val result = channel.readOutbound[Http2ResetFrame]
+    assert(result.name() == "RST_STREAM")
+    assert(result.errorCode() == Http2Error.REFUSED_STREAM.code())
+  }
+
+  test("converts non retryable NACK to RST_STREAM frame") {
+    val init = mock[ChannelInitializer[Channel]]
+    val channel = new EmbeddedChannel(H2StreamChannelInit.initServer(init, Params.empty))
+    val frame = mock[Http2HeadersFrame]
+    val headers = mock[Http2Headers]
+    when(frame.headers()).thenReturn(headers)
+    when(headers.contains(NonRetryableNackHeader)).thenReturn(true)
+
+    channel.writeOutbound(frame)
+
+    val result = channel.readOutbound[Http2ResetFrame]
+    assert(result.name() == "RST_STREAM")
+    assert(result.errorCode() == Http2Error.ENHANCE_YOUR_CALM.code())
+  }
+
+
+  test("once disabled, does not convert NACK to RST_STREAM frame") {
+    val init = mock[ChannelInitializer[Channel]]
+    val params = Params.empty + NackRstFrameHandling.Disabled
+    val channel = new EmbeddedChannel(H2StreamChannelInit.initServer(init, params))
+    val frame = mock[Http2HeadersFrame]
+    val headers = mock[Http2Headers]
+    when(frame.headers()).thenReturn(headers)
+    when(headers.contains(RetryableNackHeader)).thenReturn(true)
+
+    channel.writeOutbound(frame)
+
+    val result = channel.readOutbound[Http2HeadersFrame]
+    assert(result.name() != "RST_STREAM")
+    assert(result.headers().contains(RetryableNackHeader))
+  }
+
+}


### PR DESCRIPTION
Thank you for your amazing open source project.

## Problem

The Finagle server using HTTP/2 Protocol converts NACK response to RST_STREAM frame, which can be properly interpreted by Finagle client. However we are using ALB (AWS Application Load Balancer), which is responsible for SSL/TLS termination. Unfortunately once ALB receives RST_STREAM frame from Finagle Server (Target Group), the ALB returns to a Finagle client response: 502 Bad Gateway. Consequently we lose information whether the response is a retryable or non-retryable NACK. Moreover Finagle client treats such response as application error and does not perform any action in order to reply such request. There was discussion with AWS Support and created request to gracefully handle such scenario by notifying a client about RST_STREAM, but we do not expect any change, because according to AWS current implementation is correct.

## Solution

The Finagle server using HTTP/1.1 Protocol indicates NACKs by sending response with empty body and with specific header (finagle-http-nack, Retry-After: 0, finagle-http-retryable-request or finagle-http-nonretryable-nack). The Finagle server using HTTP/2 Protocol indicates NACKs using the same filters on server, however the main difference is in transport layer. Leveraging on HTTP/2 Protocol Finagle terminates the stream by setting RST_STREAM frame with error code. Nonretryable nacks are represented as ENHANCE_YOUR_CALM (0xB) and retryable NACKs are represented as REFUSED_STREAM (0x7) [Http2NackHandler]. The Finagle client in order to handle both NACKs in the same way converts RST_STREAM frame back to HTTP/1.1 response with NACK Headers (https://github.com/twitter/finagle/blob/develop/finagle-http2/src/main/scala/com/twitter/finagle/http2/transport/common/Http2StreamMessageHandler.scala#L122).

Knowing that we can remove `Http2NackHandler` from channel pipeline and Finagle clients will understand HTTP/2 NACKS based on HTTP headers, however server will be no longer sending RST_STREAM, which won't cause issues with any intermediate applications such as load balancers. 

## Result

The default behaviour won't be changed, however we will expose parameter to disable `Http2NackHandler`