### PR TITLE
Fix Finagle MySQL transactionWithIsolation doc typo

### DIFF
--- a/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Client.scala
+++ b/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Client.scala
@@ -238,7 +238,7 @@ trait Transactions {
    * committed.
    *
    * @example {{{
-   *   client.transaction[Foo](IsolationLevel.RepeatableRead) { c =>
+   *   client.transactionWithIsolation[Foo](IsolationLevel.RepeatableRead) { c =>
    *    for {
    *       r0 <- c.query(q0)
    *       r1 <- c.query(q1)


### PR DESCRIPTION
The example is using the wrong function name when demonstrating usage of `transactionWithIsolation`