### PR TITLE
Add MinSendBackupAfterMs to config in BackupRequestFilter

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/client/BackupRequestFilter.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/client/BackupRequestFilter.scala
@@ -41,16 +41,6 @@ object BackupRequestFilter {
   private val LostAnnotation =
     Annotation.Message("Client Backup Request Lost")
 
-  /**
-   * Use a minimum non-zero delay to prevent sending unnecessary backup requests
-   * immediately for services where the latency at the percentile where a backup will be sent is
-   * ~0ms. This is preferable to not sending any backups in the aforementioned case; by sending
-   * a backup after 1ms we can still reduce the higher latencies at greater latency percentiles.
-   * For example, if p99 latency is 0 and we are configured to send backups at the p99 latency,
-   * we can a reduce p999 latency of 10 ms to close to 1ms.
-   */
-  private val MinSendBackupAfterMs: Int = 1
-
   private[finagle] val SupersededRequestFailure =
     Failure.ignorable("Request was superseded by another in BackupRequestFilter")
 
@@ -86,7 +76,7 @@ object BackupRequestFilter {
 
   object Param {
 
-    private[client] case class Configured(maxExtraLoad: Tunable[Double], sendInterrupts: Boolean)
+    private[client] case class Configured(maxExtraLoad: Tunable[Double], sendInterrupts: Boolean, minSendBackupAfterMs: Int = 1)
         extends Param
     case object Disabled extends Param
     implicit val param: Stack.Param[BackupRequestFilter.Param] = Stack.Param(Disabled)
@@ -127,7 +117,23 @@ object BackupRequestFilter {
    *                       is returned and the result of the outstanding request is superseded. For
    *                       protocols without a control plane, where the connection is cut on
    *                       interrupts, this should be "false" to avoid connection churn.
+   *
+   * @param minSendBackupAfterMs Use a minimum non-zero delay to prevent sending unnecessary backup requests
+   *                             immediately for services where the latency at the percentile where a
+   *                             backup will be sent is ~0ms.
    */
+  def Configured(maxExtraLoad: Double, sendInterrupts: Boolean, minSendBackupAfterMs: Int): Param = {
+    require(
+      maxExtraLoad >= 0 && maxExtraLoad < 1.0,
+      s"maxExtraLoad must be between 0.0 and 1.0, was $maxExtraLoad"
+    )
+    require(
+      minSendBackupAfterMs >= 1,
+      s"minSendBackupAfterMs must be greater or equal to 1ms, was $minSendBackupAfterMs"
+    )
+    Param.Configured(Tunable.const(role.name, maxExtraLoad), sendInterrupts, minSendBackupAfterMs)
+  }
+
   def Configured(maxExtraLoad: Double, sendInterrupts: Boolean): Param = {
     require(
       maxExtraLoad >= 0 && maxExtraLoad < 1.0,
@@ -136,17 +142,22 @@ object BackupRequestFilter {
     Param.Configured(Tunable.const(role.name, maxExtraLoad), sendInterrupts)
   }
 
+  def Configured(maxExtraLoad: Tunable[Double], sendInterrupts: Boolean, minSendBackupAfterMs: Int): Param =
+    Param.Configured(maxExtraLoad, sendInterrupts, minSendBackupAfterMs)
+
   def Configured(maxExtraLoad: Tunable[Double], sendInterrupts: Boolean): Param =
     Param.Configured(maxExtraLoad, sendInterrupts)
 
   private[this] def mkFilterFromParams[Req, Rep](
     maxExtraLoad: Tunable[Double],
     sendInterrupts: Boolean,
+    minSendBackupAfterMs: Int,
     params: Stack.Params
   ): BackupRequestFilter[Req, Rep] =
     new BackupRequestFilter[Req, Rep](
       maxExtraLoad,
       sendInterrupts,
+      minSendBackupAfterMs,
       params[param.ResponseClassifier].responseClassifier,
       params[Retries.Budget].retryBudget,
       params[Histogram].lowestDiscernibleMsValue,
@@ -188,7 +199,7 @@ object BackupRequestFilter {
     keyPrefixes: Seq[String]
   ): Service[Req, Rep] =
     params[BackupRequestFilter.Param] match {
-      case BackupRequestFilter.Param.Configured(maxExtraLoad, sendInterrupts) =>
+      case BackupRequestFilter.Param.Configured(maxExtraLoad, sendInterrupts, minSendBackupAfterMs) =>
         // register BRF when registry prefixes are provided
         if (keyPrefixes.nonEmpty) {
           val value =
@@ -196,7 +207,7 @@ object BackupRequestFilter {
           val prefixes = keyPrefixes ++ Seq(BackupRequestFilter.role.name, value)
           ClientRegistry.export(params, prefixes: _*)
         }
-        val brf = mkFilterFromParams[Req, Rep](maxExtraLoad, sendInterrupts, params)
+        val brf = mkFilterFromParams[Req, Rep](maxExtraLoad, sendInterrupts, minSendBackupAfterMs, params)
         new ServiceProxy[Req, Rep](brf.andThen(service)) {
           override def close(deadline: Time): Future[Unit] =
             service.close(deadline).before(brf.close(deadline))
@@ -220,10 +231,10 @@ object BackupRequestFilter {
 
       def make(params: Params, next: ServiceFactory[Req, Rep]): ServiceFactory[Req, Rep] = {
         params[BackupRequestFilter.Param] match {
-          case Param.Configured(maxExtraLoad, sendInterrupts) =>
+          case Param.Configured(maxExtraLoad, sendInterrupts, minSendBackupAfterMs) =>
             new BackupRequestFactory[Req, Rep](
               next,
-              mkFilterFromParams(maxExtraLoad, sendInterrupts, params)
+              mkFilterFromParams(maxExtraLoad, sendInterrupts, minSendBackupAfterMs, params)
             )
           case Param.Disabled =>
             next
@@ -271,6 +282,13 @@ private[client] class BackupRequestFactory[Req, Rep](
  *                       protocols without a control plane, where the connection is cut on
  *                       interrupts, this should be "false" to avoid connection churn.
  *
+ * @param minSendBackupAfterMs Use a minimum non-zero delay to prevent sending unnecessary backup requests
+ *                             immediately for services where the latency at the percentile where a backup will be sent is
+ *                             ~0ms. This is preferable to not sending any backups in the aforementioned case; by sending
+ *                             a backup after 1ms we can still reduce the higher latencies at greater latency percentiles.
+ *                             For example, if p99 latency is 0 and we are configured to send backups at the p99 latency,
+ *                             we can a reduce p999 latency of 10 ms to close to 1ms.
+ *
  * @note If `sendInterrupts` is set to false, and for clients that mask interrupts (e.g. the
  *       Finagle Memcached client), both the original request and backup will be counted in stats,
  *       so tail latency improvements as a result of this filter will not be reflected in the
@@ -279,6 +297,7 @@ private[client] class BackupRequestFactory[Req, Rep](
 private[finagle] class BackupRequestFilter[Req, Rep](
   maxExtraLoadTunable: Tunable[Double],
   sendInterrupts: Boolean,
+  minSendBackupAfterMs: Int,
   responseClassifier: ResponseClassifier,
   newRetryBudget: (Double, () => Long) => RetryBudget,
   clientRetryBudget: RetryBudget,
@@ -293,6 +312,7 @@ private[finagle] class BackupRequestFilter[Req, Rep](
   def this(
     maxExtraLoadTunable: Tunable[Double],
     sendInterrupts: Boolean,
+    minSendBackupAfterMs: Int,
     responseClassifier: ResponseClassifier,
     clientRetryBudget: RetryBudget,
     statsReceiver: StatsReceiver,
@@ -301,6 +321,7 @@ private[finagle] class BackupRequestFilter[Req, Rep](
     this(
       maxExtraLoadTunable,
       sendInterrupts,
+      minSendBackupAfterMs,
       responseClassifier,
       newRetryBudget = BackupRequestFilter.newRetryBudget,
       clientRetryBudget = clientRetryBudget,
@@ -313,6 +334,7 @@ private[finagle] class BackupRequestFilter[Req, Rep](
   def this(
     maxExtraLoadTunable: Tunable[Double],
     sendInterrupts: Boolean,
+    minSendBackupAfterMs: Int,
     responseClassifier: ResponseClassifier,
     clientRetryBudget: RetryBudget,
     lowestDiscernibleMsValue: Int,
@@ -323,6 +345,7 @@ private[finagle] class BackupRequestFilter[Req, Rep](
     this(
       maxExtraLoadTunable,
       sendInterrupts,
+      minSendBackupAfterMs,
       responseClassifier,
       newRetryBudget = BackupRequestFilter.newRetryBudget,
       clientRetryBudget = clientRetryBudget,
@@ -375,7 +398,7 @@ private[finagle] class BackupRequestFilter[Req, Rep](
         backupRequestRetryBudget = newRetryBudget(curMaxExtraLoad, nowMs)
       }
       sendBackupAfterMillis =
-        Math.max(MinSendBackupAfterMs, windowedPercentile.percentile(percentile))
+        Math.max(minSendBackupAfterMs, windowedPercentile.percentile(percentile))
       sendAfterStat.add(sendBackupAfterMillis)
     }
   }

--- a/finagle-core/src/test/scala/com/twitter/finagle/client/MethodBuilderTest.scala
+++ b/finagle-core/src/test/scala/com/twitter/finagle/client/MethodBuilderTest.scala
@@ -820,8 +820,8 @@ class MethodBuilderTest
       .idempotent(1.percent, sendInterrupts = true, classifier)
 
     mb.params[BackupRequestFilter.Param] match {
-      case BackupRequestFilter.Param.Configured(maxExtraLoadTunable, sendInterrupts) =>
-        assert(maxExtraLoadTunable().get == 1.percent && sendInterrupts)
+      case BackupRequestFilter.Param.Configured(maxExtraLoadTunable, sendInterrupts, minSendBackupAfterMs) =>
+        assert(maxExtraLoadTunable().get == 1.percent && sendInterrupts && minSendBackupAfterMs == 1)
       case _ => fail("BackupRequestFilter not configured")
     }
     assert(mb.config.retry.responseClassifier.toString == s"Idempotent($classifier)")

--- a/finagle-http/src/main/scala/com/twitter/finagle/http/MethodBuilder.scala
+++ b/finagle-http/src/main/scala/com/twitter/finagle/http/MethodBuilder.scala
@@ -241,6 +241,16 @@ class MethodBuilder private (mb: client.MethodBuilder[Request, Response])
       )
     )
 
+  def idempotent(maxExtraLoad: Double, minSendBackupAfterMs: Int): MethodBuilder =
+    new MethodBuilder(
+      mb.idempotent(
+        maxExtraLoad,
+        sendInterrupts = false,
+        minSendBackupAfterMs,
+        HttpResponseClassifier.ServerErrorsAsFailures
+      )
+    )
+
   /**
    * @inheritdoc
    *
@@ -251,6 +261,16 @@ class MethodBuilder private (mb: client.MethodBuilder[Request, Response])
       mb.idempotent(
         maxExtraLoad,
         sendInterrupts = false,
+        HttpResponseClassifier.ServerErrorsAsFailures
+      )
+    )
+
+  def idempotent(maxExtraLoad: Tunable[Double], minSendBackupAfterMs: Int): MethodBuilder =
+    new MethodBuilder(
+      mb.idempotent(
+        maxExtraLoad,
+        sendInterrupts = false,
+        minSendBackupAfterMs,
         HttpResponseClassifier.ServerErrorsAsFailures
       )
     )

--- a/finagle-thriftmux/src/main/scala/com/twitter/finagle/thriftmux/MethodBuilder.scala
+++ b/finagle-thriftmux/src/main/scala/com/twitter/finagle/thriftmux/MethodBuilder.scala
@@ -328,6 +328,12 @@ class MethodBuilder(
       mb.idempotent(maxExtraLoad, sendInterrupts = true, ResponseClassifier.RetryOnThrows)
     )
 
+  def idempotent(maxExtraLoad: Double, minSendBackupAfterMs: Int): MethodBuilder =
+    new MethodBuilder(
+      thriftMuxClient,
+      mb.idempotent(maxExtraLoad, sendInterrupts = true, minSendBackupAfterMs, ResponseClassifier.RetryOnThrows)
+    )
+
   /**
    * @inheritdoc
    *
@@ -337,6 +343,12 @@ class MethodBuilder(
     new MethodBuilder(
       thriftMuxClient,
       mb.idempotent(maxExtraLoad, sendInterrupts = true, ResponseClassifier.RetryOnThrows)
+    )
+
+  def idempotent(maxExtraLoad: Tunable[Double], minSendBackupAfterMs: Int): MethodBuilder =
+    new MethodBuilder(
+      thriftMuxClient,
+      mb.idempotent(maxExtraLoad, sendInterrupts = true, minSendBackupAfterMs, ResponseClassifier.RetryOnThrows)
     )
 
   def nonIdempotent: MethodBuilder =


### PR DESCRIPTION
Problem

The MinSendBackupAfterMs is now set to 1 ms. Unfortunately this causes backup requests to be send when there is low load.

Solution

Added **MinSendBackupAfterMs** to the stack param Configured in BackupRequestFilter and propagated changes to `MethodBuilder` by adding new versions of `idempotent` function.

Result

Developers will be able to set their own value of **MinSendBackupAfterMs** if necessary.

Closes twitter/finagle#905