### PR TITLE
Portable shebang

### DIFF
--- a/doc/src/sphinx/code/client-server-anatomy/sbt
+++ b/doc/src/sphinx/code/client-server-anatomy/sbt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 sbtver=1.3.10
 sbtjar=sbt-launch.jar

--- a/doc/src/sphinx/code/protocols/sbt
+++ b/doc/src/sphinx/code/protocols/sbt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 sbtver=1.3.10
 sbtjar=sbt-launch.jar

--- a/doc/src/sphinx/code/quickstart/sbt
+++ b/doc/src/sphinx/code/quickstart/sbt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 sbtver=1.3.10
 sbtjar=sbt-launch.jar

--- a/finagle-benchmark/src/main/scripts/load_balancing_numbers.sh
+++ b/finagle-benchmark/src/main/scripts/load_balancing_numbers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./sbt 'project finagle-benchmark' \
       'run-main com.twitter.finagle.loadbalancer.Simulation -dur=60.seconds -bal=rr -qps=1000 -showprogress=false -showsummary=false -coldstart=false' 2>&1 |gawk 'match($0, /BinaryAnnotation\(balancer,([0-9]+).*\)/, a){print a[1]}' > all_good_1000_rr.txt

--- a/link-netty.sh
+++ b/link-netty.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ $# -ne 1 ]; then
   echo 'usage: '$0' nettyjarpath' 1>&2

--- a/netty-snapshot-env.sh
+++ b/netty-snapshot-env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 print_env () {
   echo "FINAGLE_USE_NETTY_4_SNAPSHOT=$FINAGLE_USE_NETTY_4_SNAPSHOT"

--- a/pushsite.bash
+++ b/pushsite.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/sbt
+++ b/sbt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 


### PR DESCRIPTION
Problem

- /bin/bash is not available on non-FHS distros, such as NixOS

Solution

- replace /bin/bash with /usr/bin/env bash 	

Result


See also

https://github.com/twitter/dodo/pull/15
https://github.com/twitter/finatra/pull/589
https://github.com/twitter/scrooge/pull/366
https://github.com/twitter/util/pull/314
https://github.com/twitter/twitter-server/pull/77