### PR TITLE
`finagle-http2`: Add a per session request limit option

### DIFF
--- a/finagle-http2/src/main/scala/com/twitter/finagle/http2/param/Params.scala
+++ b/finagle-http2/src/main/scala/com/twitter/finagle/http2/param/Params.scala
@@ -97,6 +97,20 @@ object MaxFrameSize {
   implicit val param = Stack.Param(MaxFrameSize(None))
 }
 
+/*
+ * A class for configuring the maximum number of requests per connection
+ * MaxConcurrentStreams will be deducted from this number to allow requests
+ * in flight up to this number.
+ */
+case class MaxRequestsPerSession(maxRequestsPerSession: Option[Long]) {
+  def mk(): (MaxRequestsPerSession, Stack.Param[MaxRequestsPerSession]) =
+    (this, MaxRequestsPerSession.param)
+}
+
+object MaxRequestsPerSession {
+  implicit val param: Stack.Param[MaxRequestsPerSession] = Stack.Param(MaxRequestsPerSession(None))
+}
+
 /**
  * A class for configuring overrides to the default maxHeaderListSize setting.
  */

--- a/finagle-http2/src/test/scala/com/twitter/finagle/http2/transport/client/ClientSessionImplTest.scala
+++ b/finagle-http2/src/test/scala/com/twitter/finagle/http2/transport/client/ClientSessionImplTest.scala
@@ -2,6 +2,10 @@ package com.twitter.finagle.http2.transport.client
 
 import com.twitter.conversions.DurationOps._
 import com.twitter.finagle.http.Request
+import com.twitter.finagle.http2.param.{
+  MaxConcurrentStreams,
+  MaxRequestsPerSession
+}
 import com.twitter.finagle.netty4.http.Bijections
 import com.twitter.finagle.{FailureFlags, Stack, Status}
 import com.twitter.util.{Await, Awaitable}
@@ -111,9 +115,13 @@ class ClientSessionImplTest extends AnyFunSuite {
     }
   }
 
-  test("Status is Closed when we're less than 50 streams away from exhausting the identifiers") {
+  test("By default status is Closed when we're less than 50 streams away from exhausting the identifiers") {
     new Ctx {
       assert(clientSession.status == Status.Open)
+
+      multiplexCodec.connection.local.createStream(Int.MaxValue - 100, false)
+      assert(clientSession.status == Status.Open)
+
       // client streams are odd streams so to be less than 50 we need to multiply by 2.
       multiplexCodec.connection.local.createStream(Int.MaxValue - 100 + 2, false)
       assert(clientSession.status == Status.Closed)
@@ -128,6 +136,23 @@ class ClientSessionImplTest extends AnyFunSuite {
       assert(clientSession.status == Status.Open)
       multiplexCodec.connection.local.createStream(1, false)
       assert(clientSession.status == Status.Busy)
+    }
+  }
+
+  test("Status is closed when we have exhausted the max requests per session limit") {
+    new Ctx {
+      override def params: Stack.Params = Stack.Params.empty
+        .+(MaxConcurrentStreams(Option(128L))).+(
+        MaxRequestsPerSession(Option(50_000L))
+      )
+      assert(clientSession.status == Status.Open)
+
+      private val expectedHighWatermark: Int = 50_000 * 2 - 128 * 2
+      multiplexCodec.connection.local.createStream(expectedHighWatermark - 1, false)
+      assert(clientSession.status == Status.Open)
+
+      multiplexCodec.connection.local.createStream(expectedHighWatermark + 1, false)
+      assert(clientSession.status == Status.Closed)
     }
   }
 


### PR DESCRIPTION
## `finagle-http2`: Add a per session request limit option

### Problem

When running finagle in a setup using HTTP/2 via application load balancers (ALB), the session is very likely subject to a limit on the number of requests. E.g. when running [via NGINX, the request limit is 1K requests per connection by default](http://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_requests). On AWS, ALB have a 10k request limit. This means that in setups that use finagle and ALBs for their L7 features, the session is subject to races happening on connection close regularly. Here's an illustration of the race happening after a limit of 10K requests has been reached:

![Illustration of race condition leading to Connection Closed Errors](https://github.com/twitter/finagle/assets/305847/4edfa681-49bb-4bb4-8a18-81152790d042)

Netty fires inactive channel for any request that is in flight for the closed session, leading Finagle to propagate a `ChannelClosedException`. There is no possible remediation for this race in Netty since Finagle manages sessions/connections.

This condition can be easily reproduced by running a Finagle server & client with an ALB like NGINX in between, sending concurrent requests up until the limit. 

### Solution

Allow configuration of a `MaxRequestsPerSession` option that aligns a session with underlying request limits. The number of`MaxConcurrentStreams` is deducted to account for any requests in flight. When this number of requests is reached, mark the session as closed so it is shut down and a new session is created.

This option is off by default and therefore opt-in.

### Result

When the configured number of requests is reached, the session is terminated and a new session is opened:

![Illustration of session closing and reopening behavior using the per session request limit](https://github.com/twitter/finagle/assets/305847/01e72afc-df33-44e7-96df-6f0f5b64ba92)
