### PR TITLE
A better Medium Logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="https://github.com/twitter/finagle/blob/develop/doc/src/sphinx/_static/logo_medium.png"><br><br>
+  <img src="https://user-images.githubusercontent.com/70687014/233679576-740ea0b2-52a6-4cb5-b8ca-d4ff96f34f6e.png" alt="background-removed-image" />
 </div>
 
 


### PR DESCRIPTION
# Brief
The Previous Medium Logo which was used in the README file was not having transparent as a result of which instead of placing it in the center the logo had a white background.

# Previously
- Lightmode ![image](https://user-images.githubusercontent.com/70687014/233682633-193b08c8-1d11-4a34-b3c5-a3a794ef9035.png)
- Darkmode ![image](https://user-images.githubusercontent.com/70687014/233682906-29044c4e-4f7d-47e8-8151-ce1f8ef5db7e.png)

# Now
- Lightmode ![image](https://user-images.githubusercontent.com/70687014/233682633-193b08c8-1d11-4a34-b3c5-a3a794ef9035.png)
- Darkmode ![image](https://user-images.githubusercontent.com/70687014/233683255-61f3db62-d418-4334-9e65-5009804e5371.png)
