### PR TITLE
finagle-core: Deposit budget once in MethodBuilder

### DIFF
--- a/finagle-core/src/main/scala/com/twitter/finagle/client/MethodBuilderRetry.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/client/MethodBuilderRetry.scala
@@ -105,7 +105,7 @@ private[finagle] class MethodBuilderRetry[Req, Rep] private[client] (mb: MethodB
 private[client] object MethodBuilderRetry {
   private[this] val DefaultMaxRetries = 2
 
-  private val Disabled: ResponseClassifier =
+  private[client] val Disabled: ResponseClassifier =
     ResponseClassifier.named("Disabled")(PartialFunction.empty)
 
   private def shouldRetry[Req, Rep](

--- a/finagle-core/src/main/scala/com/twitter/finagle/service/Retries.scala
+++ b/finagle-core/src/main/scala/com/twitter/finagle/service/Retries.scala
@@ -104,7 +104,7 @@ object Retries {
    * the calls to `RetryBudget.request()` to count. This allows for
    * swallowing the call to `request` in the second filter.
    */
-  private class WithdrawOnlyRetryBudget(underlying: RetryBudget) extends RetryBudget {
+  private[finagle] class WithdrawOnlyRetryBudget(underlying: RetryBudget) extends RetryBudget {
     def deposit(): Unit = ()
     def tryWithdraw(): Boolean = underlying.tryWithdraw()
     def balance: Long = underlying.balance


### PR DESCRIPTION
Problem

The methodbuilder interface applies the same retrybudget for RetryFilter and RequeueFilter in the same stack. Resulting in double deposit of retrybudget.

Solution

Re-use the WithdrawOnlyRetryBudget to prevent depositing successes in the RequeueFilter and only deposit in the RetryFilter. Same solution as the `Retries.moduleWithRetryPolicy` takes.

Result

Retrybudget only gets deposited once for a request.

Closes #956 