### PR TITLE
finagle/finagle-serversets: Update commons-lang to 3.20.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ Runtime Behavior Changes
 * finagle-core: Dimensional client & server metrics are prefixed with just `finagle_` instead of `rpc_finagle_client`
   and `rpc_finagle_server`, respectively. ``PHAB_ID=D1218090``
 * finagle-core: Dimensional metrics from `DefaultStatsReceiver` are no longer prefixed with `app_`. ``PHAB_ID=D1218090``
+* finagle-serversets: Update commons-lang to 3.20.0 to resolve CVEs
 
 New Features
 ~~~~~~~~~~

--- a/build.sbt
+++ b/build.sbt
@@ -517,7 +517,7 @@ lazy val finagleServersets = Project(
         ExclusionRule("com.sun.jmx", "jmxri"),
         ExclusionRule("javax.jms", "jms")
       ),
-      "commons-lang" % "commons-lang" % "2.6"
+      "org.apache.commons" % "commons-lang3" % "3.20.0"
     ),
     libraryDependencies ++= jacksonLibs,
     libraryDependencies ++= scroogeLibs,

--- a/finagle-serversets/src/main/java/com/twitter/finagle/common/base/MorePreconditions.java
+++ b/finagle-serversets/src/main/java/com/twitter/finagle/common/base/MorePreconditions.java
@@ -18,7 +18,7 @@ package com.twitter.finagle.common.base;
 
 import java.util.Objects;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * A utility helpful in concisely checking preconditions on arguments.

--- a/finagle-serversets/src/main/java/com/twitter/finagle/common/zookeeper/Group.java
+++ b/finagle-serversets/src/main/java/com/twitter/finagle/common/zookeeper/Group.java
@@ -30,8 +30,8 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.NoNodeException;

--- a/finagle-serversets/src/main/java/com/twitter/finagle/common/zookeeper/ZooKeeperClient.java
+++ b/finagle-serversets/src/main/java/com/twitter/finagle/common/zookeeper/ZooKeeperClient.java
@@ -36,7 +36,7 @@ import java.util.stream.StreamSupport;
 
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.SessionExpiredException;
 import org.apache.zookeeper.WatchedEvent;


### PR DESCRIPTION
Problem

- `finagle-serversets` uses `commons-lang` version 2.6 which contains CVE-2025-48924
  - https://nvd.nist.gov/vuln/detail/CVE-2025-48924
  - https://lists.apache.org/thread/bgv0lpswokgol11tloxnjfzdl7yrc1g1

- `commons-lang` version 2.6 is deprecated and has not received an update since 2011-01-16 
  - https://commons.apache.org/proper/commons-lang/changes.html

Solution

- Migrate `commons-lang` to `org.apache.commons.lang3` and update version to 3.20.0
- change old `org.apache.commons.lang` imports to `org.apache.commons.lang3`

Result

- `finagle-serversets` no longer contains CVE-2025-48924