### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,8 +26,8 @@ jobs:
         project: ['finagle-base-http', 'finagle-benchmark', 'finagle-benchmark-thrift', 'finagle-core', 'finagle-example', 'finagle-exp', 'finagle-grpc-context', 'finagle-http', 'finagle-http2','finagle-init','finagle-integration','finagle-memcached','finagle-mux','finagle-mysql','finagle-netty4','finagle-netty4-http','finagle-opencensus-tracing','finagle-partitioning','finagle-redis','finagle-scribe','finagle-serversets','finagle-stats','finagle-stats-core','finagle-thrift','finagle-thriftmux','finagle-toggle','finagle-tunable','finagle-zipkin-core','finagle-zipkin-scribe']
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: actions/setup-java@v1
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
       - name: echo java version
@@ -35,7 +35,7 @@ jobs:
       - name: echo javac version
         run: javac -J-Xmx32m -version
       - name: cache build dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v5
         env:
           cache-name: cache-build-deps
         with:
@@ -73,8 +73,8 @@ jobs:
     continue-on-error: true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: actions/setup-java@v1
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
       - name: echo java version
@@ -82,7 +82,7 @@ jobs:
       - name: echo javac version
         run: javac -J-Xmx32m -version
       - name: cache build dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v5
         env:
           cache-name: cache-build-deps
         with:


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/cache` | [`v2`](https://github.com/actions/cache/releases/tag/v2) | [`v5`](https://github.com/actions/cache/releases/tag/v5) | [Release](https://github.com/actions/cache/releases/tag/v5) | continuous-integration.yml |
| `actions/checkout` | [`v2.3.4`](https://github.com/actions/checkout/releases/tag/v2.3.4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | continuous-integration.yml |
| `actions/setup-java` | [`v1`](https://github.com/actions/setup-java/releases/tag/v1) | [`v5`](https://github.com/actions/setup-java/releases/tag/v5) | [Release](https://github.com/actions/setup-java/releases/tag/v5) | continuous-integration.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
