### PR TITLE
finagle-netty4-http: allow setting multiple values for a request cookie

### DIFF
--- a/finagle-base-http/src/main/scala/com/twitter/finagle/http/CookieMap.scala
+++ b/finagle-base-http/src/main/scala/com/twitter/finagle/http/CookieMap.scala
@@ -103,7 +103,7 @@ class CookieMap private[finagle] (message: Message, cookieCodec: CookieCodec)
   def getValue(name: String): Option[String] = get(name).map(_.value)
 
   /**
-   * Fetches all cookies with the given `name` from this map, in order of insertion.
+   * Fetches all cookies with the given `name` from this map.
    */
   def getAll(name: String): Seq[Cookie] = underlying(name).reverse
 
@@ -171,12 +171,14 @@ class CookieMap private[finagle] (message: Message, cookieCodec: CookieCodec)
   /**
    * Adds the given `cookie` with `name` into this map.
    *
-   * On a Response: existing cookies with this name but different domain/path
-   * will be kept. If there is already an identical cookie (different value but
-   * name/path/domain is the same) in the map, it will be replaced within a new
-   * version.
+   * '''On a Response:''' existing cookies with this name but different
+   * domain/path will be kept. If there is already an identical cookie
+   * (different value but name/path/domain is the same) in the map, it will be
+   * replaced within a new version.
    *
-   * On a Request: existing cookies with this name will be kept.
+   * '''On a Request:''' existing cookies with this name will be kept, as
+   * request cookies do not have a domain/path to distinguish them, yet the same
+   * cookie name can be repeated in a request.
    *
    * @see [[addAll]] for adding cookies in bulk
    */
@@ -188,12 +190,14 @@ class CookieMap private[finagle] (message: Message, cookieCodec: CookieCodec)
   /**
    * Adds the given `cookie` into this map.
    *
-   * On a Response: existing cookies with this name but different domain/path
-   * will be kept. If there is already an identical cookie (different value but
-   * name/path/domain is the same) in the map, it will be replaced within a new
-   * version.
+   * '''On a Response:''' existing cookies with this name but different
+   * domain/path will be kept. If there is already an identical cookie
+   * (different value but name/path/domain is the same) in the map, it will be
+   * replaced within a new version.
    *
-   * On a Request: existing cookies with this name will be kept.
+   * '''On a Request:''' existing cookies with this name will be kept, as
+   * request cookies do not have a domain/path to distinguish them, yet the same
+   * cookie name can be repeated in a request.
    *
    * @see [[addAll]] for adding cookies in bulk
    */
@@ -204,12 +208,14 @@ class CookieMap private[finagle] (message: Message, cookieCodec: CookieCodec)
   /**
    * Adds multiple `cookies` into this map.
    *
-   * On a Response: existing cookies with this name but different domain/path
-   * will be kept. If there is already an identical cookie (different value but
-   * name/path/domain is the same) in the map, it will be replaced within a new
-   * version.
+   * '''On a Response:''' existing cookies with this name but different
+   * domain/path will be kept. If there is already an identical cookie
+   * (different value but name/path/domain is the same) in the map, it will be
+   * replaced within a new version.
    *
-   * On a Request: existing cookies with this name will be kept.
+   * '''On a Request:''' existing cookies with this name will be kept, as
+   * request cookies do not have a domain/path to distinguish them, yet the same
+   * cookie name can be repeated in a request.
    */
   def addAll(cookies: TraversableOnce[Cookie]): Unit = {
     cookies.foreach(c => addNoRewrite(c.name, c))

--- a/finagle-base-http/src/main/scala/com/twitter/finagle/http/netty4/Netty4CookieCodec.scala
+++ b/finagle-base-http/src/main/scala/com/twitter/finagle/http/netty4/Netty4CookieCodec.scala
@@ -52,7 +52,7 @@ private[finagle] object Netty4CookieCodec extends CookieCodec {
   }
 
   def decodeServer(header: String): Option[Iterable[Cookie]] = {
-    val cookies = serverDecoder.decode(header).asScala.map(cookieToFinagle)
+    val cookies = serverDecoder.decodeAll(header).asScala.map(cookieToFinagle)
     if (!cookies.isEmpty) Some(cookies)
     else None
   }


### PR DESCRIPTION
See issue #909.

Problem:
In a Response, `CookieMap` allows setting multiple cookie values for a given name as long as they differ by their domain or path. However, in a Request, if the client sent several values for a given cookie name, only the last one is currently available.

Solution:
Fix a bug in `Netty4CookieCodec` when decoding request cookies, and change `CookieMap` behavior to allow inserting multiple values for a request cookie. Also preserve insertion order for the different values for a given cookie name, to preserve the order in which the client sent the values in a request.