### PR TITLE
Add Scala 3 support to build and CI matrix

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [2.12.12, 2.13.6]
+        scala: [2.12.12, 2.13.6, 3.2.2]
         java: ['1.8', '1.11']
         project: ['finagle-base-http', 'finagle-benchmark', 'finagle-benchmark-thrift', 'finagle-core', 'finagle-example', 'finagle-exp', 'finagle-grpc-context', 'finagle-http', 'finagle-http2','finagle-init','finagle-integration','finagle-memcached','finagle-mux','finagle-mysql','finagle-netty4','finagle-netty4-http','finagle-opencensus-tracing','finagle-partitioning','finagle-redis','finagle-scribe','finagle-serversets','finagle-stats','finagle-stats-core','finagle-thrift','finagle-thriftmux','finagle-toggle','finagle-tunable','finagle-zipkin-core','finagle-zipkin-scribe']
     runs-on: ubuntu-latest
@@ -111,4 +111,4 @@ jobs:
       - name: set up netty snapshot
         run: source ./netty-snapshot-env.sh
       - name: test
-        run: ${{ format('./sbt ++{0} clean "{1}/test"', matrix.scala, matrix.project) }}
+        run: ${{ format('./sbt "++{0} -v clean; ++{0} {1}/test"', matrix.scala, matrix.project) }}


### PR DESCRIPTION
Hi, this is early work on supporting a native Scala 3 build for Finagle.

The changes I've made are close to the current setup in twitter/util (including [my PR](https://github.com/twitter/util/pull/308) there for Scala 3 CI).

Right now this only adds Scala 3 to `finagle-init` as a PoC because other modules are still blocked on twitter/util as far as I know.

I'm aware that many Finagle modules are already usable with Scala 3 projects using the cross-compilation (= `.cross(CrossVersion.for3Use2_13)`) feature. This works decently well for applications but is not a suitable solution for libraries which build on Finagle or more complex cross-building setups.

Note: Currently this branches from `release` not from `develop` because the latter seems to be unstable. I will rebase onto `develop` before converting the draft into a real PR ready to be merged.