### PR TITLE
Give NullParameter a friendly string representation

### DIFF
--- a/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Parameter.scala
+++ b/finagle-mysql/src/main/scala/com/twitter/finagle/mysql/Parameter.scala
@@ -179,6 +179,7 @@ object Parameter {
     type A = Null
     def value: Null = null
     def evidence: CanBeParameter[Null] = CanBeParameter.nullCanBeParameter
+    override def toString: String = "Parameter(null)"
   }
 }
 


### PR DESCRIPTION
Otherwise stringifying it results in random output like `com.twitter.finagle.mysql.Parameter$NullParameter$@5550f534`.

This doesn't work well with e.g. snapshot tests.