### PR TITLE
finagle-core: canonical name for per host stats

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/LoadBalancerFactory.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/LoadBalancerFactory.scala
@@ -229,7 +229,11 @@ object LoadBalancerFactory {
         else {
           val scope = addr match {
             case Address.Inet(ia, _) =>
-              "%s:%d".format(ia.getHostName, ia.getPort)
+              if(useCanonicalHostname()) {
+                "%s:%d".format(ia.getAddress.getCanonicalHostName, ia.getPort)
+              } else {
+                "%s:%d".format(ia.getHostName, ia.getPort)
+              }
             case other => other.toString
           }
           val host = hostStatsReceiver.scope(label).scope(scope)

--- a/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/flags.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/flags.scala
@@ -41,14 +41,6 @@ object perHostStats
         "\tor the NullStatsReceiver if none given."
     )
 
-object useCanonicalHostname
-  extends GlobalFlag[Boolean](
-    false,
-    "enable/default using canonical host name in stats.\n" +
-      "\tWhen enabled, canonical host name for endpoint will be used.\n" +
-      "\tWhen disabled, given hostname will be used."
-  )
-
 package exp {
 
   import com.twitter.finagle.loadbalancer.aperture.EagerConnectionsType

--- a/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/flags.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/flags.scala
@@ -41,6 +41,14 @@ object perHostStats
         "\tor the NullStatsReceiver if none given."
     )
 
+object useCanonicalHostname
+  extends GlobalFlag[Boolean](
+    false,
+    "enable/default using canonical host name in stats.\n" +
+      "\tWhen enabled, canonical host name for endpoint will be used.\n" +
+      "\tWhen disabled, given hostname will be used."
+  )
+
 package exp {
 
   import com.twitter.finagle.loadbalancer.aperture.EagerConnectionsType

--- a/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/LoadBalancerFactoryTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/loadbalancer/LoadBalancerFactoryTest.scala
@@ -110,7 +110,7 @@ class LoadBalancerFactoryTest extends AnyFunSuite with Eventually with Integrati
       val sr1 = new InMemoryStatsReceiver
 
       val nonCanonicalPort: String = "github.com:443"
-      val canonicalPerHostStatKey = Seq(label, nonCanonicalPort, "available")
+      val nonCanonicalPerHostStatKey = Seq(label, nonCanonicalPort, "available")
 
       perHostStats.let(true) {
         useCanonicalHostname.let(false) {
@@ -118,14 +118,14 @@ class LoadBalancerFactoryTest extends AnyFunSuite with Eventually with Integrati
             .configured(LoadBalancerFactory.HostStats(sr))
             .newService(nonCanonicalPort)("test")
           eventually {
-            assert(sr.self.gauges(canonicalPerHostStatKey).apply == 1.0)
+            assert(sr.self.gauges(nonCanonicalPerHostStatKey).apply == 1.0)
           }
 
           client
             .configured(LoadBalancerFactory.HostStats(sr1))
             .newService(nonCanonicalPort)("test")
           eventually {
-            assert(sr1.gauges(canonicalPerHostStatKey).apply == 1.0)
+            assert(sr1.gauges(nonCanonicalPerHostStatKey).apply == 1.0)
           }
         }
       }


### PR DESCRIPTION
Issue #918

Problem:
With DNS balancing per host stats are collapsing in single branch.

Solution:
Use canonical host name in stats receiver scope.